### PR TITLE
fix(deploy): ownership transfer in deployment script

### DIFF
--- a/script/Main.s.sol
+++ b/script/Main.s.sol
@@ -39,10 +39,10 @@ contract Main is Script, StoryProtocolCoreAddressManager, BroadcastManager, Json
         _beginBroadcast();
         _deployProtocolContracts(deployer);
         _writeDeployment();
-        _endBroadcast();
 
         // Transfer ownership of beacon proxy to SPG
         spgNftBeacon.transferOwnership(address(spg));
+        _endBroadcast();
 
         // Set beacon contract via multisig.
         // spg.setNftContractBeacon(address(spgNftBeacon));


### PR DESCRIPTION
## Description

This PR moves `_endBroadcast()` call after `spgNftBeacon.transferOwnership(address(spg))` to perform proper ownership transfer before ending the broadcast.

## Test Plan 

- Verify the deployment script completes without errors.

- Check the ownership of `spgNftBeacon` is correctly transferred to `spg`.

## Related Issue
N/A

## Notes
N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
	- Adjusted the sequence of operations in the main contract for better timing and control over the broadcast and ownership transfer.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->