### PR TITLE
fix(licensing): resolve inconsistent licenses in the repository

### DIFF
--- a/contracts/BaseWorkflow.sol
+++ b/contracts/BaseWorkflow.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
 import { IAccessController } from "@storyprotocol/core/interfaces/access/IAccessController.sol";

--- a/contracts/GroupingWorkflows.sol
+++ b/contracts/GroupingWorkflows.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
 import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";

--- a/contracts/SPGNFT.sol
+++ b/contracts/SPGNFT.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
 import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";

--- a/contracts/StoryProtocolGateway.sol
+++ b/contracts/StoryProtocolGateway.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/interfaces/IGroupingWorkflows.sol
+++ b/contracts/interfaces/IGroupingWorkflows.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
 import { PILTerms } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";

--- a/contracts/interfaces/ISPGNFT.sol
+++ b/contracts/interfaces/ISPGNFT.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
 import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";

--- a/contracts/interfaces/IStoryProtocolGateway.sol
+++ b/contracts/interfaces/IStoryProtocolGateway.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
 import { PILTerms } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
 /// @title Errors Library

--- a/contracts/lib/LicensingHelper.sol
+++ b/contracts/lib/LicensingHelper.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/lib/MetadataHelper.sol
+++ b/contracts/lib/MetadataHelper.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
 import { ICoreMetadataModule } from "@storyprotocol/core/interfaces/modules/metadata/ICoreMetadataModule.sol";

--- a/contracts/lib/PermissionHelper.sol
+++ b/contracts/lib/PermissionHelper.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
 import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";

--- a/contracts/lib/SPGNFTLib.sol
+++ b/contracts/lib/SPGNFTLib.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
 /// @title SPG NFT Library

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prepare": "husky install"
   },
   "author": "StoryProtocol",
-  "license": "BUSL-1.1",
+  "license": "MIT",
   "devDependencies": {
     "chai": "^5.0.3",
     "dotenv": "^16.4.1",

--- a/script/Main.s.sol
+++ b/script/Main.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 /* solhint-disable no-console */
 

--- a/script/UpgradeSPG.s.sol
+++ b/script/UpgradeSPG.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 /* solhint-disable no-console */
 

--- a/script/UpgradeSPGNFT.s.sol
+++ b/script/UpgradeSPGNFT.s.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 /* solhint-disable no-console */
 

--- a/test/GroupingWorkflows.t.sol
+++ b/test/GroupingWorkflows.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
 import { BaseTest } from "./utils/BaseTest.t.sol";

--- a/test/SPGNFT.t.sol
+++ b/test/SPGNFT.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
 import { BeaconProxy } from "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";

--- a/test/StoryProtocolGateway.t.sol
+++ b/test/StoryProtocolGateway.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
 import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";

--- a/test/mocks/MockERC20.sol
+++ b/test/mocks/MockERC20.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.23;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/test/mocks/MockERC721.sol
+++ b/test/mocks/MockERC721.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSDL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.23;
 
 import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";

--- a/test/mocks/MockEvenSplitGroupPool.sol
+++ b/test/mocks/MockEvenSplitGroupPool.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.23;
 
 import { IGroupRewardPool } from "@storyprotocol/core/interfaces/modules/grouping/IGroupRewardPool.sol";

--- a/test/utils/TestProxyHelper.t.sol
+++ b/test/utils/TestProxyHelper.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
 import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";


### PR DESCRIPTION
## Description
<!-- Add a description of the changes that this PR introduces -->

This PR addresses the inconsistency in the licensing across several files within the repository. 
The repository is licensed under the MIT License, but certain contracts were previously licensed under BUSL-1.1. 
For consistency, all contracts have been updated to the MIT License.

## Related Issue
<!-- The related Issue section can indicate which issue or task the Pull Request is related with -->

This PR closes #45  
