### PR TITLE
feat(grouping): add support for custom license templates in `GroupingWorkflows`

### DIFF
--- a/contracts/GroupingWorkflows.sol
+++ b/contracts/GroupingWorkflows.sol
@@ -12,13 +12,11 @@ import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensi
 import { ICoreMetadataModule } from "@storyprotocol/core/interfaces/modules/metadata/ICoreMetadataModule.sol";
 
 import { GroupNFT } from "@storyprotocol/core/GroupNFT.sol";
-import { PILTerms } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
 
 import { Errors } from "./lib/Errors.sol";
 import { BaseWorkflow } from "./BaseWorkflow.sol";
 import { ISPGNFT } from "./interfaces/ISPGNFT.sol";
 import { MetadataHelper } from "./lib/MetadataHelper.sol";
-import { LicensingHelper } from "./lib/LicensingHelper.sol";
 import { PermissionHelper } from "./lib/PermissionHelper.sol";
 import { IGroupingWorkflows } from "./interfaces/IGroupingWorkflows.sol";
 import { IStoryProtocolGateway as ISPG } from "./interfaces/IStoryProtocolGateway.sol";
@@ -106,21 +104,23 @@ contract GroupingWorkflows is
     }
 
     /// @notice Mint an NFT from a SPGNFT collection, register it with metadata as an IP, attach
-    /// Programmable IP License Terms to the registered IP, and add it to a group IP.
+    /// license terms to the registered IP, and add it to a group IP.
     /// @dev Caller must have the minter role for the provided SPG NFT.
     /// @param spgNftContract The address of the SPGNFT collection.
     /// @param groupId The ID of the group IP to add the newly registered IP.
     /// @param recipient The address of the recipient of the minted NFT.
-    /// @param licenseTermsId The ID of the registered PIL terms that will be attached to the newly registered IP.
+    /// @param licenseTermsId The ID of the registered PIL terms that will be attached to the new IP.
+    /// @param licenseTemplate The address of the license template used for `licenseTermsId`.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
     /// @param sigAddToGroup Signature data for addIp to the group IP via the Grouping Module.
     /// @return ipId The ID of the newly registered IP.
     /// @return tokenId The ID of the newly minted NFT.
