### PR TITLE
refactor(metadata): add `struct Metadata` for better readability

### DIFF
--- a/contracts/SPGNFT.sol
+++ b/contracts/SPGNFT.sol
@@ -112,26 +112,26 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
 
     /// @notice Mints an NFT from the collection. Only callable by the minter role.
     /// @param to The address of the recipient of the minted NFT.
-    /// @param nftMetadata OPTIONAL. The desired metadata for the newly minted NFT.
+    /// @param nftMetadataURI OPTIONAL. The desired metadata for the newly minted NFT.
     /// @return tokenId The ID of the minted NFT.
     function mint(
         address to,
-        string calldata nftMetadata
+        string calldata nftMetadataURI
     ) public virtual onlyRole(SPGNFTLib.MINTER_ROLE) returns (uint256 tokenId) {
-        tokenId = _mintToken({ to: to, payer: msg.sender, nftMetadata: nftMetadata });
+        tokenId = _mintToken({ to: to, payer: msg.sender, nftMetadataURI: nftMetadataURI });
     }
 
     /// @notice Mints an NFT from the collection. Only callable by the SPG.
     /// @param to The address of the recipient of the minted NFT.
     /// @param payer The address of the payer for the mint fee.
-    /// @param nftMetadata OPTIONAL. The desired metadata for the newly minted NFT.
+    /// @param nftMetadataURI OPTIONAL. The desired metadata for the newly minted NFT.
     /// @return tokenId The ID of the minted NFT.
     function mintBySPG(
         address to,
         address payer,
-        string calldata nftMetadata
+        string calldata nftMetadataURI
     ) public virtual onlySPG returns (uint256 tokenId) {
-        tokenId = _mintToken({ to: to, payer: payer, nftMetadata: nftMetadata });
+        tokenId = _mintToken({ to: to, payer: payer, nftMetadataURI: nftMetadataURI });
     }
 
     /// @dev Withdraws the contract's token balance to the recipient.
@@ -152,9 +152,9 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
     /// @dev Mints an NFT from the collection.
     /// @param to The address of the recipient of the minted NFT.
     /// @param payer The address of the payer for the mint fee.
-    /// @param nftMetadata OPTIONAL. The desired metadata for the newly minted NFT.
+    /// @param nftMetadataURI OPTIONAL. The desired metadata for the newly minted NFT.
     /// @return tokenId The ID of the minted NFT.
