### PR TITLE
fix(deploy-script): remove duplicated `_endBroadcast` call

### DIFF
--- a/script/Main.s.sol
+++ b/script/Main.s.sol
@@ -46,8 +46,6 @@ contract Main is Script, StoryProtocolCoreAddressManager, BroadcastManager, Json
 
         // Set beacon contract via multisig.
         // spg.setNftContractBeacon(address(spgNftBeacon));
-
-        _endBroadcast();
     }
 
     function _deployProtocolContracts(address accessControlDeployer) private {


### PR DESCRIPTION
## Description
<!-- Add a description of the changes that this PR introduces -->
This PR removes the duplicated `_endBroadcast` call in the deployment script which was causing deployment to fail.

## Test Plan 
<!-- The test plan section indicates detailed steps on how to verify and test code changes. 
You can list the test cases or test steps that need to be performed.-->
All existing tests passes locally.