### PR TITLE
fix(spg): make _registerPILTermsAndAttach idempotent to avoid failure on re-attaching license terms

### DIFF
--- a/contracts/StoryProtocolGateway.sol
+++ b/contracts/StoryProtocolGateway.sol
@@ -403,6 +403,11 @@ contract StoryProtocolGateway is IStoryProtocolGateway, AccessManagedUpgradeable
         PILTerms calldata terms
     ) internal returns (uint256 licenseTermsId) {
         licenseTermsId = PIL_TEMPLATE.registerLicenseTerms(terms);
+
+        // Returns the license terms ID if already attached.
+        if (LICENSE_REGISTRY.hasIpAttachedLicenseTerms(ipId, address(PIL_TEMPLATE), licenseTermsId))
+            return licenseTermsId;
+
         LICENSING_MODULE.attachLicenseTerms(ipId, address(PIL_TEMPLATE), licenseTermsId);
     }
 


### PR DESCRIPTION
## Description
<!-- Add a description of the changes that this PR introduces -->
This PR addresses an issue where the SDK would fail when attempting to attach license terms that have already been attached to an IP. The method `_registerPILTermsAndAttach` has been updated to be idempotent.


## Key Changes
<!-- The test plan section indicates detailed steps on how to verify and test code changes. 
You can list the test cases or test steps that need to be performed.-->
- Modified `_registerPILTermsAndAttach` Functionality:
    - Now returns the `licenseTermsId` immediately if the license terms have already been attached to the specified IP.
    - Make sure that the SDK will not fail or duplicate actions when attempting to re-attach the same license terms.

## Related Issue
<!-- The related Issue section can indicate which issue or task the Pull Request is related with -->
This PR closes #24 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced efficiency in the license registration process by adding a check to prevent redundant operations for already attached license terms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->