### PR TITLE
feat(spg): add public minting support

### DIFF
--- a/contracts/BaseWorkflow.sol
+++ b/contracts/BaseWorkflow.sol
@@ -50,11 +50,14 @@ abstract contract BaseWorkflow {
         PIL_TEMPLATE = IPILicenseTemplate(pilTemplate);
     }
 
-    /// @notice Check that the caller has the minter role for the provided SPG NFT.
+    /// @notice Check that the caller is authorized to mint for the provided SPG NFT.
+    /// @notice The caller must have the MINTER_ROLE for the SPG NFT or the SPG NFT must has public minting enabled.
     /// @param spgNftContract The address of the SPG NFT.
-    modifier onlyCallerWithMinterRole(address spgNftContract) {
-        if (!ISPGNFT(spgNftContract).hasRole(SPGNFTLib.MINTER_ROLE, msg.sender))
-            revert Errors.SPG__CallerNotMinterRole();
+    modifier onlyMintAuthorized(address spgNftContract) {
+        if (
+            !ISPGNFT(spgNftContract).hasRole(SPGNFTLib.MINTER_ROLE, msg.sender) &&
+            !ISPGNFT(spgNftContract).publicMinting()
+        ) revert Errors.SPG__CallerNotAuthorizedToMint();
         _;
     }
 }

--- a/contracts/GroupingWorkflows.sol
+++ b/contracts/GroupingWorkflows.sol
@@ -124,7 +124,7 @@ contract GroupingWorkflows is
         uint256 licenseTermsId,
         ISPG.IPMetadata calldata ipMetadata,
         ISPG.SignatureData calldata sigAddToGroup
-    ) external onlyCallerWithMinterRole(spgNftContract) returns (address ipId, uint256 tokenId) {
+    ) external onlyMintAuthorized(spgNftContract) returns (address ipId, uint256 tokenId) {
         tokenId = ISPGNFT(spgNftContract).mintByPeriphery({
             to: address(this),
             payer: msg.sender,

--- a/contracts/SPGNFT.sol
+++ b/contracts/SPGNFT.sol
@@ -19,6 +19,7 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
     /// @param mintFeeToken The token to pay for minting.
     /// @param mintFeeRecipient The address to receive mint fees.
     /// @param mintOpen The status of minting, whether it is open or not.
+    /// @param publicMinting True if the collection is open for everyone to mint.
     /// @custom:storage-location erc7201:story-protocol-periphery.SPGNFT
     struct SPGNFTStorage {
         uint32 maxSupply;

--- a/contracts/StoryProtocolGateway.sol
+++ b/contracts/StoryProtocolGateway.sol
@@ -164,7 +164,7 @@ contract StoryProtocolGateway is
         address spgNftContract,
         address recipient,
         IPMetadata calldata ipMetadata
-    ) external onlyCallerWithMinterRole(spgNftContract) returns (address ipId, uint256 tokenId) {
+    ) external onlyMintAuthorized(spgNftContract) returns (address ipId, uint256 tokenId) {
         tokenId = ISPGNFT(spgNftContract).mintByPeriphery({
             to: address(this),
             payer: msg.sender,
@@ -230,11 +230,7 @@ contract StoryProtocolGateway is
         address recipient,
         IPMetadata calldata ipMetadata,
         PILTerms calldata terms
-    )
-        external
-        onlyCallerWithMinterRole(spgNftContract)
-        returns (address ipId, uint256 tokenId, uint256 licenseTermsId)
-    {
+    ) external onlyMintAuthorized(spgNftContract) returns (address ipId, uint256 tokenId, uint256 licenseTermsId) {
         tokenId = ISPGNFT(spgNftContract).mintByPeriphery({
             to: address(this),
             payer: msg.sender,
@@ -312,7 +308,7 @@ contract StoryProtocolGateway is
         MakeDerivative calldata derivData,
         IPMetadata calldata ipMetadata,
         address recipient
-    ) external onlyCallerWithMinterRole(spgNftContract) returns (address ipId, uint256 tokenId) {
+    ) external onlyMintAuthorized(spgNftContract) returns (address ipId, uint256 tokenId) {
         tokenId = ISPGNFT(spgNftContract).mintByPeriphery({
             to: address(this),
             payer: msg.sender,
@@ -409,7 +405,7 @@ contract StoryProtocolGateway is
         bytes calldata royaltyContext,
         IPMetadata calldata ipMetadata,
         address recipient
-    ) external onlyCallerWithMinterRole(spgNftContract) returns (address ipId, uint256 tokenId) {
+    ) external onlyMintAuthorized(spgNftContract) returns (address ipId, uint256 tokenId) {
         LicensingHelper.collectLicenseTokens(licenseTokenIds, address(LICENSE_TOKEN));
 
         tokenId = ISPGNFT(spgNftContract).mintByPeriphery({

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -7,8 +7,8 @@ library Errors {
     /// @notice Zero address provided as a param to SPG.
     error SPG__ZeroAddressParam();
 
-    /// @notice Caller does not have the minter role.
-    error SPG__CallerNotMinterRole();
+    /// @notice Caller is not authorized to mint.
+    error SPG__CallerNotAuthorizedToMint();
 
     /// @notice License token list is empty.
     error SPG__EmptyLicenseTokens();


### PR DESCRIPTION
## Description
This PR adds public minting support for SPG functions that handle minting. It replaces the `onlyCallerWithMinterRole` access control modifier with `onlyMintAuthorized`, which checks if the caller is authorized to mint—either by having the minter role in the given SPG NFT contract or if the contract has `publicMinting` enabled.

## Test Plan
- Added `test_SPG_revert_mintAndRegisterIp_callerNotAuthorizedToMint` to verify that minting is blocked when the caller doesn't have the minter role and public minting is disabled in the collection.
- Added `test_SPG_mintAndRegisterIp_publicMint` to test that minting is allowed when public minting is enabled, even if the caller doesn't have the minter role.
- Existing tests already cover cases where the caller has the minter role, but public minting is disabled.

All new and existing tests pass locally.

## Related Issue
- Closes #58