### PR TITLE
feat(derivative): use licensing module's `predictMintingLicenseFee` for minting fee calculation

### DIFF
--- a/contracts/StoryProtocolGateway.sol
+++ b/contracts/StoryProtocolGateway.sol
@@ -324,9 +324,8 @@ contract StoryProtocolGateway is
 
         LicensingHelper.collectMintFeesAndSetApproval(
             msg.sender,
-            ipId,
             address(ROYALTY_MODULE),
-            address(LICENSE_REGISTRY),
+            address(LICENSING_MODULE),
             derivData.licenseTemplate,
             derivData.parentIpIds,
             derivData.licenseTermsIds
@@ -378,9 +377,8 @@ contract StoryProtocolGateway is
 
         LicensingHelper.collectMintFeesAndSetApproval(
             msg.sender,
-            ipId,
             address(ROYALTY_MODULE),
-            address(LICENSE_REGISTRY),
+            address(LICENSING_MODULE),
             derivData.licenseTemplate,
             derivData.parentIpIds,
             derivData.licenseTermsIds


### PR DESCRIPTION
## Description
This PR replaces the existing minting fee calculation logic for a single parent with a call to `predictMintingLicenseFee` function from the licensing module. This function allows minting fee prediction without triggering any state changes.

## Test Plan
All existing tests pass locally.

## Related Issue
- Closes #61