### PR TITLE
chore: add missing comments, remove redundant assertion & create3 deployer

### DIFF
--- a/contracts/StoryProtocolGateway.sol
+++ b/contracts/StoryProtocolGateway.sol
@@ -263,6 +263,7 @@ contract StoryProtocolGateway is IStoryProtocolGateway, ERC721Holder, AccessMana
     /// @param derivData The derivative data to be used for registerDerivative.
     /// @param nftMetadata OPTIONAL. The desired metadata for the newly minted NFT.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
+    /// @param recipient The address to receive the minted NFT.
     /// @return ipId The ID of the registered IP.
     /// @return tokenId The ID of the minted NFT.
     function mintAndRegisterIpAndMakeDerivative(
@@ -556,6 +557,7 @@ contract StoryProtocolGateway is IStoryProtocolGateway, ERC721Holder, AccessMana
     /// @param licenseTemplate The address of the license template.
     /// @param licenseTermsId The ID of the license terms for the parent IP.
     /// @param amount The amount of licenses to mint.
+    /// @return The mint fee for the given parent IP.
     function _getMintFeeForSingleParent(
         address childIpId,
         address parentIpId,

--- a/contracts/interfaces/IStoryProtocolGateway.sol
+++ b/contracts/interfaces/IStoryProtocolGateway.sol
@@ -136,6 +136,7 @@ interface IStoryProtocolGateway {
     /// @param derivData The derivative data to be used for registerDerivative.
     /// @param nftMetadata OPTIONAL. The desired metadata for the newly minted NFT.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
+    /// @param recipient The address to receive the minted NFT.
     /// @return ipId The ID of the registered IP.
     /// @return tokenId The ID of the minted NFT.
     function mintAndRegisterIpAndMakeDerivative(

--- a/test/StoryProtocolGateway.t.sol
+++ b/test/StoryProtocolGateway.t.sol
@@ -594,7 +594,6 @@ contract StoryProtocolGatewayTest is BaseTest {
         assertTrue(ipAssetRegistry.isRegistered(ipIdChild));
         assertEq(tokenIdChild, 2);
         assertMetadata(ipIdChild, ipMetadataDefault);
-        assertMetadata(ipIdChild, ipMetadataDefault);
         (address licenseTemplateChild, uint256 licenseTermsIdChild) = licenseRegistry.getAttachedLicenseTerms(
             ipIdChild,
             0


### PR DESCRIPTION
## Description
<!-- Add a description of the changes that this PR introduces -->
This PR introduces the following minor updates:
- Added missing parameter comments to SPG and its interface.
- Removed a redundant assert statement from SPG tests.
- Removed the unnecessary Create3 deployer from the SPGNFT upgrade script.