### PR TITLE
fix(grouping): make license attachment idempotent

### DIFF
--- a/contracts/GroupingWorkflows.sol
+++ b/contracts/GroupingWorkflows.sol
@@ -17,6 +17,7 @@ import { Errors } from "./lib/Errors.sol";
 import { BaseWorkflow } from "./BaseWorkflow.sol";
 import { ISPGNFT } from "./interfaces/ISPGNFT.sol";
 import { MetadataHelper } from "./lib/MetadataHelper.sol";
+import { LicensingHelper } from "./lib/LicensingHelper.sol";
 import { PermissionHelper } from "./lib/PermissionHelper.sol";
 import { IGroupingWorkflows } from "./interfaces/IGroupingWorkflows.sol";
 import { IStoryProtocolGateway as ISPG } from "./interfaces/IStoryProtocolGateway.sol";
@@ -132,7 +133,14 @@ contract GroupingWorkflows is
         ipId = IP_ASSET_REGISTRY.register(block.chainid, spgNftContract, tokenId);
         MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);
 
-        LICENSING_MODULE.attachLicenseTerms(ipId, licenseTemplate, licenseTermsId);
+        // attach license terms to the IP, do nothing if already attached
+        LicensingHelper.attachLicenseTerms(
+            ipId,
+            address(LICENSING_MODULE),
+            address(LICENSE_REGISTRY),
+            licenseTemplate,
+            licenseTermsId
+        );
 
         PermissionHelper.setPermissionForModule(
             groupId,
@@ -190,7 +198,14 @@ contract GroupingWorkflows is
 
         MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);
 
