### PR TITLE
Add Function to Enable Registering IP with metadata

### DIFF
--- a/contracts/StoryProtocolGateway.sol
+++ b/contracts/StoryProtocolGateway.sol
@@ -149,6 +149,22 @@ contract StoryProtocolGateway is IStoryProtocolGateway, AccessManagedUpgradeable
         ISPGNFT(nftContract).safeTransferFrom(address(this), recipient, tokenId, "");
     }
 
+    /// @notice Registers an NFT as IP with metadata.
+    /// @param nftContract The address of the NFT collection.
+    /// @param tokenId The ID of the NFT.
+    /// @param metadata OPTIONAL. The desired metadata for the newly registered IP.
+    /// @param sigMetadata OPTIONAL. Signature data for setAll (metadata) for the IP via the Core Metadata Module.
+    /// @return ipId The ID of the registered IP.
+    function registerIp(
+        address nftContract,
+        uint256 tokenId,
+        IPMetadata calldata metadata,
+        SignatureData calldata sigMetadata
+    ) external returns (address ipId) {
+        ipId = IP_ASSET_REGISTRY.register(block.chainid, nftContract, tokenId);
+        _setMetadataWithSig(metadata, ipId, sigMetadata);
+    }
+
     /// @notice Register Programmable IP License Terms (if unregistered) and attach it to IP.
     /// @param ipId The ID of the IP.
     /// @param terms The PIL terms to be registered.

--- a/contracts/interfaces/IStoryProtocolGateway.sol
+++ b/contracts/interfaces/IStoryProtocolGateway.sol
@@ -70,6 +70,19 @@ interface IStoryProtocolGateway {
         IPMetadata calldata metadata
     ) external returns (address ipId, uint256 tokenId);
 
+    /// @notice Registers an NFT as IP with metadata.
+    /// @param nftContract The address of the NFT collection.
+    /// @param tokenId The ID of the NFT.
+    /// @param metadata OPTIONAL. The desired metadata for the newly registered IP.
+    /// @param sigMetadata OPTIONAL. Signature data for setAll (metadata) for the IP via the Core Metadata Module.
+    /// @return ipId The ID of the registered IP.
+    function registerIp(
+        address nftContract,
+        uint256 tokenId,
+        IPMetadata calldata metadata,
+        SignatureData calldata sigMetadata
+    ) external returns (address ipId);
+
     /// @notice Register Programmable IP License Terms (if unregistered) and attach it to IP.
     /// @param ipId The ID of the IP.
     /// @param terms The PIL terms to be registered.

--- a/test/StoryProtocolGateway.t.sol
+++ b/test/StoryProtocolGateway.t.sol
@@ -15,6 +15,7 @@ import { Errors } from "../contracts/lib/Errors.sol";
 import { SPGNFTLib } from "../contracts/lib/SPGNFTLib.sol";
 
 import { BaseTest } from "./utils/BaseTest.t.sol";
+import { MockERC721 } from "./mocks/MockERC721.sol";
 
 contract StoryProtocolGatewayTest is BaseTest {
     struct IPAsset {
@@ -110,6 +111,33 @@ contract StoryProtocolGatewayTest is BaseTest {
         assertEq(tokenId2, 2);
         assertTrue(ipAssetRegistry.isRegistered(ipId2));
         assertMetadata(ipId2, metadataDefault);
+    }
+
+    function test_SPG_registerIp() public withCollection {
+        MockERC721 nftContract = new MockERC721("Test NFT");
+        uint256 tokenId = nftContract.mint(address(alice));
+        address expectedIpId = ipAssetRegistry.ipId(block.chainid, address(nftContract), tokenId);
+
+        uint256 deadline = block.timestamp + 1000;
+
+        (bytes memory sigMetadata, ) = _getSetPermissionSignatureForSPG({
+            ipId: expectedIpId,
+            module: address(coreMetadataModule),
+            selector: ICoreMetadataModule.setAll.selector,
+            deadline: deadline,
+            nonce: 1,
+            signerPk: alicePk
+        });
+
+        address actualIpId = spg.registerIp({
+            nftContract: address(nftContract),
+            tokenId: tokenId,
+            metadata: metadataDefault,
+            sigMetadata: ISPG.SignatureData({ signer: alice, deadline: deadline, signature: sigMetadata })
+        });
+
+        assertEq(actualIpId, expectedIpId);
+        assertMetadata(actualIpId, metadataDefault);
     }
 
     modifier withIp(address owner) {

--- a/test/StoryProtocolGateway.t.sol
+++ b/test/StoryProtocolGateway.t.sol
@@ -137,6 +137,7 @@ contract StoryProtocolGatewayTest is BaseTest {
         });
 
         assertEq(actualIpId, expectedIpId);
+        assertTrue(ipAssetRegistry.isRegistered(actualIpId));
         assertMetadata(actualIpId, metadataDefault);
     }
 

--- a/test/mocks/MockERC721.sol
+++ b/test/mocks/MockERC721.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BUSDL-1.1
+pragma solidity 0.8.23;
+
+import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+
+contract MockERC721 is ERC721 {
+    uint256 private _counter;
+
+    constructor(string memory name) ERC721(name, name) {
+        _counter = 0;
+    }
+
+    function mint(address to) public returns (uint256 tokenId) {
+        tokenId = ++_counter;
+        _safeMint(to, tokenId);
+        return tokenId;
+    }
+
+    function burn(uint256 tokenId) public {
+        _burn(tokenId);
+    }
+
+    function transferFrom(address from, address to, uint256 tokenId) public override {
+        _transfer(from, to, tokenId);
+    }
+}


### PR DESCRIPTION
## Description
Add `registerIp` which allows registering an existing NFT as an IP with optional metadata. If metadata is non-empty, a signature is required to allow SPG to set the metadata.

## Test Plan 
Test added for `registerIp`.

## Related Issue
Closes #7

## Note
SPG will be upgraded once this PR is merged.