-    function mintAndRegisterIpAndAttachPILTermsAndAddToGroup(
+    function mintAndRegisterIpAndAttachLicenseAndAddToGroup(
         address spgNftContract,
         address groupId,
         address recipient,
         uint256 licenseTermsId,
+        address licenseTemplate,
         ISPG.IPMetadata calldata ipMetadata,
         ISPG.SignatureData calldata sigAddToGroup
     ) external onlyCallerWithMinterRole(spgNftContract) returns (address ipId, uint256 tokenId) {
@@ -132,7 +132,7 @@ contract GroupingWorkflows is
         ipId = IP_ASSET_REGISTRY.register(block.chainid, spgNftContract, tokenId);
         MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);
 
-        LICENSING_MODULE.attachLicenseTerms(ipId, address(PIL_TEMPLATE), licenseTermsId);
+        LICENSING_MODULE.attachLicenseTerms(ipId, licenseTemplate, licenseTermsId);
 
         PermissionHelper.setPermissionForModule(
             groupId,
@@ -149,22 +149,24 @@ contract GroupingWorkflows is
         ISPGNFT(spgNftContract).safeTransferFrom(address(this), recipient, tokenId, "");
     }
 
-    /// @notice Register an NFT as IP with metadata, attach Programmable IP License Terms to the registered IP,
+    /// @notice Register an NFT as IP with metadata, attach license terms to the registered IP,
     /// and add it to a group IP.
     /// @param nftContract The address of the NFT collection.
     /// @param tokenId The ID of the NFT.
     /// @param groupId The ID of the group IP to add the newly registered IP.
-    /// @param licenseTermsId The ID of the registered PIL terms that will be attached to the newly registered IP.
+    /// @param licenseTermsId The ID of the registered PIL terms that will be attached to the new IP.
+    /// @param licenseTemplate The address of the license template used for `licenseTermsId`.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
     /// @param sigMetadataAndAttach Signature data for setAll (metadata) and attachLicenseTerms to the IP
     /// via the Core Metadata Module and Licensing Module.
     /// @param sigAddToGroup Signature data for addIp to the group IP via the Grouping Module.
     /// @return ipId The ID of the newly registered IP.
-    function registerIpAndAttachPILTermsAndAddToGroup(
+    function registerIpAndAttachLicenseAndAddToGroup(
         address nftContract,
         uint256 tokenId,
         address groupId,
         uint256 licenseTermsId,
+        address licenseTemplate,
         ISPG.IPMetadata calldata ipMetadata,
         ISPG.SignatureData calldata sigMetadataAndAttach,
         ISPG.SignatureData calldata sigAddToGroup
@@ -188,7 +190,7 @@ contract GroupingWorkflows is
 
         MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);
 
-        LICENSING_MODULE.attachLicenseTerms(ipId, address(PIL_TEMPLATE), licenseTermsId);
+        LICENSING_MODULE.attachLicenseTerms(ipId, licenseTemplate, licenseTermsId);
 
         PermissionHelper.setPermissionForModule(
             groupId,
@@ -203,28 +205,23 @@ contract GroupingWorkflows is
         GROUPING_MODULE.addIp(groupId, ipIds);
     }
 
-    /// @notice Register a group IP with a group reward pool, register Programmable IP License Terms,
-    /// attach it to the group IP, and add individual IPs to the group IP.
+    /// @notice Register a group IP with a group reward pool, attach license terms to the group IP,
+    /// and add individual IPs to the group IP.
     /// @dev ipIds must have the same PIL terms as the group IP.
     /// @param groupPool The address of the group reward pool.
     /// @param ipIds The IDs of the IPs to add to the newly registered group IP.
-    /// @param groupIpTerms The PIL terms to be registered and attached to the newly registered group IP.
+    /// @param licenseTermsId The ID of the registered PIL terms that will be attached to the new group IP.
+    /// @param licenseTemplate The address of the license template used for `licenseTermsId`.
     /// @return groupId The ID of the newly registered group IP.
-    /// @return groupLicenseTermsId The ID of the newly registered PIL terms.
-    function registerGroupAndAttachPILTermsAndAddIps(
+    function registerGroupAndAttachLicenseAndAddIps(
         address groupPool,
         address[] calldata ipIds,
-        PILTerms calldata groupIpTerms
-    ) external returns (address groupId, uint256 groupLicenseTermsId) {
+        uint256 licenseTermsId,
+        address licenseTemplate
+    ) external returns (address groupId) {
         groupId = GROUPING_MODULE.registerGroup(groupPool);
 
-        groupLicenseTermsId = LicensingHelper.registerPILTermsAndAttach(
-            groupId,
-            address(PIL_TEMPLATE),
-            address(LICENSING_MODULE),
-            address(LICENSE_REGISTRY),
-            groupIpTerms
-        );
+        LICENSING_MODULE.attachLicenseTerms(groupId, licenseTemplate, licenseTermsId);
 
         GROUPING_MODULE.addIp(groupId, ipIds);
 

--- a/contracts/GroupingWorkflows.sol
+++ b/contracts/GroupingWorkflows.sol
@@ -109,8 +109,8 @@ contract GroupingWorkflows is
     /// @param spgNftContract The address of the SPGNFT collection.
     /// @param groupId The ID of the group IP to add the newly registered IP.
     /// @param recipient The address of the recipient of the minted NFT.
-    /// @param licenseTermsId The ID of the registered PIL terms that will be attached to the new IP.
-    /// @param licenseTemplate The address of the license template used for `licenseTermsId`.
+    /// @param licenseTemplate The address of the license template to be attached to the new IP.
+    /// @param licenseTermsId The ID of the registered license terms that will be attached to the new IP.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
     /// @param sigAddToGroup Signature data for addIp to the group IP via the Grouping Module.
     /// @return ipId The ID of the newly registered IP.
@@ -119,8 +119,8 @@ contract GroupingWorkflows is
         address spgNftContract,
         address groupId,
         address recipient,
-        uint256 licenseTermsId,
         address licenseTemplate,
+        uint256 licenseTermsId,
         ISPG.IPMetadata calldata ipMetadata,
         ISPG.SignatureData calldata sigAddToGroup
     ) external onlyCallerWithMinterRole(spgNftContract) returns (address ipId, uint256 tokenId) {
@@ -154,8 +154,8 @@ contract GroupingWorkflows is
     /// @param nftContract The address of the NFT collection.
     /// @param tokenId The ID of the NFT.
     /// @param groupId The ID of the group IP to add the newly registered IP.
-    /// @param licenseTermsId The ID of the registered PIL terms that will be attached to the new IP.
-    /// @param licenseTemplate The address of the license template used for `licenseTermsId`.
+    /// @param licenseTemplate The address of the license template to be attached to the new IP.
+    /// @param licenseTermsId The ID of the registered license terms that will be attached to the new IP.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
     /// @param sigMetadataAndAttach Signature data for setAll (metadata) and attachLicenseTerms to the IP
     /// via the Core Metadata Module and Licensing Module.
@@ -165,8 +165,8 @@ contract GroupingWorkflows is
         address nftContract,
         uint256 tokenId,
         address groupId,
-        uint256 licenseTermsId,
         address licenseTemplate,
+        uint256 licenseTermsId,
         ISPG.IPMetadata calldata ipMetadata,
         ISPG.SignatureData calldata sigMetadataAndAttach,
         ISPG.SignatureData calldata sigAddToGroup
@@ -210,14 +210,14 @@ contract GroupingWorkflows is
     /// @dev ipIds must have the same PIL terms as the group IP.
     /// @param groupPool The address of the group reward pool.
     /// @param ipIds The IDs of the IPs to add to the newly registered group IP.
-    /// @param licenseTermsId The ID of the registered PIL terms that will be attached to the new group IP.
-    /// @param licenseTemplate The address of the license template used for `licenseTermsId`.
+    /// @param licenseTemplate The address of the license template to be attached to the new group IP.
+    /// @param licenseTermsId The ID of the registered license terms that will be attached to the new group IP.
     /// @return groupId The ID of the newly registered group IP.
     function registerGroupAndAttachLicenseAndAddIps(
         address groupPool,
         address[] calldata ipIds,
-        uint256 licenseTermsId,
-        address licenseTemplate
+        address licenseTemplate,
+        uint256 licenseTermsId
     ) external returns (address groupId) {
         groupId = GROUPING_MODULE.registerGroup(groupPool);
 

--- a/contracts/interfaces/IGroupingWorkflows.sol
+++ b/contracts/interfaces/IGroupingWorkflows.sol
@@ -8,57 +8,62 @@ import { IStoryProtocolGateway as ISPG } from "../interfaces/IStoryProtocolGatew
 /// @title Grouping Workflows Interface
 interface IGroupingWorkflows {
     /// @notice Mint an NFT from a SPGNFT collection, register it with metadata as an IP,
-    /// attach Programmable IP License Terms to the registered IP, and add it to a group IP.
+    /// attach license terms to the registered IP, and add it to a group IP.
     /// @dev Caller must have the minter role for the provided SPG NFT.
     /// @param spgNftContract The address of the SPGNFT collection.
     /// @param groupId The ID of the group IP to add the newly registered IP.
     /// @param recipient The address of the recipient of the minted NFT.
-    /// @param licenseTermsId The ID of the registered PIL terms that will be attached to the newly registered IP.
+    /// @param licenseTermsId The ID of the registered license terms that will be attached to the new IP.
+    /// @param licenseTemplate The address of the license template used for `licenseTermsId`.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
     /// @param sigAddToGroup Signature data for addIp to the group IP via the Grouping Module.
     /// @return ipId The ID of the newly registered IP.
     /// @return tokenId The ID of the newly minted NFT.
-    function mintAndRegisterIpAndAttachPILTermsAndAddToGroup(
+    function mintAndRegisterIpAndAttachLicenseAndAddToGroup(
         address spgNftContract,
         address groupId,
         address recipient,
         uint256 licenseTermsId,
+        address licenseTemplate,
         ISPG.IPMetadata calldata ipMetadata,
         ISPG.SignatureData calldata sigAddToGroup
     ) external returns (address ipId, uint256 tokenId);
 
-    /// @notice Register an NFT as IP with metadata, attach Programmable IP License Terms to the registered IP,
+    /// @notice Register an NFT as IP with metadata, attach license terms to the registered IP,
     /// and add it to a group IP.
     /// @param nftContract The address of the NFT collection.
     /// @param tokenId The ID of the NFT.
     /// @param groupId The ID of the group IP to add the newly registered IP.
-    /// @param licenseTermsId The ID of the registered PIL terms that will be attached to the newly registered IP.
+    /// @param licenseTermsId The ID of the registered license terms that will be attached to the new IP.
+    /// @param licenseTemplate The address of the license template used for `licenseTermsId`.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
     /// @param sigMetadataAndAttach Signature data for setAll (metadata) and attachLicenseTerms to the IP
     /// via the Core Metadata Module and Licensing Module.
     /// @param sigAddToGroup Signature data for addIp to the group IP via the Grouping Module.
     /// @return ipId The ID of the newly registered IP.
-    function registerIpAndAttachPILTermsAndAddToGroup(
+    function registerIpAndAttachLicenseAndAddToGroup(
         address nftContract,
         uint256 tokenId,
         address groupId,
         uint256 licenseTermsId,
+        address licenseTemplate,
         ISPG.IPMetadata calldata ipMetadata,
         ISPG.SignatureData calldata sigMetadataAndAttach,
         ISPG.SignatureData calldata sigAddToGroup
     ) external returns (address ipId);
 
-    /// @notice Register a group IP with a group reward pool, register Programmable IP License Terms,
-    /// attach it to the group IP, and add individual IPs to the group IP.
-    /// @dev ipIds must be have the same PIL terms as the group IP.
+    /// @notice Register a group IP with a group reward pool, attach license terms to the group IP,
+    /// and add individual IPs to the group IP.
+    /// @dev ipIds must be have the same license terms as the group IP.
     /// @param groupPool The address of the group reward pool.
     /// @param ipIds The IDs of the IPs to add to the newly registered group IP.
-    /// @param groupIpTerms The PIL terms to be registered and attached to the newly registered group IP.
+    /// @param licenseTermsId The ID of the registered license terms that will be attached to the new group IP.
+    /// @param licenseTemplate The address of the license template used for `licenseTermsId`.
     /// @return groupId The ID of the newly registered group IP.
-    /// @return groupLicenseTermsId The ID of the newly registered PIL terms.
-    function registerGroupAndAttachPILTermsAndAddIps(
+    function registerGroupAndAttachLicenseAndAddIps(
         address groupPool,
         address[] calldata ipIds,
-        PILTerms calldata groupIpTerms
-    ) external returns (address groupId, uint256 groupLicenseTermsId);
+        uint256 licenseTermsId,
+        address licenseTemplate
+    ) external returns (address groupId);
 }

--- a/contracts/interfaces/IGroupingWorkflows.sol
+++ b/contracts/interfaces/IGroupingWorkflows.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
-import { PILTerms } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
-
 import { IStoryProtocolGateway as ISPG } from "../interfaces/IStoryProtocolGateway.sol";
 
 /// @title Grouping Workflows Interface
@@ -13,8 +11,8 @@ interface IGroupingWorkflows {
     /// @param spgNftContract The address of the SPGNFT collection.
     /// @param groupId The ID of the group IP to add the newly registered IP.
     /// @param recipient The address of the recipient of the minted NFT.
+    /// @param licenseTemplate The address of the license template to be attached to the new IP.
     /// @param licenseTermsId The ID of the registered license terms that will be attached to the new IP.
-    /// @param licenseTemplate The address of the license template used for `licenseTermsId`.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
     /// @param sigAddToGroup Signature data for addIp to the group IP via the Grouping Module.
     /// @return ipId The ID of the newly registered IP.
@@ -23,8 +21,8 @@ interface IGroupingWorkflows {
         address spgNftContract,
         address groupId,
         address recipient,
-        uint256 licenseTermsId,
         address licenseTemplate,
+        uint256 licenseTermsId,
         ISPG.IPMetadata calldata ipMetadata,
         ISPG.SignatureData calldata sigAddToGroup
     ) external returns (address ipId, uint256 tokenId);
@@ -34,8 +32,8 @@ interface IGroupingWorkflows {
     /// @param nftContract The address of the NFT collection.
     /// @param tokenId The ID of the NFT.
     /// @param groupId The ID of the group IP to add the newly registered IP.
+    /// @param licenseTemplate The address of the license template to be attached to the new IP.
     /// @param licenseTermsId The ID of the registered license terms that will be attached to the new IP.
-    /// @param licenseTemplate The address of the license template used for `licenseTermsId`.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
     /// @param sigMetadataAndAttach Signature data for setAll (metadata) and attachLicenseTerms to the IP
     /// via the Core Metadata Module and Licensing Module.
@@ -45,8 +43,8 @@ interface IGroupingWorkflows {
         address nftContract,
         uint256 tokenId,
         address groupId,
-        uint256 licenseTermsId,
         address licenseTemplate,
+        uint256 licenseTermsId,
         ISPG.IPMetadata calldata ipMetadata,
         ISPG.SignatureData calldata sigMetadataAndAttach,
         ISPG.SignatureData calldata sigAddToGroup
@@ -57,13 +55,13 @@ interface IGroupingWorkflows {
     /// @dev ipIds must be have the same license terms as the group IP.
     /// @param groupPool The address of the group reward pool.
     /// @param ipIds The IDs of the IPs to add to the newly registered group IP.
+    /// @param licenseTemplate The address of the license template to be attached to the new group IP.
     /// @param licenseTermsId The ID of the registered license terms that will be attached to the new group IP.
-    /// @param licenseTemplate The address of the license template used for `licenseTermsId`.
     /// @return groupId The ID of the newly registered group IP.
     function registerGroupAndAttachLicenseAndAddIps(
         address groupPool,
         address[] calldata ipIds,
-        uint256 licenseTermsId,
-        address licenseTemplate
+        address licenseTemplate,
+        uint256 licenseTermsId
     ) external returns (address groupId);
 }

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -23,9 +23,9 @@
 
 ### Final Step: Add IP(s) to a group IP Asset
 
-- `mintAndRegisterIpAndAttachPILTermsAndAddToGroup`: Mints a NFT → Registers it as an IP → Attaches the given PIL terms to the IP → Adds the IP to a group IP
-- `registerIpAndAttachPILTermsAndAddToGroup`: Registers an IP → Attaches the given PIL terms to the IP → Adds the IP to a group IP
-- `registerGroupAndAttachPILTermsAndAddIps`: Registers a group IP → Registers PIL terms → Attaches the PIL terms to group IP → Adds existing IPs to the group IP
+- `mintAndRegisterIpAndAttachLicenseAndAddToGroup`: Mints a NFT → Registers it as an IP → Attaches the given license terms to the IP → Adds the IP to a group IP
+- `registerIpAndAttachLicenseAndAddToGroup`: Registers an IP → Attaches the given license terms to the IP → Adds the IP to a group IP
+- `registerGroupAndAttachLicenseAndAddIps`: Registers a group IP → Attaches the given license terms to the group IP → Adds existing IPs to the group IP
 
 
 > 📚 For full contract interfaces, check out `contracts/interfaces`.

--- a/test/GroupingWorkflows.t.sol
+++ b/test/GroupingWorkflows.t.sol
@@ -72,8 +72,8 @@ contract GroupingWorkflowsTest is BaseTest {
             groupId: groupId,
             recipient: caller,
             ipMetadata: ipMetadataEmpty,
-            licenseTermsId: 1,
             licenseTemplate: address(pilTemplate),
+            licenseTermsId: 1,
             sigAddToGroup: ISPG.SignatureData({ signer: alice, deadline: deadline, signature: sigAddToGroup })
         });
 
@@ -172,12 +172,12 @@ contract GroupingWorkflowsTest is BaseTest {
             (ipIds[i], ) = abi.decode(results[i], (address, uint256));
         }
 
-        (groupId) = groupingWorkflows.registerGroupAndAttachLicenseAndAddIps(
-            address(rewardPool),
-            ipIds,
-            1,
-            address(pilTemplate)
-        );
+        (groupId) = groupingWorkflows.registerGroupAndAttachLicenseAndAddIps({
+            groupPool: address(rewardPool),
+            ipIds: ipIds,
+            licenseTemplate: address(pilTemplate),
+            licenseTermsId: 1
+        });
 
         assertTrue(ipAssetRegistry.isRegisteredGroup(groupId));
         (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(groupId, 0);

--- a/test/GroupingWorkflows.t.sol
+++ b/test/GroupingWorkflows.t.sol
@@ -67,12 +67,13 @@ contract GroupingWorkflowsTest is BaseTest {
             signerPk: alicePk
         });
 
-        (address ipId, uint256 tokenId) = groupingWorkflows.mintAndRegisterIpAndAttachPILTermsAndAddToGroup({
+        (address ipId, uint256 tokenId) = groupingWorkflows.mintAndRegisterIpAndAttachLicenseAndAddToGroup({
             spgNftContract: address(nftContract),
             groupId: groupId,
             recipient: caller,
             ipMetadata: ipMetadataEmpty,
             licenseTermsId: 1,
+            licenseTemplate: address(pilTemplate),
             sigAddToGroup: ISPG.SignatureData({ signer: alice, deadline: deadline, signature: sigAddToGroup })
         });
 
@@ -119,12 +120,13 @@ contract GroupingWorkflowsTest is BaseTest {
             signerPk: alicePk
         });
 
-        address ipId = groupingWorkflows.registerIpAndAttachPILTermsAndAddToGroup({
+        address ipId = groupingWorkflows.registerIpAndAttachLicenseAndAddToGroup({
             nftContract: address(nftContract),
             tokenId: tokenId,
             groupId: groupId,
             ipMetadata: ipMetadataEmpty,
             licenseTermsId: 1,
+            licenseTemplate: address(pilTemplate),
             sigMetadataAndAttach: ISPG.SignatureData({
                 signer: alice,
                 deadline: deadline,
@@ -170,18 +172,17 @@ contract GroupingWorkflowsTest is BaseTest {
             (ipIds[i], ) = abi.decode(results[i], (address, uint256));
         }
 
-        uint256 groupLicenseTermsId;
-        (groupId, groupLicenseTermsId) = groupingWorkflows.registerGroupAndAttachPILTermsAndAddIps(
+        (groupId) = groupingWorkflows.registerGroupAndAttachLicenseAndAddIps(
             address(rewardPool),
             ipIds,
-            PILFlavors.nonCommercialSocialRemixing()
+            1,
+            address(pilTemplate)
         );
 
         assertTrue(ipAssetRegistry.isRegisteredGroup(groupId));
-        assertEq(groupLicenseTermsId, 1);
         (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(groupId, 0);
         assertEq(licenseTemplate, address(pilTemplate));
-        assertEq(licenseTermsId, groupLicenseTermsId);
+        assertEq(licenseTermsId, 1);
 
         assertEq(ipAssetRegistry.totalMembers(groupId), 10);
         for (uint256 i = 0; i < 10; i++) {


### PR DESCRIPTION
## Description
This PR introduces support for custom license templates in the `GroupingWorkflows` contract. This allows custom licenses to be attached to individual or group IPs using user-provided license templates, instead of being restricted to the PIL template.

**Key changes:**
- Updated all relevant `GroupingWorkflows` functions to accept a license template address as a parameter.
- Modified `attachLicenseTerms` calls to the `LicensingModule` to use the provided license template address.
- Updated tests and documentation to reflect these changes.

## Related Issue
- Issue #54

## Notes
This PR includes interface changes to `GroupingWorkflows`, which may require updating any contracts or systems interacting with it.