-    function _mintToken(address to, address payer, string calldata nftMetadata) internal returns (uint256 tokenId) {
+    function _mintToken(address to, address payer, string calldata nftMetadataURI) internal returns (uint256 tokenId) {
         SPGNFTStorage storage $ = _getSPGNFTStorage();
         if ($.totalSupply + 1 > $.maxSupply) revert Errors.SPGNFT__MaxSupplyReached();
 
@@ -165,7 +165,7 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
         tokenId = ++$.totalSupply;
         _mint(to, tokenId);
 
-        if (bytes(nftMetadata).length > 0) _setTokenURI(tokenId, nftMetadata);
+        if (bytes(nftMetadataURI).length > 0) _setTokenURI(tokenId, nftMetadataURI);
     }
 
     //

--- a/contracts/interfaces/ISPGNFT.sol
+++ b/contracts/interfaces/ISPGNFT.sol
@@ -44,16 +44,16 @@ interface ISPGNFT is IAccessControl, IERC721, IERC721Metadata {
 
     /// @notice Mints an NFT from the collection. Only callable by the minter role.
     /// @param to The address of the recipient of the minted NFT.
-    /// @param nftMetadata OPTIONAL. The desired metadata for the newly minted NFT.
+    /// @param nftMetadataURI OPTIONAL. The desired metadata for the newly minted NFT.
     /// @return tokenId The ID of the minted NFT.
-    function mint(address to, string calldata nftMetadata) external returns (uint256 tokenId);
+    function mint(address to, string calldata nftMetadataURI) external returns (uint256 tokenId);
 
     /// @notice Mints an NFT from the collection. Only callable by the SPG.
     /// @param to The address of the recipient of the minted NFT.
     /// @param payer The address of the payer for the mint fee.
-    /// @param nftMetadata OPTIONAL. The desired metadata for the newly minted NFT.
+    /// @param nftMetadataURI OPTIONAL. The desired metadata for the newly minted NFT.
     /// @return tokenId The ID of the minted NFT.
-    function mintBySPG(address to, address payer, string calldata nftMetadata) external returns (uint256 tokenId);
+    function mintBySPG(address to, address payer, string calldata nftMetadataURI) external returns (uint256 tokenId);
 
     /// @dev Withdraws the contract's token balance to the recipient.
     /// @param recipient The token to withdraw.

--- a/contracts/interfaces/IStoryProtocolGateway.sol
+++ b/contracts/interfaces/IStoryProtocolGateway.sol
@@ -8,13 +8,25 @@ interface IStoryProtocolGateway {
     /// @param nftContract The address of the newly created NFT collection.
     event CollectionCreated(address indexed nftContract);
 
-    /// @notice Struct for metadata for an IP.
-    /// @param metadataURI The URI of the metadata for the IP.
-    /// @param metadataHash The hash of the metadata for the IP.
+    /// @notice Struct for metadata solely for IP registration.
+    /// @param ipMetadataURI The URI of the metadata for the IP.
+    /// @param ipMetadataHash The hash of the metadata for the IP.
     /// @param nftMetadataHash The hash of the metadata for the IP NFT.
     struct IPMetadata {
-        string metadataURI;
-        bytes32 metadataHash;
+        string ipMetadataURI;
+        bytes32 ipMetadataHash;
+        bytes32 nftMetadataHash;
+    }
+
+    /// @notice Struct for metadata for NFT minting and IP registration.
+    /// @param ipMetadataURI The URI of the metadata for the IP.
+    /// @param ipMetadataHash The hash of the metadata for the IP.
+    /// @param nftMetadataURI The URI of the metadata for the NFT.
+    /// @param nftMetadataHash The hash of the metadata for the IP NFT.
+    struct Metadata {
+        string ipMetadataURI;
+        bytes32 ipMetadataHash;
+        string nftMetadataURI;
         bytes32 nftMetadataHash;
     }
 
@@ -61,15 +73,13 @@ interface IStoryProtocolGateway {
     /// @dev Caller must have the minter role for the provided SPG NFT.
     /// @param nftContract The address of the NFT collection.
     /// @param recipient The address of the recipient of the minted NFT.
-    /// @param nftMetadata OPTIONAL. The desired metadata for the newly minted NFT.
-    /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
+    /// @param metadata OPTIONAL. The desired metadata for the newly minted NFT and newly registered IP.
     /// @return ipId The ID of the registered IP.
     /// @return tokenId The ID of the minted NFT.
     function mintAndRegisterIp(
         address nftContract,
         address recipient,
-        string calldata nftMetadata,
-        IPMetadata calldata ipMetadata
+        Metadata calldata metadata
     ) external returns (address ipId, uint256 tokenId);
 
     /// @notice Registers an NFT as IP with metadata.
@@ -96,8 +106,7 @@ interface IStoryProtocolGateway {
     /// @dev Caller must have the minter role for the provided SPG NFT.
     /// @param nftContract The address of the NFT collection.
     /// @param recipient The address of the recipient of the minted NFT.
-    /// @param nftMetadata OPTIONAL. The desired metadata for the newly minted NFT.
-    /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
+    /// @param metadata OPTIONAL. The desired metadata for the newly minted NFT and newly registered IP.
     /// @param terms The PIL terms to be registered.
     /// @return ipId The ID of the registered IP.
     /// @return tokenId The ID of the minted NFT.
@@ -105,8 +114,7 @@ interface IStoryProtocolGateway {
     function mintAndRegisterIpAndAttachPILTerms(
         address nftContract,
         address recipient,
-        string calldata nftMetadata,
-        IPMetadata calldata ipMetadata,
+        Metadata calldata metadata,
         PILTerms calldata terms
     ) external returns (address ipId, uint256 tokenId, uint256 licenseTermsId);
 
@@ -134,16 +142,14 @@ interface IStoryProtocolGateway {
     /// @dev Caller must have the minter role for the provided SPG NFT.
     /// @param nftContract The address of the NFT collection.
     /// @param derivData The derivative data to be used for registerDerivative.
-    /// @param nftMetadata OPTIONAL. The desired metadata for the newly minted NFT.
-    /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
+    /// @param metadata OPTIONAL. The desired metadata for the newly minted NFT and newly registered IP.
     /// @param recipient The address to receive the minted NFT.
     /// @return ipId The ID of the registered IP.
     /// @return tokenId The ID of the minted NFT.
     function mintAndRegisterIpAndMakeDerivative(
         address nftContract,
         MakeDerivative calldata derivData,
-        string calldata nftMetadata,
-        IPMetadata calldata ipMetadata,
+        Metadata calldata metadata,
         address recipient
     ) external returns (address ipId, uint256 tokenId);
 
@@ -169,8 +175,7 @@ interface IStoryProtocolGateway {
     /// @param nftContract The address of the NFT collection.
     /// @param licenseTokenIds The IDs of the license tokens to be burned for linking the IP to parent IPs.
     /// @param royaltyContext The context for royalty module, should be empty for Royalty Policy LAP.
-    /// @param nftMetadata OPTIONAL. The desired metadata for the newly minted NFT.
-    /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
+    /// @param metadata OPTIONAL. The desired metadata for the newly minted NFT and newly registered IP.
     /// @param recipient The address to receive the minted NFT.
     /// @return ipId The ID of the registered IP.
     /// @return tokenId The ID of the minted NFT.
@@ -178,8 +183,7 @@ interface IStoryProtocolGateway {
         address nftContract,
         uint256[] calldata licenseTokenIds,
         bytes calldata royaltyContext,
-        string calldata nftMetadata,
-        IPMetadata calldata ipMetadata,
+        Metadata calldata metadata,
         address recipient
     ) external returns (address ipId, uint256 tokenId);
 


### PR DESCRIPTION
## Description
This PR introduces a new `struct Metadata`, merging `string nftMetadata` and `struct IPMetadata` for improved readability and parameter handling. The following SPG functions have been updated:
- `mintAndRegisterIpAndMakeDerivativeWithLicenseTokens`
- `mintAndRegisterIpAndMakeDerivative`
- `mintAndRegisterIpAndAttachPILTerms`
- `mintAndRegisterIp`

## Test Plan
All existing tests pass locally.

## Notes
This change impacts the `IStoryProtocolGateway` interface. Existing function calls must be updated accordingly.