### PR TITLE
fix(register-derivatives): collect and approve minting fees for commercial licenses

### DIFF
--- a/contracts/SPGNFT.sol
+++ b/contracts/SPGNFT.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.23;
 
 import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+// solhint-disable-next-line max-line-length
 import { ERC721URIStorageUpgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721URIStorageUpgradeable.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";

--- a/script/Main.s.sol
+++ b/script/Main.s.sol
@@ -57,6 +57,8 @@ contract Main is Script, StoryProtocolCoreAddressManager, BroadcastManager, Json
                 accessControllerAddr,
                 ipAssetRegistryAddr,
                 licensingModuleAddr,
+                licenseRegistryAddr,
+                royaltyModuleAddr,
                 coreMetadataModuleAddr,
                 pilTemplateAddr,
                 licenseTokenAddr

--- a/script/utils/StoryProtocolCoreAddressManager.sol
+++ b/script/utils/StoryProtocolCoreAddressManager.sol
@@ -10,6 +10,8 @@ contract StoryProtocolCoreAddressManager is Script {
     address internal protocolAccessManagerAddr;
     address internal ipAssetRegistryAddr;
     address internal licensingModuleAddr;
+    address internal licenseRegistryAddr;
+    address internal royaltyModuleAddr;
     address internal coreMetadataModuleAddr;
     address internal accessControllerAddr;
     address internal pilTemplateAddr;
@@ -31,6 +33,8 @@ contract StoryProtocolCoreAddressManager is Script {
         protocolAccessManagerAddr = json.readAddress(".main.ProtocolAccessManager");
         ipAssetRegistryAddr = json.readAddress(".main.IPAssetRegistry");
         licensingModuleAddr = json.readAddress(".main.LicensingModule");
+        licenseRegistryAddr = json.readAddress(".main.LicenseRegistry");
+        royaltyModuleAddr = json.readAddress(".main.RoyaltyModule");
         coreMetadataModuleAddr = json.readAddress(".main.CoreMetadataModule");
         accessControllerAddr = json.readAddress(".main.AccessController");
         pilTemplateAddr = json.readAddress(".main.PILicenseTemplate");


### PR DESCRIPTION
## Description
This PR fixes an issue where calling `registerIpAndMakeDerivative` and `mintAndRegisterIpAndMakeDerivative` for derivatives under parents with commercial licenses throws an `ERC20InsufficientAllowance` error.

## Key Changes
- Implemented `_collectMintFeesAndSetApproval` and helper functions to:
  1. Fetch and calculate the total minting fees required to register the derivative.
  2. Transfer the minting fees from the caller to the SPG contract.
  3. Approve the royalty policy to collect the minting fees.
- Added calls to `_collectMintFeesAndSetApproval` in `registerIpAndMakeDerivative` and `mintAndRegisterIpAndMakeDerivative` prior to registering the derivative.

## Tests 
- Updated existing tests to reflect changes in SPG functions.
- Added new tests to verify correct registration of derivatives under commercial licenses.

## Related Issue
This PR closes #21.

## Notes
Users must approve an additional transaction to transfer the minting fees to the SPG contract when calling `registerIpAndMakeDerivative` and `mintAndRegisterIpAndMakeDerivative`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced licensing and royalty functionalities in the StoryProtocolGateway contract.
	- Added support for dynamic fee structures based on licensing terms.
	- Introduced new parameters for handling licensing and royalty modules during initialization.
  
- **Bug Fixes**
	- Improved logic for minting fees and approvals to ensure secure financial transactions.

- **Tests**
	- Updated test logic and modifiers to reflect new licensing types, enhancing clarity and accuracy in testing.
	- Introduced internal functions to improve the reusability and maintainability of the test suite.

- **Chores**
	- Adjusted linter settings to accommodate longer lines in the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->