### PR TITLE
feat(spg): add group IPA feature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,8 +3,8 @@ MAINNET_RPC_URL = https://eth-mainnet.g.alchemy.com/v2/1234123412341234
 # TODO: Remove private key in favor of forge cast wallet
 MAINNET_PRIVATEKEY= 12341234123412341234123412341234
 
-# SEPOLIA
-SEPOLIA_RPC_URL = https://eth-mainnet.g.alchemy.com/v2/1234123412341234
+# TESTNET
+TESTNET_RPC_URL = https://eth-mainnet.g.alchemy.com/v2/1234123412341234
 # TODO: Remove private key in favor of forge cast wallet
 
 # ETHSCAN

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,22 @@
 # CHANGELOG
 
+## v1.1.0
+- Migrate periphery contracts from protocol core repo (#1)
+- Revamped SPG with NFT collection and mint token logic. (#5, #6)
+- Added support for batch transactions via `multicall` (#38)
+- Added functionality for registering IP with metadata and supporting metadata for SPG NFT. (#8, #20, #37)
+- Addressed ownership transfer issues in deployment script. (#18, #39)
+- Fixed issues with derivative registration, including minting fees for commercial licenses, license token flow, and making register and attach PIL terms idempotent. (#23, #25, #30)
+- Added SPG & SPG NFT upgrade scripts (#10)
+- Added IP Graph, Solady's ERC6551 integration, and core protocol package bumps. (#30)
+- Enhance CI/CD, repo, and misc.(#2, #3, #11, #32)
+
+**Full Changelog**: [v1.1.0](https://github.com/storyprotocol/protocol-periphery-v1/commits/v1.1.0)
+
 ## v1.0.0-beta-rc1
 
 This is the first release of the Story Protocol Gateway
 
 - Adds the SPG, a convenient wrapper around the core contracts for registration
 - Includes NFT minting management tooling for registering and minting in one-shot
+

--- a/contracts/interfaces/IStoryProtocolGateway.sol
+++ b/contracts/interfaces/IStoryProtocolGateway.sol
@@ -60,15 +60,15 @@ interface IStoryProtocolGateway {
         address owner
     ) external returns (address nftContract);
 
-    /// @notice Mint an NFT from a collection and register it with metadata as an IP.
+    /// @notice Mint an NFT from a SPGNFT collection and register it with metadata as an IP.
     /// @dev Caller must have the minter role for the provided SPG NFT.
-    /// @param nftContract The address of the NFT collection.
+    /// @param spgNftContract The address of the SPGNFT collection.
     /// @param recipient The address of the recipient of the minted NFT.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
     /// @return ipId The ID of the registered IP.
-    /// @return tokenId The ID of the minted NFT.
+    /// @return tokenId The ID of the newly minted NFT.
     function mintAndRegisterIp(
-        address nftContract,
+        address spgNftContract,
         address recipient,
         IPMetadata calldata ipMetadata
     ) external returns (address ipId, uint256 tokenId);
@@ -78,7 +78,7 @@ interface IStoryProtocolGateway {
     /// @param tokenId The ID of the NFT.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
     /// @param sigMetadata OPTIONAL. Signature data for setAll (metadata) for the IP via the Core Metadata Module.
-    /// @return ipId The ID of the registered IP.
+    /// @return ipId The ID of the newly registered IP.
     function registerIp(
         address nftContract,
         uint256 tokenId,
@@ -89,21 +89,22 @@ interface IStoryProtocolGateway {
     /// @notice Register Programmable IP License Terms (if unregistered) and attach it to IP.
     /// @param ipId The ID of the IP.
     /// @param terms The PIL terms to be registered.
-    /// @return licenseTermsId The ID of the registered PIL terms.
+    /// @return licenseTermsId The ID of the newly registered PIL terms.
     function registerPILTermsAndAttach(address ipId, PILTerms calldata terms) external returns (uint256 licenseTermsId);
 
-    /// @notice Mint an NFT from a collection, register it with metadata as an IP, register Programmable IP License
+    /// @notice Mint an NFT from a SPGNFT collection, register it with metadata as an IP,
+    /// register Programmable IPLicense
     /// Terms (if unregistered), and attach it to the registered IP.
     /// @dev Caller must have the minter role for the provided SPG NFT.
-    /// @param nftContract The address of the NFT collection.
+    /// @param spgNftContract The address of the SPGNFT collection.
     /// @param recipient The address of the recipient of the minted NFT.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
     /// @param terms The PIL terms to be registered.
-    /// @return ipId The ID of the registered IP.
-    /// @return tokenId The ID of the minted NFT.
-    /// @return licenseTermsId The ID of the registered PIL terms.
+    /// @return ipId The ID of the newly registered IP.
+    /// @return tokenId The ID of the newly minted NFT.
+    /// @return licenseTermsId The ID of the newly registered PIL terms.
     function mintAndRegisterIpAndAttachPILTerms(
-        address nftContract,
+        address spgNftContract,
         address recipient,
         IPMetadata calldata ipMetadata,
         PILTerms calldata terms
@@ -118,8 +119,8 @@ interface IStoryProtocolGateway {
     /// @param terms The PIL terms to be registered.
     /// @param sigMetadata OPTIONAL. Signature data for setAll (metadata) for the IP via the Core Metadata Module.
     /// @param sigAttach Signature data for attachLicenseTerms to the IP via the Licensing Module.
-    /// @return ipId The ID of the registered IP.
-    /// @return licenseTermsId The ID of the registered PIL terms.
+    /// @return ipId The ID of the newly registered IP.
+    /// @return licenseTermsId The ID of the newly registered PIL terms.
     function registerIpAndAttachPILTerms(
         address nftContract,
         uint256 tokenId,
@@ -129,29 +130,29 @@ interface IStoryProtocolGateway {
         SignatureData calldata sigAttach
     ) external returns (address ipId, uint256 licenseTermsId);
 
-    /// @notice Mint an NFT from a collection and register it as a derivative IP without license tokens.
+    /// @notice Mint an NFT from a SPGNFT collection and register it as a derivative IP without license tokens.
     /// @dev Caller must have the minter role for the provided SPG NFT.
-    /// @param nftContract The address of the NFT collection.
+    /// @param spgNftContract The address of the SPGNFT collection.
     /// @param derivData The derivative data to be used for registerDerivative.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
     /// @param recipient The address to receive the minted NFT.
-    /// @return ipId The ID of the registered IP.
-    /// @return tokenId The ID of the minted NFT.
+    /// @return ipId The ID of the newly registered IP.
+    /// @return tokenId The ID of the newly minted NFT.
     function mintAndRegisterIpAndMakeDerivative(
-        address nftContract,
+        address spgNftContract,
         MakeDerivative calldata derivData,
         IPMetadata calldata ipMetadata,
         address recipient
     ) external returns (address ipId, uint256 tokenId);
 
-    /// @notice Register the given NFT as a derivative IP with metadata without using license tokens.
+    /// @notice Register the given NFT as a derivative IP with metadata without license tokens.
     /// @param nftContract The address of the NFT collection.
     /// @param tokenId The ID of the NFT.
     /// @param derivData The derivative data to be used for registerDerivative.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
     /// @param sigMetadata OPTIONAL. Signature data for setAll (metadata) for the IP via the Core Metadata Module.
     /// @param sigRegister Signature data for registerDerivative for the IP via the Licensing Module.
-    /// @return ipId The ID of the registered IP.
+    /// @return ipId The ID of the newly registered IP.
     function registerIpAndMakeDerivative(
         address nftContract,
         uint256 tokenId,
@@ -161,17 +162,17 @@ interface IStoryProtocolGateway {
         SignatureData calldata sigRegister
     ) external returns (address ipId);
 
-    /// @notice Mint an NFT from a collection and register it as a derivative IP using license tokens.
+    /// @notice Mint an NFT from a SPGNFT collection and register it as a derivative IP using license tokens.
     /// @dev Caller must have the minter role for the provided SPG NFT.
-    /// @param nftContract The address of the NFT collection.
+    /// @param spgNftContract The address of the SPGNFT collection.
     /// @param licenseTokenIds The IDs of the license tokens to be burned for linking the IP to parent IPs.
     /// @param royaltyContext The context for royalty module, should be empty for Royalty Policy LAP.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
     /// @param recipient The address to receive the minted NFT.
-    /// @return ipId The ID of the registered IP.
-    /// @return tokenId The ID of the minted NFT.
+    /// @return ipId The ID of the newly registered IP.
+    /// @return tokenId The ID of the newly minted NFT.
     function mintAndRegisterIpAndMakeDerivativeWithLicenseTokens(
-        address nftContract,
+        address spgNftContract,
         uint256[] calldata licenseTokenIds,
         bytes calldata royaltyContext,
         IPMetadata calldata ipMetadata,
@@ -186,7 +187,7 @@ interface IStoryProtocolGateway {
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
     /// @param sigMetadata OPTIONAL. Signature data for setAll (metadata) for the IP via the Core Metadata Module.
     /// @param sigRegister Signature data for registerDerivativeWithLicenseTokens for the IP via the Licensing Module.
-    /// @return ipId The ID of the registered IP.
+    /// @return ipId The ID of the newly registered IP.
     function registerIpAndMakeDerivativeWithLicenseTokens(
         address nftContract,
         uint256 tokenId,
@@ -196,4 +197,59 @@ interface IStoryProtocolGateway {
         SignatureData calldata sigMetadata,
         SignatureData calldata sigRegister
     ) external returns (address ipId);
+
+    /// @notice Mint an NFT from a SPGNFT collection, register it with metadata as an IP,
+    /// attach Programmable IP License Terms to the registered IP, and add it to a group IP.
+    /// @dev Caller must have the minter role for the provided SPG NFT.
+    /// @param spgNftContract The address of the SPGNFT collection.
+    /// @param groupId The ID of the group IP to add the newly registered IP.
+    /// @param recipient The address of the recipient of the minted NFT.
+    /// @param licenseTermsId The ID of the registered PIL terms that will be attached to the newly registered IP.
+    /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
+    /// @param sigAddToGroup Signature data for addIp to the group IP via the Grouping Module.
+    /// @return ipId The ID of the newly registered IP.
+    /// @return tokenId The ID of the newly minted NFT.
+    function mintAndRegisterIpAndAttachPILTermsAndAddToGroup(
+        address spgNftContract,
+        address groupId,
+        address recipient,
+        uint256 licenseTermsId,
+        IPMetadata calldata ipMetadata,
+        SignatureData calldata sigAddToGroup
+    ) external returns (address ipId, uint256 tokenId);
+
+    /// @notice Register an NFT as IP with metadata, attach Programmable IP License Terms to the registered IP,
+    /// and add it to a group IP.
+    /// @param nftContract The address of the NFT collection.
+    /// @param tokenId The ID of the NFT.
+    /// @param groupId The ID of the group IP to add the newly registered IP.
+    /// @param licenseTermsId The ID of the registered PIL terms that will be attached to the newly registered IP.
+    /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
+    /// @param sigMetadataAndAttach Signature data for setAll (metadata) and attachLicenseTerms to the IP
+    /// via the Core Metadata Module and Licensing Module.
+    /// @param sigAddToGroup Signature data for addIp to the group IP via the Grouping Module.
+    /// @return ipId The ID of the newly registered IP.
+    function registerIpAndAttachPILTermsAndAddToGroup(
+        address nftContract,
+        uint256 tokenId,
+        address groupId,
+        uint256 licenseTermsId,
+        IPMetadata calldata ipMetadata,
+        SignatureData calldata sigMetadataAndAttach,
+        SignatureData calldata sigAddToGroup
+    ) external returns (address ipId);
+
+    /// @notice Register a group IP with a group reward pool, register Programmable IP License Terms,
+    /// attach it to the group IP, and add individual IPs to the group IP.
+    /// @dev ipIds must be have the same PIL terms as the group IP.
+    /// @param groupPool The address of the group reward pool.
+    /// @param ipIds The IDs of the IPs to add to the newly registered group IP.
+    /// @param groupIpTerms The PIL terms to be registered and attached to the newly registered group IP.
+    /// @return groupId The ID of the newly registered group IP.
+    /// @return groupLicenseTermsId The ID of the newly registered PIL terms.
+    function registerGroupAndAttachPILTermsAndAddIps(
+        address groupPool,
+        address[] calldata ipIds,
+        PILTerms calldata groupIpTerms
+    ) external returns (address groupId, uint256 groupLicenseTermsId);
 }

--- a/foundry.toml
+++ b/foundry.toml
@@ -14,7 +14,7 @@ fs_permissions = [{ access = 'read', path = './' }, { access = 'read-write', pat
 # Comment out for local development (testing requires 0xSplit forks — will add Mock soon)
 # pin fork by using --fork-block-number 19042069 to reduce wait time
 mainnet = "https://rpc.ankr.com/eth"
-sepolia = "${SEPOLIA_RPC_URL}"
+testnet = "${TESTNET_RPC_URL}"
 
 
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@story-protocol/protocol-periphery",
-  "version": "v1.0.0-rc1",
+  "version": "v1.1.0",
   "description": "Story Protocol periphery smart contracts",
   "main": "",
   "directories": {

--- a/script/Main.s.sol
+++ b/script/Main.s.sol
@@ -4,11 +4,9 @@ pragma solidity ^0.8.23;
 
 import { console2 } from "forge-std/console2.sol";
 import { Script } from "forge-std/Script.sol";
-import { stdJson } from "forge-std/StdJson.sol";
 import { ICreate3Deployer } from "@create3-deployer/contracts/Create3Deployer.sol";
 
 import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
-import { IPAssetRegistry } from "@storyprotocol/core/registries/IPAssetRegistry.sol";
 
 import { StoryProtocolGateway } from "../contracts/StoryProtocolGateway.sol";
 import { SPGNFT } from "../contracts/SPGNFT.sol";
@@ -61,7 +59,9 @@ contract Main is Script, StoryProtocolCoreAddressManager, BroadcastManager, Json
                 royaltyModuleAddr,
                 coreMetadataModuleAddr,
                 pilTemplateAddr,
-                licenseTokenAddr
+                licenseTokenAddr,
+                groupingModuleAddr,
+                groupNFTAddr
             )
         );
         spg = StoryProtocolGateway(
@@ -103,7 +103,7 @@ contract Main is Script, StoryProtocolCoreAddressManager, BroadcastManager, Json
         console2.log(string.concat(contractKey, " deployed to:"), newAddress);
     }
 
-    function _getSalt(string memory name) private view returns (bytes32 salt) {
+    function _getSalt(string memory name) private pure returns (bytes32 salt) {
         salt = keccak256(abi.encode(name, create3SaltSeed));
     }
 }

--- a/script/UpgradeSPG.s.sol
+++ b/script/UpgradeSPG.s.sol
@@ -60,7 +60,9 @@ contract UpgradeSPG is
                 royaltyModuleAddr,
                 coreMetadataModuleAddr,
                 pilTemplateAddr,
-                licenseTokenAddr
+                licenseTokenAddr,
+                groupingModuleAddr,
+                groupNFTAddr
             )
         );
         console2.log("New SPG Implementation", newSpgImpl);

--- a/script/utils/BroadcastManager.s.sol
+++ b/script/utils/BroadcastManager.s.sol
@@ -17,9 +17,9 @@ contract BroadcastManager is Script {
             multisig = vm.envAddress("MAINNET_MULTISIG_ADDRESS");
             vm.startBroadcast(deployerPrivateKey);
         } else if (block.chainid == 1513 || block.chainid == 11155111) {
-            deployerPrivateKey = vm.envUint("SEPOLIA_PRIVATEKEY");
-            deployer = vm.envAddress("SEPOLIA_DEPLOYER_ADDRESS");
-            multisig = vm.envAddress("SEPOLIA_MULTISIG_ADDRESS");
+            deployerPrivateKey = vm.envUint("TESTNET_PRIVATEKEY");
+            deployer = vm.envAddress("TESTNET_DEPLOYER_ADDRESS");
+            multisig = vm.envAddress("TESTNET_MULTISIG_ADDRESS");
             vm.startBroadcast(deployerPrivateKey);
         } else if (block.chainid == 31337) {
             multisig = address(0x456);

--- a/script/utils/StoryProtocolCoreAddressManager.sol
+++ b/script/utils/StoryProtocolCoreAddressManager.sol
@@ -16,6 +16,8 @@ contract StoryProtocolCoreAddressManager is Script {
     address internal accessControllerAddr;
     address internal pilTemplateAddr;
     address internal licenseTokenAddr;
+    address internal groupingModuleAddr;
+    address internal groupNFTAddr;
 
     function _readStoryProtocolCoreAddresses() internal {
         string memory root = vm.projectRoot();
@@ -39,5 +41,7 @@ contract StoryProtocolCoreAddressManager is Script {
         accessControllerAddr = json.readAddress(".main.AccessController");
         pilTemplateAddr = json.readAddress(".main.PILicenseTemplate");
         licenseTokenAddr = json.readAddress(".main.LicenseToken");
+        groupingModuleAddr = json.readAddress(".main.GroupingModule");
+        groupNFTAddr = json.readAddress(".main.GroupNFT");
     }
 }

--- a/script/utils/upgrades/ERC7201Helper.s.sol
+++ b/script/utils/upgrades/ERC7201Helper.s.sol
@@ -14,7 +14,7 @@ contract ERC7201HelperScript is Script {
     string constant NAMESPACE = "story-protocol-periphery";
     string constant CONTRACT_NAME = "SPG";
 
-    function run() external {
+    function run() external pure {
         bytes memory erc7201Key = abi.encodePacked(NAMESPACE, ".", CONTRACT_NAME);
         bytes32 hash = keccak256(abi.encode(uint256(keccak256(erc7201Key)) - 1)) & ~bytes32(uint256(0xff));
 

--- a/test/mocks/MockEvenSplitGroupPool.sol
+++ b/test/mocks/MockEvenSplitGroupPool.sol
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.23;
+
+import { IGroupRewardPool } from "@storyprotocol/core/interfaces/modules/grouping/IGroupRewardPool.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { EnumerableSet } from "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+
+contract MockEvenSplitGroupPool is IGroupRewardPool {
+    using SafeERC20 for IERC20;
+    using EnumerableSet for EnumerableSet.AddressSet;
+
+    struct IpRewardInfo {
+        uint256 startPoolBalance; // balance of pool when IP added to pool
+        uint256 rewardDebt; // pending reward = (PoolInfo.accBalance - startPoolBalance)  / totalIp - ip.rewardDebt
+    }
+
+    struct PoolInfo {
+        uint256 accBalance;
+        uint256 availableBalance;
+    }
+
+    mapping(address groupId => mapping(address ipId => uint256 addedTime)) public ipAddedTime;
+    mapping(address groupId => uint256 totalMemberIPs) public totalMemberIPs;
+    mapping(address groupId => EnumerableSet.AddressSet tokens) internal groupTokens;
+    // Info of each token pool. groupId => { token => PoolInfo}
+    mapping(address groupId => mapping(address token => PoolInfo)) public poolInfo;
+    // Info of each user that stakes LP tokens. groupId => { token => { ipId => IpInfo}}
+    mapping(address groupId => mapping(address tokenId => mapping(address ipId => IpRewardInfo))) public ipRewardInfo;
+
+    function addIp(address groupId, address ipId) external {
+        // ignore if IP is already added to pool
+        if (ipAddedTime[groupId][ipId] != 0) return;
+        ipAddedTime[groupId][ipId] = block.timestamp;
+        // set rewardDebt of IP to current availableReward of the IP
+        totalMemberIPs[groupId] += 1;
+
+        EnumerableSet.AddressSet storage tokens = groupTokens[groupId];
+        uint256 length = tokens.length();
+        for (uint256 i = 0; i < length; i++) {
+            address token = tokens.at(i);
+            _collectRoyalties(groupId, token);
+            uint256 totalReward = poolInfo[groupId][token].accBalance;
+            ipRewardInfo[groupId][token][ipId].startPoolBalance = totalReward;
+            ipRewardInfo[groupId][token][ipId].rewardDebt = 0;
+        }
+    }
+
+    function removeIp(address groupId, address ipId) external {
+        EnumerableSet.AddressSet storage tokens = groupTokens[groupId];
+        uint256 length = tokens.length();
+        address[] memory ipIds = new address[](1);
+        ipIds[0] = ipId;
+        for (uint256 i = 0; i < length; i++) {
+            address token = tokens.at(i);
+            _collectRoyalties(groupId, token);
+            _distributeRewards(groupId, token, ipIds);
+            ipAddedTime[groupId][ipId] = 0;
+        }
+        totalMemberIPs[groupId] -= 1;
+    }
+
+    /// @notice Returns the reward for each IP in the group
+    /// @param groupId The group ID
+    /// @param token The reward token
+    /// @param ipIds The IP IDs
+    /// @return The rewards for each IP
+    function getAvailableReward(
+        address groupId,
+        address token,
+        address[] calldata ipIds
+    ) external view returns (uint256[] memory) {
+        return _getAvailableReward(groupId, token, ipIds);
+    }
+
+    function distributeRewards(
+        address groupId,
+        address token,
+        address[] calldata ipIds
+    ) external returns (uint256[] memory rewards) {
+        return _distributeRewards(groupId, token, ipIds);
+    }
+
+    function collectRoyalties(address groupId, address token) external {
+        _collectRoyalties(groupId, token);
+    }
+
+    function _getAvailableReward(
+        address groupId,
+        address token,
+        address[] memory ipIds
+    ) internal view returns (uint256[] memory) {
+        uint256 totalAccumulatePoolBalance = poolInfo[groupId][token].accBalance;
+        uint256[] memory rewards = new uint256[](ipIds.length);
+        for (uint256 i = 0; i < ipIds.length; i++) {
+            // ignore if IP is not added to pool
+            if (ipAddedTime[groupId][ipIds[i]] == 0) {
+                rewards[i] = 0;
+                revert("IP not added to pool");
+                continue;
+            }
+            uint256 poolBalanceBeforeIpAdded = ipRewardInfo[groupId][token][ipIds[i]].startPoolBalance;
+            uint256 rewardPerIP = (totalAccumulatePoolBalance - poolBalanceBeforeIpAdded) / totalMemberIPs[groupId];
+            rewards[i] = rewardPerIP - ipRewardInfo[groupId][token][ipIds[i]].rewardDebt;
+        }
+        return rewards;
+    }
+
+    function _distributeRewards(
+        address groupId,
+        address token,
+        address[] memory ipIds
+    ) internal returns (uint256[] memory rewards) {
+        rewards = _getAvailableReward(groupId, token, ipIds);
+        for (uint256 i = 0; i < ipIds.length; i++) {
+            // calculate pending reward for each IP
+            ipRewardInfo[groupId][token][ipIds[i]].rewardDebt += rewards[i];
+            poolInfo[groupId][token].availableBalance -= rewards[i];
+            // call royalty module to transfer reward to IP as royalty
+            IERC20(token).safeTransfer(ipIds[i], rewards[i]);
+        }
+    }
+
+    function _collectRoyalties(address groupId, address token) internal {
+        // call royalty module to collect revenue of token
+        uint256 royalties = 0;
+        poolInfo[groupId][token].availableBalance += royalties;
+        poolInfo[groupId][token].accBalance += royalties;
+        groupTokens[groupId].add(token);
+    }
+
+    function depositReward(address groupId, address token, uint256 amount) external {
+        IERC20(token).safeTransferFrom(msg.sender, address(this), amount);
+        poolInfo[groupId][token].accBalance += amount;
+        poolInfo[groupId][token].availableBalance += amount;
+        groupTokens[groupId].add(token);
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -436,7 +436,7 @@
 
 "@story-protocol/protocol-core@github:storyprotocol/protocol-core-v1#main":
   version "1.1.0"
-  resolved "https://codeload.github.com/storyprotocol/protocol-core-v1/tar.gz/8133cd54641341b7efd116318ff93cf3d8a17a1a"
+  resolved "https://codeload.github.com/storyprotocol/protocol-core-v1/tar.gz/4d961e5f4dc4605013d4237d9705236fd5e2fba2"
   dependencies:
     "@openzeppelin/contracts" "5.0.2"
     "@openzeppelin/contracts-upgradeable" "5.0.2"
@@ -490,9 +490,9 @@
   integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
 "@types/node@*":
-  version "22.4.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.4.0.tgz#c295fe1d6f5f58916cc61dbef8cf65b5b9b71de9"
-  integrity sha512-49AbMDwYUz7EXxKU/r7mXOsxwFr4BYbvB7tWYxVuLdb2ibd30ijjXINSMAHiEEZk5PCRBmW1gUeisn2VMKt3cQ==
+  version "22.5.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.5.1.tgz#de01dce265f6b99ed32b295962045d10b5b99560"
+  integrity sha512-KkHsxej0j9IW1KKOOAA/XBA0z08UFSrRQHErzEfA3Vgq57eXIMYboIlHJuYIfd+lwCQjtKqUu3UnmKbtUc9yRw==
   dependencies:
     undici-types "~6.19.2"
 
@@ -1529,9 +1529,9 @@ http2-wrapper@^2.1.10:
     resolve-alpn "^1.2.0"
 
 husky@^9.0.11:
-  version "9.1.4"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-9.1.4.tgz#926fd19c18d345add5eab0a42b2b6d9a80259b34"
-  integrity sha512-bho94YyReb4JV7LYWRWxZ/xr6TtOTt8cMfmQ39MQYJ7f/YE268s3GdghGwi+y4zAeqewE5zYLvuhV0M0ijsDEA==
+  version "9.1.5"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-9.1.5.tgz#2b6edede53ee1adbbd3a3da490628a23f5243b83"
+  integrity sha512-rowAVRUBfI0b4+niA4SJMhfQwc107VLkBUgEYYAOQAbqDCnra1nYh83hF/MDmhYs9t9n1E3DuKOrs2LYNC+0Ag==
 
 ignore@^5.1.1, ignore@^5.2.0, ignore@^5.2.4:
   version "5.3.2"
@@ -1587,9 +1587,9 @@ is-binary-path@~2.1.0:
     binary-extensions "^2.0.0"
 
 is-core-module@^2.13.0:
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.15.0.tgz#71c72ec5442ace7e76b306e9d48db361f22699ea"
-  integrity sha512-Dd+Lb2/zvk9SKy1TGCt1wFJFo/MWBPMX5x7KcvLajWTGuomczdQX61PvY5yK6SVACwpoexWo81IfFyoKY2QnTA==
+  version "2.15.1"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.15.1.tgz#a7363a25bee942fefab0de13bf6aa372c82dcc37"
+  integrity sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==
   dependencies:
     hasown "^2.0.2"
 
@@ -1805,9 +1805,9 @@ micro-ftch@^0.3.1:
   integrity sha512-/0LLxhzP0tfiR5hcQebtudP56gUurs2CLkGarnCiB/OqEyUFQ6U3paQi/tgLv0hBJYt2rnr9MNpxz4fiiugstg==
 
 micromatch@^4.0.4:
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.7.tgz#33e8190d9fe474a9895525f5618eee136d46c2e5"
-  integrity sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
+  integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
   dependencies:
     braces "^3.0.3"
     picomatch "^2.3.1"
@@ -2086,9 +2086,9 @@ prettier-linter-helpers@^1.0.0:
     fast-diff "^1.1.2"
 
 prettier-plugin-solidity@^1.1.3:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/prettier-plugin-solidity/-/prettier-plugin-solidity-1.4.0.tgz#9eaa6e1d380c8d2b58e4c533ee36eda5c65870c1"
-  integrity sha512-XXEOjKaY4nC0Hjqv+DMo+A7ZNbS70jil0phl1mdMAbKf45pkxfhPXrNBMDSWsTYTldwSX+8JOwsUynO3enVc5A==
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-solidity/-/prettier-plugin-solidity-1.4.1.tgz#8060baf18853a9e34d2e09e47e87b4f19e15afe9"
+  integrity sha512-Mq8EtfacVZ/0+uDKTtHZGW3Aa7vEbX/BNx63hmVg6YTiTXSiuKP0amj0G6pGwjmLaOfymWh3QgXEZkjQbU8QRg==
   dependencies:
     "@solidity-parser/parser" "^0.18.0"
     semver "^7.5.4"
@@ -2545,9 +2545,9 @@ tslib@2.4.0:
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
 tslib@^2.6.2:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.6.3.tgz#0438f810ad7a9edcde7a241c3d80db693c8cbfe0"
-  integrity sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.7.0.tgz#d9b40c5c40ab59e8738f297df3087bf1a2690c01"
+  integrity sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -2600,9 +2600,9 @@ uglify-js@^3.1.4:
   integrity sha512-S8KA6DDI47nQXJSi2ctQ629YzwOVs+bQML6DAtvy0wgNdpi+0ySpQK0g2pxBq2xfF2z3YCscu7NNA8nXT9PlIQ==
 
 undici-types@~6.19.2:
-  version "6.19.6"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.6.tgz#e218c3df0987f4c0e0008ca00d6b6472d9b89b36"
-  integrity sha512-e/vggGopEfTKSvj4ihnOLTsqhrKRN3LeO6qSN/GxohhuRv8qH9bNQ4B8W7e/vFL+0XTnmHPB4/kegunZGA4Org==
+  version "6.19.8"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
+  integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
 
 universalify@^0.1.0:
   version "0.1.2"


### PR DESCRIPTION
## Description

This PR introduces new SPG functions to support Group IPA features from protocol-core-v1 ([see PR#192](https://github.com/storyprotocol/protocol-core-v1/pull/192)). These functions allow the following operations in a single call:

1. Mint a token → Register as new IP → Attach PIL license terms → Add to Group IP.
2. Register an existing token as new IP → Attach PIL license terms → Add to Group IP.
3. Register a new Group IP → Add multiple existing IPs to the Group.

Additionally, this PR updates the codebase to accommodate interface changes in the royalty-related sections of the core protocol.

## Test Plan
New tests have been added for each function. All new and existing tests pass locally.

## Related Issue

Closes #35