-        LICENSING_MODULE.attachLicenseTerms(ipId, licenseTemplate, licenseTermsId);
+        // attach license terms to the IP, do nothing if already attached
+        LicensingHelper.attachLicenseTerms(
+            ipId,
+            address(LICENSING_MODULE),
+            address(LICENSE_REGISTRY),
+            licenseTemplate,
+            licenseTermsId
+        );
 
         PermissionHelper.setPermissionForModule(
             groupId,
@@ -221,7 +236,14 @@ contract GroupingWorkflows is
     ) external returns (address groupId) {
         groupId = GROUPING_MODULE.registerGroup(groupPool);
 
-        LICENSING_MODULE.attachLicenseTerms(groupId, licenseTemplate, licenseTermsId);
+        // attach license terms to the group IP, do nothing if already attached
+        LicensingHelper.attachLicenseTerms(
+            groupId,
+            address(LICENSING_MODULE),
+            address(LICENSE_REGISTRY),
+            licenseTemplate,
+            licenseTermsId
+        );
 
         GROUPING_MODULE.addIp(groupId, ipIds);
 

--- a/contracts/lib/LicensingHelper.sol
+++ b/contracts/lib/LicensingHelper.sol
@@ -35,11 +35,27 @@ library LicensingHelper {
     ) internal returns (uint256 licenseTermsId) {
         licenseTermsId = IPILicenseTemplate(pilTemplate).registerLicenseTerms(terms);
 
-        // Returns the license terms ID if already attached.
-        if (ILicenseRegistry(licenseRegistry).hasIpAttachedLicenseTerms(ipId, pilTemplate, licenseTermsId))
-            return licenseTermsId;
+        attachLicenseTerms(ipId, licensingModule, licenseRegistry, pilTemplate, licenseTermsId);
+    }
 
-        ILicensingModule(licensingModule).attachLicenseTerms(ipId, pilTemplate, licenseTermsId);
+    /// @dev Attaches license terms to the given IP.
+    /// @param ipId The ID of the IP.
+    /// @param licensingModule The address of the Licensing Module.
+    /// @param licenseRegistry The address of the License Registry.
+    /// @param licenseTemplate The address of the license template.
+    /// @param licenseTermsId The ID of the license terms to be attached.
+    function attachLicenseTerms(
+        address ipId,
+        address licensingModule,
+        address licenseRegistry,
+        address licenseTemplate,
+        uint256 licenseTermsId
+    ) internal {
+        // Returns if license terms are already attached.
+        if (ILicenseRegistry(licenseRegistry).hasIpAttachedLicenseTerms(ipId, licenseTemplate, licenseTermsId))
+            return;
+
+        ILicensingModule(licensingModule).attachLicenseTerms(ipId, licenseTemplate, licenseTermsId);
     }
 
     /// @dev Collects license tokens from the caller. Assumes the periphery contract has permission to transfer the license tokens.

--- a/foundry.toml
+++ b/foundry.toml
@@ -2,13 +2,17 @@
 src = 'contracts'
 out = 'out'
 libs = ['node_modules', 'lib']
-cache_path  = 'forge-cache'
+cache_path = 'forge-cache'
 gas_reports = ["*"]
 optimizer = true
 optimizer_runs = 20000
 test = 'test'
 solc = '0.8.23'
-fs_permissions = [{ access = 'read', path = './' }, { access = 'read-write', path = './deploy-out' }]
+fs_permissions = [
+    { access = 'read', path = './' },
+    { access = 'read-write', path = './deploy-out' },
+]
+evm_version = 'cancun'
 
 [rpc_endpoints]
 # Comment out for local development (testing requires 0xSplit forks — will add Mock soon)

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,7 +1,7 @@
 @openzeppelin/=node_modules/@openzeppelin/
-@openzeppelin-foundry-upgrades/=lib/openzeppelin-foundry-upgrades
+@openzeppelin-foundry-upgrades/=lib/openzeppelin-foundry-upgrades/
 @storyprotocol/core/=node_modules/@story-protocol/protocol-core/contracts/
-@storyprotocol/script/=node_modules/@story-protocol/protocol-core/script/foundry
+@storyprotocol/script/=node_modules/@story-protocol/protocol-core/script/foundry/
 @create3-deployer/=node_modules/@story-protocol/create3-deployer/
 @solady/=node_modules/solady/
 ds-test/=lib/forge-std/lib/ds-test/src/

--- a/script/utils/DeployHelper.sol
+++ b/script/utils/DeployHelper.sol
@@ -6,23 +6,23 @@ pragma solidity ^0.8.23;
 import { console2 } from "forge-std/console2.sol";
 import { Script } from "forge-std/Script.sol";
 import { stdJson } from "forge-std/StdJson.sol";
+import { ICreate3Deployer } from "@create3-deployer/contracts/ICreate3Deployer.sol";
 import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
+import { StorageLayoutChecker } from "@storyprotocol/script/utils/upgrades/StorageLayoutCheck.s.sol";
 
 // contracts
-import { SPGNFT } from "contracts/SPGNFT.sol";
-import { GroupingWorkflows } from "contracts/GroupingWorkflows.sol";
-import { StoryProtocolGateway } from "contracts/StoryProtocolGateway.sol";
+import { SPGNFT } from "../../contracts/SPGNFT.sol";
+import { GroupingWorkflows } from "../../contracts/GroupingWorkflows.sol";
+import { StoryProtocolGateway } from "../../contracts/StoryProtocolGateway.sol";
 
 // script
 import { StringUtil } from "./StringUtil.sol";
 import { BroadcastManager } from "./BroadcastManager.s.sol";
 import { JsonDeploymentHandler } from "./JsonDeploymentHandler.s.sol";
 import { StoryProtocolCoreAddressManager } from "./StoryProtocolCoreAddressManager.sol";
-import { StorageLayoutChecker } from "@storyprotocol/script/utils/upgrades/StorageLayoutCheck.s.sol";
 
 // test
-import { TestProxyHelper } from "test/utils/TestProxyHelper.t.sol";
-import { ICreate3Deployer } from "@create3-deployer/contracts/ICreate3Deployer.sol";
+import { TestProxyHelper } from "../../test/utils/TestProxyHelper.t.sol";
 
 contract DeployHelper is
     Script,
@@ -44,17 +44,12 @@ contract DeployHelper is
     uint256 internal create3SaltSeed;
 
     // SPGNFT
-    SPGNFT private spgNftImpl;
-    UpgradeableBeacon private spgNftBeacon;
+    SPGNFT internal spgNftImpl;
+    UpgradeableBeacon internal spgNftBeacon;
 
     // Periphery Workflows
-    StoryProtocolGateway private spg;
-    GroupingWorkflows private groupingWorkflows;
-
-    // keep private to avoid conflict with inheriting contracts
-    uint256 private immutable ARBITRATION_PRICE;
-    uint256 private immutable MAX_ROYALTY_APPROVAL;
-    address private immutable TREASURY_ADDRESS;
+    StoryProtocolGateway internal spg;
+    GroupingWorkflows internal groupingWorkflows;
 
     // DeployHelper variable
     bool private writeDeploys;

--- a/test/utils/BaseTest.t.sol
+++ b/test/utils/BaseTest.t.sol
@@ -69,7 +69,7 @@ contract BaseTest is Test {
     GroupingModule internal groupingModule;
     GroupNFT internal groupNFT;
     IPGraphACL internal ipGraphACL;
-    MockEvenSplitGroupPool public rewardPool;
+    MockEvenSplitGroupPool internal rewardPool;
 
     StoryProtocolGateway internal spg;
     SPGNFT internal spgNftImpl;


### PR DESCRIPTION
## Description
<!-- Add a description of the changes that this PR introduces -->
This PR adds a fix to ensure idempotency when attaching license terms in `GroupingWorkflows`.

### Key Changes
- Added the `attachLicenseTerms` helper function, which attaches license terms only if they haven't been applied already. `GroupingWorkflows` now uses this helper instead of calling `LicensingModule` directly.
- Miscellaneous Fixes: Added EVM version, removed unnecessary imports, fixed state variable visibility, and applied minor style improvements.

## Test Plan 
<!-- The test plan section indicates detailed steps on how to verify and test code changes. 
You can list the test cases or test steps that need to be performed.-->
All existing and new tests pass locally.

## Related Issue
<!-- The related Issue section can indicate which issue or task the Pull Request is related with -->

- Issue #24 