### PR TITLE
 feat(spg & spgnft): add support for base URI

### DIFF
--- a/contracts/SPGNFT.sol
+++ b/contracts/SPGNFT.sol
@@ -13,22 +13,25 @@ import { SPGNFTLib } from "./lib/SPGNFTLib.sol";
 
 contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeable {
     /// @dev Storage structure for the SPGNFTSotrage.
-    /// @param maxSupply The maximum supply of the collection.
-    /// @param totalSupply The total minted supply of the collection.
-    /// @param mintFee The fee to mint an NFT from the collection.
-    /// @param mintFeeToken The token to pay for minting.
-    /// @param mintFeeRecipient The address to receive mint fees.
-    /// @param mintOpen The status of minting, whether it is open or not.
-    /// @param publicMinting True if the collection is open for everyone to mint.
+    /// @param _maxSupply The maximum supply of the collection.
+    /// @param _totalSupply The total minted supply of the collection.
+    /// @param _mintFee The fee to mint an NFT from the collection.
+    /// @param _mintFeeToken The token to pay for minting.
+    /// @param _mintFeeRecipient The address to receive mint fees.
+    /// @param _mintOpen The status of minting, whether it is open or not.
+    /// @param _publicMinting True if the collection is open for everyone to mint.
+    /// @param _baseURI The base URI for the collection. If baseURI is not empty, tokenURI will be
+    /// either baseURI + token ID (if nftMetadataURI is empty) or baseURI + nftMetadataURI.
     /// @custom:storage-location erc7201:story-protocol-periphery.SPGNFT
     struct SPGNFTStorage {
-        uint32 maxSupply;
-        uint32 totalSupply;
-        uint256 mintFee;
-        address mintFeeToken;
-        address mintFeeRecipient;
-        bool mintOpen;
-        bool publicMinting;
+        uint32 _maxSupply;
+        uint32 _totalSupply;
+        uint256 _mintFee;
+        address _mintFeeToken;
+        address _mintFeeRecipient;
+        bool _mintOpen;
+        bool _publicMinting;
+        string _baseURI;
     }
 
     // keccak256(abi.encode(uint256(keccak256("story-protocol-periphery.SPGNFT")) - 1)) & ~bytes32(uint256(0xff));
@@ -57,118 +60,117 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
         _disableInitializers();
     }
 
-    /// @dev Initializes the NFT collection.
+    /// @dev Initializes the SPGNFT collection.
     /// @dev If mint fee is non-zero, mint token must be set.
-    /// @param name The name of the collection.
-    /// @param symbol The symbol of the collection.
-    /// @param maxSupply The maximum supply of the collection.
-    /// @param mintFee The fee to mint an NFT from the collection.
-    /// @param mintFeeToken The token to pay for minting.
-    /// @param mintFeeRecipient The address to receive mint fees.
-    /// @param owner The owner of the collection. Zero address indicates no owner.
-    /// @param mintOpen Whether the collection is open for minting on creation. Configurable by the owner.
-    /// @param isPublicMinting If true, anyone can mint from the collection. If false, only the addresses with the
-    /// minter role can mint. Configurable by the owner.
+    /// @param initParams The initialization parameters for the collection. See {ISPGNFT-InitParams}
     function initialize(
-        string memory name,
-        string memory symbol,
-        uint32 maxSupply,
-        uint256 mintFee,
-        address mintFeeToken,
-        address mintFeeRecipient,
-        address owner,
-        bool mintOpen,
-        bool isPublicMinting
+        ISPGNFT.InitParams calldata initParams
     ) public initializer {
-        if (mintFee > 0 && mintFeeToken == address(0)) revert Errors.SPGNFT__ZeroAddressParam();
-        if (maxSupply == 0) revert Errors.SPGNFT__ZeroMaxSupply();
+        if (initParams.mintFee > 0 && initParams.mintFeeToken == address(0)) revert Errors.SPGNFT__ZeroAddressParam();
+        if (initParams.maxSupply == 0) revert Errors.SPGNFT__ZeroMaxSupply();
 
-        _grantRole(SPGNFTLib.ADMIN_ROLE, owner);
-        _grantRole(SPGNFTLib.MINTER_ROLE, owner);
+        _grantRole(SPGNFTLib.ADMIN_ROLE, initParams.owner);
+        _grantRole(SPGNFTLib.MINTER_ROLE, initParams.owner);
 
         // grant roles to SPG
-        if (owner != SPG_ADDRESS) {
+        if (initParams.owner != SPG_ADDRESS) {
             _grantRole(SPGNFTLib.ADMIN_ROLE, SPG_ADDRESS);
             _grantRole(SPGNFTLib.MINTER_ROLE, SPG_ADDRESS);
         }
 
         SPGNFTStorage storage $ = _getSPGNFTStorage();
-        $.maxSupply = maxSupply;
-        $.mintFee = mintFee;
-        $.mintFeeToken = mintFeeToken;
-        $.mintFeeRecipient = mintFeeRecipient;
-        $.mintOpen = mintOpen;
-        $.publicMinting = isPublicMinting;
+        $._maxSupply = initParams.maxSupply;
+        $._mintFee = initParams.mintFee;
+        $._mintFeeToken = initParams.mintFeeToken;
+        $._mintFeeRecipient = initParams.mintFeeRecipient;
+        $._mintOpen = initParams.mintOpen;
+        $._publicMinting = initParams.isPublicMinting;
+        $._baseURI = initParams.baseURI;
 
-        __ERC721_init(name, symbol);
+        __ERC721_init(initParams.name, initParams.symbol);
     }
 
     /// @notice Returns the total minted supply of the collection.
     function totalSupply() public view returns (uint256) {
-        return uint256(_getSPGNFTStorage().totalSupply);
+        return uint256(_getSPGNFTStorage()._totalSupply);
     }
 
     /// @notice Returns the current mint fee of the collection.
     function mintFee() public view returns (uint256) {
-        return _getSPGNFTStorage().mintFee;
+        return _getSPGNFTStorage()._mintFee;
     }
 
     /// @notice Returns the current mint token of the collection.
     function mintFeeToken() public view returns (address) {
-        return _getSPGNFTStorage().mintFeeToken;
+        return _getSPGNFTStorage()._mintFeeToken;
     }
 
     /// @notice Returns the current mint fee recipient of the collection.
     function mintFeeRecipient() public view returns (address) {
-        return _getSPGNFTStorage().mintFeeRecipient;
+        return _getSPGNFTStorage()._mintFeeRecipient;
     }
 
     /// @notice Returns true if the collection is open for minting.
     function mintOpen() public view returns (bool) {
-        return _getSPGNFTStorage().mintOpen;
+        return _getSPGNFTStorage()._mintOpen;
     }
 
     /// @notice Returns true if the collection is open for public minting.
     function publicMinting() public view returns (bool) {
-        return _getSPGNFTStorage().publicMinting;
+        return _getSPGNFTStorage()._publicMinting;
+    }
+
+    /// @notice Returns the base URI for the collection.
+    /// @dev If baseURI is not empty, tokenURI will be either or baseURI + nftMetadataURI
+    /// or baseURI + token ID (if nftMetadataURI is empty).
+    function baseURI() external view returns (string memory) {
+        return _baseURI();
     }
 
     /// @notice Sets the fee to mint an NFT from the collection. Payment is in the designated currency.
     /// @dev Only callable by the admin role.
     /// @param fee The new mint fee paid in the mint token.
     function setMintFee(uint256 fee) public onlyRole(SPGNFTLib.ADMIN_ROLE) {
-        _getSPGNFTStorage().mintFee = fee;
+        _getSPGNFTStorage()._mintFee = fee;
     }
 
     /// @notice Sets the mint token for the collection.
     /// @dev Only callable by the admin role.
     /// @param token The new mint token for mint payment.
     function setMintFeeToken(address token) public onlyRole(SPGNFTLib.ADMIN_ROLE) {
-        _getSPGNFTStorage().mintFeeToken = token;
+        _getSPGNFTStorage()._mintFeeToken = token;
     }
 
     /// @notice Sets the recipient of mint fees.
     /// @dev Only callable by the fee recipient.
     /// @param newFeeRecipient The new fee recipient.
     function setMintFeeRecipient(address newFeeRecipient) public {
-        if (msg.sender != _getSPGNFTStorage().mintFeeRecipient) {
+        if (msg.sender != _getSPGNFTStorage()._mintFeeRecipient) {
             revert Errors.SPGNFT__CallerNotFeeRecipient();
         }
-        _getSPGNFTStorage().mintFeeRecipient = newFeeRecipient;
+        _getSPGNFTStorage()._mintFeeRecipient = newFeeRecipient;
     }
 
     /// @notice Sets the minting status.
     /// @dev Only callable by the admin role.
     /// @param mintOpen Whether minting is open or not.
     function setMintOpen(bool mintOpen) public onlyRole(SPGNFTLib.ADMIN_ROLE) {
-        _getSPGNFTStorage().mintOpen = mintOpen;
+        _getSPGNFTStorage()._mintOpen = mintOpen;
     }
 
     /// @notice Sets the public minting status.
     /// @dev Only callable by the admin role.
     /// @param isPublicMinting Whether the collection is open for public minting or not.
     function setPublicMinting(bool isPublicMinting) public onlyRole(SPGNFTLib.ADMIN_ROLE) {
-        _getSPGNFTStorage().publicMinting = isPublicMinting;
+        _getSPGNFTStorage()._publicMinting = isPublicMinting;
+    }
+
+    /// @notice Sets the base URI for the collection. If baseURI is not empty, tokenURI will be
+    /// either baseURI + token ID (if nftMetadataURI is empty) or baseURI + nftMetadataURI.
+    /// @dev Only callable by the admin role.
+    /// @param baseURI The new base URI for the collection.
+    function setBaseURI(string memory baseURI) public onlyRole(SPGNFTLib.ADMIN_ROLE) {
+        _getSPGNFTStorage()._baseURI = baseURI;
     }
 
     /// @notice Mints an NFT from the collection. Only callable by the minter role.
@@ -176,7 +178,7 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
     /// @param nftMetadataURI OPTIONAL. The URI of the desired metadata for the newly minted NFT.
     /// @return tokenId The ID of the minted NFT.
     function mint(address to, string calldata nftMetadataURI) public virtual returns (uint256 tokenId) {
-        if (!_getSPGNFTStorage().publicMinting && !hasRole(SPGNFTLib.MINTER_ROLE, msg.sender)) {
+        if (!_getSPGNFTStorage()._publicMinting && !hasRole(SPGNFTLib.MINTER_ROLE, msg.sender)) {
             revert Errors.SPGNFT__MintingDenied();
         }
         tokenId = _mintToken({ to: to, payer: msg.sender, nftMetadataURI: nftMetadataURI });
@@ -198,7 +200,7 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
     /// @dev Withdraws the contract's token balance to the fee recipient.
     /// @param token The token to withdraw.
     function withdrawToken(address token) public {
-        IERC20(token).transfer(_getSPGNFTStorage().mintFeeRecipient, IERC20(token).balanceOf(address(this)));
+        IERC20(token).transfer(_getSPGNFTStorage()._mintFeeRecipient, IERC20(token).balanceOf(address(this)));
     }
 
     /// @dev Supports ERC165 interface.
@@ -216,17 +218,25 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
     /// @return tokenId The ID of the minted NFT.
     function _mintToken(address to, address payer, string calldata nftMetadataURI) internal returns (uint256 tokenId) {
         SPGNFTStorage storage $ = _getSPGNFTStorage();
-        if (!$.mintOpen) revert Errors.SPGNFT__MintingClosed();
-        if ($.totalSupply + 1 > $.maxSupply) revert Errors.SPGNFT__MaxSupplyReached();
+        if (!$._mintOpen) revert Errors.SPGNFT__MintingClosed();
+        if ($._totalSupply + 1 > $._maxSupply) revert Errors.SPGNFT__MaxSupplyReached();
 
-        if ($.mintFeeToken != address(0) && $.mintFee > 0) {
-            IERC20($.mintFeeToken).transferFrom(payer, address(this), $.mintFee);
+        if ($._mintFeeToken != address(0) && $._mintFee > 0) {
+            IERC20($._mintFeeToken).transferFrom(payer, address(this), $._mintFee);
         }
 
-        tokenId = ++$.totalSupply;
+        tokenId = ++$._totalSupply;
         _mint(to, tokenId);
 
         if (bytes(nftMetadataURI).length > 0) _setTokenURI(tokenId, nftMetadataURI);
+    }
+
+    /// @dev Base URI for computing tokenURI.
+    /// @dev If baseURI is not empty, tokenURI will be either or baseURI + nftMetadataURI
+    /// or baseURI + token ID (if nftMetadataURI is empty).
+    /// @return baseURI The base URI for the collection.
+    function _baseURI() internal view override returns (string memory) {
+        return _getSPGNFTStorage()._baseURI;
     }
 
     //

--- a/contracts/SPGNFT.sol
+++ b/contracts/SPGNFT.sol
@@ -63,9 +63,7 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
     /// @dev Initializes the SPGNFT collection.
     /// @dev If mint fee is non-zero, mint token must be set.
     /// @param initParams The initialization parameters for the collection. See {ISPGNFT-InitParams}
-    function initialize(
-        ISPGNFT.InitParams calldata initParams
-    ) public initializer {
+    function initialize(ISPGNFT.InitParams calldata initParams) public initializer {
         if (initParams.mintFee > 0 && initParams.mintFeeToken == address(0)) revert Errors.SPGNFT__ZeroAddressParam();
         if (initParams.maxSupply == 0) revert Errors.SPGNFT__ZeroMaxSupply();
 

--- a/contracts/StoryProtocolGateway.sol
+++ b/contracts/StoryProtocolGateway.sol
@@ -115,42 +115,15 @@ contract StoryProtocolGateway is
         UpgradeableBeacon(_getSPGStorage().nftContractBeacon).upgradeTo(newNftContract);
     }
 
-    /// @notice Creates a new NFT collection to be used by SPG.
-    /// @param name The name of the collection.
-    /// @param symbol The symbol of the collection.
-    /// @param maxSupply The maximum supply of the collection.
-    /// @param mintFee The cost to mint an NFT from the collection.
-    /// @param mintFeeToken The token to be used for mint payment.
-    /// @param mintFeeRecipient The address to receive mint fees.
-    /// @param owner The owner of the collection. Zero address indicates no owner.
-    /// @param mintOpen Whether the collection is open for minting on creation. Configurable by the owner.
-    /// @param isPublicMinting If true, anyone can mint from the collection. If false, only the addresses with the
-    /// minter role can mint. Configurable by the owner.
-    /// @return nftContract The address of the newly created NFT collection.
+    /// @notice Creates a new SPGNFT collection to be used by SPG.
+    /// @param spgNftInitParams The initialization parameters for the SPGNFT collection. See {ISPGNFT-InitParams}.
+    /// @return spgNftContract The address of the newly created SPGNFT collection.
     function createCollection(
-        string calldata name,
-        string calldata symbol,
-        uint32 maxSupply,
-        uint256 mintFee,
-        address mintFeeToken,
-        address mintFeeRecipient,
-        address owner,
-        bool mintOpen,
-        bool isPublicMinting
-    ) external returns (address nftContract) {
-        nftContract = address(new BeaconProxy(_getSPGStorage().nftContractBeacon, ""));
-        ISPGNFT(nftContract).initialize(
-            name,
-            symbol,
-            maxSupply,
-            mintFee,
-            mintFeeToken,
-            mintFeeRecipient,
-            owner,
-            mintOpen,
-            isPublicMinting
-        );
-        emit CollectionCreated(nftContract);
+        ISPGNFT.InitParams calldata spgNftInitParams
+    ) external returns (address spgNftContract) {
+        spgNftContract = address(new BeaconProxy(_getSPGStorage().nftContractBeacon, ""));
+        ISPGNFT(spgNftContract).initialize(spgNftInitParams);
+        emit CollectionCreated(spgNftContract);
     }
 
     /// @notice Mint an NFT from a SPGNFT collection and register it with metadata as an IP.

--- a/contracts/StoryProtocolGateway.sol
+++ b/contracts/StoryProtocolGateway.sol
@@ -118,9 +118,7 @@ contract StoryProtocolGateway is
     /// @notice Creates a new SPGNFT collection to be used by SPG.
     /// @param spgNftInitParams The initialization parameters for the SPGNFT collection. See {ISPGNFT-InitParams}.
     /// @return spgNftContract The address of the newly created SPGNFT collection.
-    function createCollection(
-        ISPGNFT.InitParams calldata spgNftInitParams
-    ) external returns (address spgNftContract) {
+    function createCollection(ISPGNFT.InitParams calldata spgNftInitParams) external returns (address spgNftContract) {
         spgNftContract = address(new BeaconProxy(_getSPGStorage().nftContractBeacon, ""));
         ISPGNFT(spgNftContract).initialize(spgNftInitParams);
         emit CollectionCreated(spgNftContract);

--- a/contracts/interfaces/ISPGNFT.sol
+++ b/contracts/interfaces/ISPGNFT.sol
@@ -36,9 +36,7 @@ interface ISPGNFT is IAccessControl, IERC721, IERC721Metadata {
     /// @dev Initializes the NFT collection.
     /// @dev If mint fee is non-zero, mint token must be set.
     /// @param params The initialization parameters. See `InitParams`.
-    function initialize(
-        InitParams calldata params
-    ) external;
+    function initialize(InitParams calldata params) external;
 
     /// @notice Returns the total minted supply of the collection.
     function totalSupply() external view returns (uint256);

--- a/contracts/interfaces/ISPGNFT.sol
+++ b/contracts/interfaces/ISPGNFT.sol
@@ -6,10 +6,12 @@ import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import { IERC721Metadata } from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
 
 interface ISPGNFT is IAccessControl, IERC721, IERC721Metadata {
-    /// @dev Initializes the NFT collection.
+    /// @notice Struct for initializing the NFT collection.
     /// @dev If mint fee is non-zero, mint token must be set.
     /// @param name The name of the collection.
     /// @param symbol The symbol of the collection.
+    /// @param baseURI The base URI for the collection. If baseURI is not empty, tokenURI will be
+    /// either baseURI + token ID (if nftMetadataURI is empty) or baseURI + nftMetadataURI.
     /// @param maxSupply The maximum supply of the collection.
     /// @param mintFee The fee to mint an NFT from the collection.
     /// @param mintFeeToken The token to pay for minting.
@@ -18,16 +20,24 @@ interface ISPGNFT is IAccessControl, IERC721, IERC721Metadata {
     /// @param mintOpen Whether the collection is open for minting on creation. Configurable by the owner.
     /// @param isPublicMinting If true, anyone can mint from the collection. If false, only the addresses with the
     /// minter role can mint. Configurable by the owner.
+    struct InitParams {
+        string name;
+        string symbol;
+        string baseURI;
+        uint32 maxSupply;
+        uint256 mintFee;
+        address mintFeeToken;
+        address mintFeeRecipient;
+        address owner;
+        bool mintOpen;
+        bool isPublicMinting;
+    }
+
+    /// @dev Initializes the NFT collection.
+    /// @dev If mint fee is non-zero, mint token must be set.
+    /// @param params The initialization parameters. See `InitParams`.
     function initialize(
-        string memory name,
-        string memory symbol,
-        uint32 maxSupply,
-        uint256 mintFee,
-        address mintFeeToken,
-        address mintFeeRecipient,
-        address owner,
-        bool mintOpen,
-        bool isPublicMinting
+        InitParams calldata params
     ) external;
 
     /// @notice Returns the total minted supply of the collection.
@@ -47,6 +57,11 @@ interface ISPGNFT is IAccessControl, IERC721, IERC721Metadata {
 
     /// @notice Returns true if the collection is open for public minting.
     function publicMinting() external view returns (bool);
+
+    /// @notice Returns the base URI for the collection.
+    /// @dev If baseURI is not empty, tokenURI will be either or baseURI + nftMetadataURI
+    /// or baseURI + token ID (if nftMetadataURI is empty).
+    function baseURI() external view returns (string memory);
 
     /// @notice Sets the fee to mint an NFT from the collection. Payment is in the designated currency.
     /// @dev Only callable by the admin role.
@@ -72,6 +87,12 @@ interface ISPGNFT is IAccessControl, IERC721, IERC721Metadata {
     /// @dev Only callable by the admin role.
     /// @param isPublicMinting Whether the collection is open for public minting or not.
     function setPublicMinting(bool isPublicMinting) external;
+
+    /// @notice Sets the base URI for the collection. If baseURI is not empty, tokenURI will be
+    /// either baseURI + token ID (if nftMetadataURI is empty) or baseURI + nftMetadataURI.
+    /// @dev Only callable by the admin role.
+    /// @param baseURI The new base URI for the collection.
+    function setBaseURI(string memory baseURI) external;
 
     /// @notice Mints an NFT from the collection. Only callable by the minter role.
     /// @param to The address of the recipient of the minted NFT.

--- a/contracts/interfaces/IStoryProtocolGateway.sol
+++ b/contracts/interfaces/IStoryProtocolGateway.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.23;
 
 import { PILTerms } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
+import { ISPGNFT } from "./ISPGNFT.sol";
 
 /// @title Story Protocol Gateway Interface
 interface IStoryProtocolGateway {
@@ -45,28 +46,11 @@ interface IStoryProtocolGateway {
     }
 
     /// @notice Creates a new NFT collection to be used by SPG.
-    /// @param name The name of the collection.
-    /// @param symbol The symbol of the collection.
-    /// @param maxSupply The maximum supply of the collection.
-    /// @param mintFee The cost to mint an NFT from the collection.
-    /// @param mintFeeToken The token to be used for mint payment.
-    /// @param mintFeeRecipient The address to receive mint fees.
-    /// @param owner The owner of the collection. Zero address indicates no owner.
-    /// @param mintOpen Whether the collection is open for minting on creation. Configurable by the owner.
-    /// @param isPublicMinting If true, anyone can mint from the collection. If false, only the addresses with the
-    /// minter role can mint. Configurable by the owner.
-    /// @return nftContract The address of the newly created NFT collection.
+    /// @param spgNftInitParams The init params for the SPGNFT collection. See {ISPGNFT-InitParams}.
+    /// @return spgNftContract The address of the newly created SPGNFT collection.
     function createCollection(
-        string calldata name,
-        string calldata symbol,
-        uint32 maxSupply,
-        uint256 mintFee,
-        address mintFeeToken,
-        address mintFeeRecipient,
-        address owner,
-        bool mintOpen,
-        bool isPublicMinting
-    ) external returns (address nftContract);
+        ISPGNFT.InitParams calldata spgNftInitParams
+    ) external returns (address spgNftContract);
 
     /// @notice Mint an NFT from a SPGNFT collection and register it with metadata as an IP.
     /// @dev Caller must have the minter role for the provided SPG NFT.

--- a/contracts/interfaces/IStoryProtocolGateway.sol
+++ b/contracts/interfaces/IStoryProtocolGateway.sol
@@ -48,9 +48,7 @@ interface IStoryProtocolGateway {
     /// @notice Creates a new NFT collection to be used by SPG.
     /// @param spgNftInitParams The init params for the SPGNFT collection. See {ISPGNFT-InitParams}.
     /// @return spgNftContract The address of the newly created SPGNFT collection.
-    function createCollection(
-        ISPGNFT.InitParams calldata spgNftInitParams
-    ) external returns (address spgNftContract);
+    function createCollection(ISPGNFT.InitParams calldata spgNftInitParams) external returns (address spgNftContract);
 
     /// @notice Mint an NFT from a SPGNFT collection and register it with metadata as an IP.
     /// @dev Caller must have the minter role for the provided SPG NFT.

--- a/test/GroupingWorkflows.t.sol
+++ b/test/GroupingWorkflows.t.sol
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
-import { BaseTest } from "./utils/BaseTest.t.sol";
-
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
 import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
 import { IGroupingModule } from "@storyprotocol/core/interfaces/modules/grouping/IGroupingModule.sol";
@@ -10,7 +9,11 @@ import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensi
 
 import { IStoryProtocolGateway as ISPG } from "../contracts/interfaces/IStoryProtocolGateway.sol";
 
+import { BaseTest } from "./utils/BaseTest.t.sol";
+
 contract GroupingWorkflowsTest is BaseTest {
+    using Strings for uint256;
+
     address internal groupId;
 
     function setUp() public override {
@@ -83,7 +86,7 @@ contract GroupingWorkflowsTest is BaseTest {
         assertTrue(ipAssetRegistry.containsIp(groupId, ipId));
         assertEq(ipAssetRegistry.totalMembers(groupId), 1);
         assertEq(tokenId, 1);
-        assertSPGNFTMetadata(tokenId, ipMetadataEmpty.nftMetadataURI);
+        assertSPGNFTMetadata(tokenId, string.concat(testBaseURI, tokenId.toString()));
         assertMetadata(ipId, ipMetadataEmpty);
         (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId, 0);
         assertEq(licenseTemplate, address(pilTemplate));
@@ -140,7 +143,7 @@ contract GroupingWorkflowsTest is BaseTest {
         assertTrue(ipAssetRegistry.isRegisteredGroup(groupId));
         assertTrue(ipAssetRegistry.containsIp(groupId, expectedIpId));
         assertEq(ipAssetRegistry.totalMembers(groupId), 1);
-        assertSPGNFTMetadata(tokenId, ipMetadataEmpty.nftMetadataURI);
+        assertSPGNFTMetadata(tokenId, string.concat(testBaseURI, tokenId.toString()));
         assertMetadata(expectedIpId, ipMetadataEmpty);
         (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(expectedIpId, 0);
         assertEq(licenseTemplate, address(pilTemplate));

--- a/test/SPGNFT.t.sol
+++ b/test/SPGNFT.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { BeaconProxy } from "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
 import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/UpgradeableBeacon.sol";
 import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
@@ -14,6 +15,8 @@ import { Errors } from "../contracts/lib/Errors.sol";
 import { BaseTest } from "./utils/BaseTest.t.sol";
 
 contract SPGNFTTest is BaseTest {
+    using Strings for uint256;
+
     string internal nftMetadataEmpty;
     string internal nftMetadataDefault;
 
@@ -23,9 +26,10 @@ contract SPGNFTTest is BaseTest {
         feeRecipient = address(0xbeef);
 
         nftContract = ISPGNFT(
-            spg.createCollection({
+            spg.createCollection(ISPGNFT.InitParams({
                 name: "Test Collection",
                 symbol: "TEST",
+                baseURI: testBaseURI,
                 maxSupply: 100,
                 mintFee: 100 * 10 ** mockToken.decimals(),
                 mintFeeToken: address(mockToken),
@@ -33,7 +37,7 @@ contract SPGNFTTest is BaseTest {
                 owner: alice,
                 mintOpen: true,
                 isPublicMinting: false
-            })
+            }))
         );
 
         nftMetadataEmpty = "";
@@ -45,9 +49,10 @@ contract SPGNFTTest is BaseTest {
         address NFT_CONTRACT_BEACON = address(new UpgradeableBeacon(spgNftImpl, deployer));
         ISPGNFT anotherNftContract = ISPGNFT(address(new BeaconProxy(NFT_CONTRACT_BEACON, "")));
 
-        anotherNftContract.initialize({
+        anotherNftContract.initialize(ISPGNFT.InitParams({
             name: "Test Collection",
             symbol: "TEST",
+            baseURI: testBaseURI,
             maxSupply: 100,
             mintFee: 100 * 10 ** mockToken.decimals(),
             mintFeeToken: address(mockToken),
@@ -55,7 +60,7 @@ contract SPGNFTTest is BaseTest {
             owner: alice,
             mintOpen: true,
             isPublicMinting: false
-        });
+        }));
 
         assertEq(nftContract.name(), anotherNftContract.name());
         assertEq(nftContract.symbol(), anotherNftContract.symbol());
@@ -74,9 +79,10 @@ contract SPGNFTTest is BaseTest {
         nftContract = ISPGNFT(address(new BeaconProxy(NFT_CONTRACT_BEACON, "")));
 
         vm.expectRevert(Errors.SPGNFT__ZeroAddressParam.selector);
-        nftContract.initialize({
+        nftContract.initialize(ISPGNFT.InitParams({
             name: "Test Collection",
             symbol: "TEST",
+            baseURI: testBaseURI,
             maxSupply: 100,
             mintFee: 1,
             mintFeeToken: address(0),
@@ -84,12 +90,13 @@ contract SPGNFTTest is BaseTest {
             owner: alice,
             mintOpen: true,
             isPublicMinting: false
-        });
+        }));
 
         vm.expectRevert(Errors.SPGNFT__ZeroMaxSupply.selector);
-        nftContract.initialize({
+        nftContract.initialize(ISPGNFT.InitParams({
             name: "Test Collection",
             symbol: "TEST",
+            baseURI: testBaseURI,
             maxSupply: 0,
             mintFee: 0,
             mintFeeToken: address(mockToken),
@@ -97,7 +104,7 @@ contract SPGNFTTest is BaseTest {
             owner: alice,
             mintOpen: true,
             isPublicMinting: false
-        });
+        }));
     }
 
     function test_SPGNFT_mint() public {
@@ -116,7 +123,7 @@ contract SPGNFTTest is BaseTest {
         assertEq(nftContract.ownerOf(tokenId), bob);
         assertEq(mockToken.balanceOf(alice), balanceBeforeAlice - mintFee);
         assertEq(mockToken.balanceOf(address(nftContract)), balanceBeforeContract + mintFee);
-        assertSPGNFTMetadata(tokenId, nftMetadataEmpty);
+        assertSPGNFTMetadata(tokenId, string.concat(testBaseURI, tokenId.toString()));
         balanceBeforeAlice = mockToken.balanceOf(alice);
         balanceBeforeContract = mockToken.balanceOf(address(nftContract));
 
@@ -126,7 +133,7 @@ contract SPGNFTTest is BaseTest {
         assertEq(nftContract.ownerOf(tokenId), bob);
         assertEq(mockToken.balanceOf(alice), balanceBeforeAlice - mintFee);
         assertEq(mockToken.balanceOf(address(nftContract)), balanceBeforeContract + mintFee);
-        assertSPGNFTMetadata(tokenId, nftMetadataDefault);
+        assertSPGNFTMetadata(tokenId, string.concat(testBaseURI, nftMetadataDefault));
         balanceBeforeAlice = mockToken.balanceOf(alice);
         balanceBeforeContract = mockToken.balanceOf(address(nftContract));
 
@@ -141,7 +148,7 @@ contract SPGNFTTest is BaseTest {
         assertEq(nftContract.ownerOf(tokenId), cal);
         assertEq(mockToken.balanceOf(alice), balanceBeforeAlice - mintFee);
         assertEq(mockToken.balanceOf(address(nftContract)), balanceBeforeContract + mintFee);
-        assertSPGNFTMetadata(tokenId, nftMetadataDefault);
+        assertSPGNFTMetadata(tokenId, string.concat(testBaseURI, nftMetadataDefault));
 
         vm.stopPrank();
     }
@@ -193,6 +200,33 @@ contract SPGNFTTest is BaseTest {
 
         nftContract.setMintFeeToken(address(mockToken));
         assertEq(nftContract.mintFeeToken(), address(mockToken));
+
+        vm.stopPrank();
+    }
+
+    function test_SPGNFT_setBaseURI() public {
+        vm.startPrank(alice);
+        mockToken.mint(address(alice), 1000 * 10 ** mockToken.decimals());
+        mockToken.approve(address(nftContract), 1000 * 10 ** mockToken.decimals());
+
+        // non empty baseURI
+        assertEq(nftContract.baseURI(), testBaseURI);
+        uint256 tokenId1 = nftContract.mint(alice, nftMetadataDefault);
+        assertEq(nftContract.tokenURI(tokenId1), string.concat(testBaseURI, nftMetadataDefault));
+
+        nftContract.setBaseURI("test");
+        assertEq(nftContract.baseURI(), "test");
+        uint256 tokenId2 = nftContract.mint(alice, nftMetadataEmpty);
+        assertEq(nftContract.tokenURI(tokenId1), string.concat("test", nftMetadataDefault));
+        assertEq(nftContract.tokenURI(tokenId2), string.concat("test", tokenId2.toString()));
+
+        // empty baseURI
+        nftContract.setBaseURI("");
+        assertEq(nftContract.baseURI(), "");
+        uint256 tokenId3 = nftContract.mint(alice, nftMetadataDefault);
+        assertEq(nftContract.tokenURI(tokenId1), nftMetadataDefault);
+        assertEq(nftContract.tokenURI(tokenId2), nftMetadataEmpty);
+        assertEq(nftContract.tokenURI(tokenId3), nftMetadataDefault);
 
         vm.stopPrank();
     }

--- a/test/SPGNFT.t.sol
+++ b/test/SPGNFT.t.sol
@@ -26,18 +26,20 @@ contract SPGNFTTest is BaseTest {
         feeRecipient = address(0xbeef);
 
         nftContract = ISPGNFT(
-            spg.createCollection(ISPGNFT.InitParams({
-                name: "Test Collection",
-                symbol: "TEST",
-                baseURI: testBaseURI,
-                maxSupply: 100,
-                mintFee: 100 * 10 ** mockToken.decimals(),
-                mintFeeToken: address(mockToken),
-                mintFeeRecipient: alice,
-                owner: alice,
-                mintOpen: true,
-                isPublicMinting: false
-            }))
+            spg.createCollection(
+                ISPGNFT.InitParams({
+                    name: "Test Collection",
+                    symbol: "TEST",
+                    baseURI: testBaseURI,
+                    maxSupply: 100,
+                    mintFee: 100 * 10 ** mockToken.decimals(),
+                    mintFeeToken: address(mockToken),
+                    mintFeeRecipient: alice,
+                    owner: alice,
+                    mintOpen: true,
+                    isPublicMinting: false
+                })
+            )
         );
 
         nftMetadataEmpty = "";
@@ -49,18 +51,20 @@ contract SPGNFTTest is BaseTest {
         address NFT_CONTRACT_BEACON = address(new UpgradeableBeacon(spgNftImpl, deployer));
         ISPGNFT anotherNftContract = ISPGNFT(address(new BeaconProxy(NFT_CONTRACT_BEACON, "")));
 
-        anotherNftContract.initialize(ISPGNFT.InitParams({
-            name: "Test Collection",
-            symbol: "TEST",
-            baseURI: testBaseURI,
-            maxSupply: 100,
-            mintFee: 100 * 10 ** mockToken.decimals(),
-            mintFeeToken: address(mockToken),
-            mintFeeRecipient: feeRecipient,
-            owner: alice,
-            mintOpen: true,
-            isPublicMinting: false
-        }));
+        anotherNftContract.initialize(
+            ISPGNFT.InitParams({
+                name: "Test Collection",
+                symbol: "TEST",
+                baseURI: testBaseURI,
+                maxSupply: 100,
+                mintFee: 100 * 10 ** mockToken.decimals(),
+                mintFeeToken: address(mockToken),
+                mintFeeRecipient: feeRecipient,
+                owner: alice,
+                mintOpen: true,
+                isPublicMinting: false
+            })
+        );
 
         assertEq(nftContract.name(), anotherNftContract.name());
         assertEq(nftContract.symbol(), anotherNftContract.symbol());
@@ -79,32 +83,36 @@ contract SPGNFTTest is BaseTest {
         nftContract = ISPGNFT(address(new BeaconProxy(NFT_CONTRACT_BEACON, "")));
 
         vm.expectRevert(Errors.SPGNFT__ZeroAddressParam.selector);
-        nftContract.initialize(ISPGNFT.InitParams({
-            name: "Test Collection",
-            symbol: "TEST",
-            baseURI: testBaseURI,
-            maxSupply: 100,
-            mintFee: 1,
-            mintFeeToken: address(0),
-            mintFeeRecipient: feeRecipient,
-            owner: alice,
-            mintOpen: true,
-            isPublicMinting: false
-        }));
+        nftContract.initialize(
+            ISPGNFT.InitParams({
+                name: "Test Collection",
+                symbol: "TEST",
+                baseURI: testBaseURI,
+                maxSupply: 100,
+                mintFee: 1,
+                mintFeeToken: address(0),
+                mintFeeRecipient: feeRecipient,
+                owner: alice,
+                mintOpen: true,
+                isPublicMinting: false
+            })
+        );
 
         vm.expectRevert(Errors.SPGNFT__ZeroMaxSupply.selector);
-        nftContract.initialize(ISPGNFT.InitParams({
-            name: "Test Collection",
-            symbol: "TEST",
-            baseURI: testBaseURI,
-            maxSupply: 0,
-            mintFee: 0,
-            mintFeeToken: address(mockToken),
-            mintFeeRecipient: feeRecipient,
-            owner: alice,
-            mintOpen: true,
-            isPublicMinting: false
-        }));
+        nftContract.initialize(
+            ISPGNFT.InitParams({
+                name: "Test Collection",
+                symbol: "TEST",
+                baseURI: testBaseURI,
+                maxSupply: 0,
+                mintFee: 0,
+                mintFeeToken: address(mockToken),
+                mintFeeRecipient: feeRecipient,
+                owner: alice,
+                mintOpen: true,
+                isPublicMinting: false
+            })
+        );
     }
 
     function test_SPGNFT_mint() public {

--- a/test/StoryProtocolGateway.t.sol
+++ b/test/StoryProtocolGateway.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
 import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
 import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingModule.sol";
@@ -15,6 +16,8 @@ import { BaseTest } from "./utils/BaseTest.t.sol";
 import { MockERC721 } from "./mocks/MockERC721.sol";
 
 contract StoryProtocolGatewayTest is BaseTest {
+    using Strings for uint256;
+
     struct IPAsset {
         address payable ipId;
         uint256 tokenId;
@@ -45,9 +48,10 @@ contract StoryProtocolGatewayTest is BaseTest {
     function test_SPG_revert_mintAndRegisterIp_callerNotAuthorizedToMint() public {
         vm.prank(alice); // minter and admin of nftContract
         nftContract = ISPGNFT(
-            spg.createCollection({
+            spg.createCollection(ISPGNFT.InitParams({
                 name: "Test Private Collection",
                 symbol: "TESTPRIV",
+                baseURI: testBaseURI,
                 maxSupply: 100,
                 mintFee: 100 * 10 ** mockToken.decimals(),
                 mintFeeToken: address(mockToken),
@@ -55,7 +59,7 @@ contract StoryProtocolGatewayTest is BaseTest {
                 owner: minter,
                 mintOpen: true,
                 isPublicMinting: false // not public minting
-            })
+            }))
         );
 
         vm.expectRevert(Errors.SPG__CallerNotAuthorizedToMint.selector);
@@ -66,9 +70,10 @@ contract StoryProtocolGatewayTest is BaseTest {
     function test_SPG_mintAndRegisterIp_publicMint() public {
         vm.prank(alice); // minter and admin of nftContract
         nftContract = ISPGNFT(
-            spg.createCollection({
+            spg.createCollection(ISPGNFT.InitParams({
                 name: "Test Public Collection",
                 symbol: "TESTPUB",
+                baseURI: testBaseURI,
                 maxSupply: 100,
                 mintFee: 1 * 10 ** mockToken.decimals(),
                 mintFeeToken: address(mockToken),
@@ -76,7 +81,7 @@ contract StoryProtocolGatewayTest is BaseTest {
                 owner: minter,
                 mintOpen: true,
                 isPublicMinting: true // public minting is enabled
-            })
+            }))
         );
 
         vm.startPrank(bob); // caller does not have minter role
@@ -93,7 +98,7 @@ contract StoryProtocolGatewayTest is BaseTest {
 
         assertTrue(ipAssetRegistry.isRegistered(ipId));
         assertEq(tokenId, 1);
-        assertSPGNFTMetadata(tokenId, ipMetadataEmpty.nftMetadataURI);
+        assertSPGNFTMetadata(tokenId, string.concat(testBaseURI, tokenId.toString()));
         assertMetadata(ipId, ipMetadataEmpty);
     }
 
@@ -108,7 +113,7 @@ contract StoryProtocolGatewayTest is BaseTest {
         });
         assertEq(tokenId1, 1);
         assertTrue(ipAssetRegistry.isRegistered(ipId1));
-        assertSPGNFTMetadata(tokenId1, ipMetadataEmpty.nftMetadataURI);
+        assertSPGNFTMetadata(tokenId1, string.concat(testBaseURI, tokenId1.toString()));
         assertMetadata(ipId1, ipMetadataEmpty);
 
         (address ipId2, uint256 tokenId2) = spg.mintAndRegisterIp({
@@ -118,7 +123,7 @@ contract StoryProtocolGatewayTest is BaseTest {
         });
         assertEq(tokenId2, 2);
         assertTrue(ipAssetRegistry.isRegistered(ipId2));
-        assertSPGNFTMetadata(tokenId2, ipMetadataDefault.nftMetadataURI);
+        assertSPGNFTMetadata(tokenId2, string.concat(testBaseURI, ipMetadataDefault.nftMetadataURI));
         assertMetadata(ipId2, ipMetadataDefault);
     }
 
@@ -215,7 +220,7 @@ contract StoryProtocolGatewayTest is BaseTest {
         assertTrue(ipAssetRegistry.isRegistered(ipId1));
         assertEq(tokenId1, 1);
         assertEq(licenseTermsId1, 1);
-        assertSPGNFTMetadata(tokenId1, ipMetadataEmpty.nftMetadataURI);
+        assertSPGNFTMetadata(tokenId1, string.concat(testBaseURI, tokenId1.toString()));
         assertMetadata(ipId1, ipMetadataEmpty);
         (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId1, 0);
         assertEq(licenseTemplate, address(pilTemplate));
@@ -230,7 +235,7 @@ contract StoryProtocolGatewayTest is BaseTest {
         assertTrue(ipAssetRegistry.isRegistered(ipId2));
         assertEq(tokenId2, 2);
         assertEq(licenseTermsId1, licenseTermsId2);
-        assertSPGNFTMetadata(tokenId2, ipMetadataDefault.nftMetadataURI);
+        assertSPGNFTMetadata(tokenId2, string.concat(testBaseURI, ipMetadataDefault.nftMetadataURI));
         assertMetadata(ipId2, ipMetadataDefault);
     }
 
@@ -370,7 +375,7 @@ contract StoryProtocolGatewayTest is BaseTest {
         });
         assertTrue(ipAssetRegistry.isRegistered(ipIdChild));
         assertEq(tokenIdChild, 2);
-        assertSPGNFTMetadata(tokenIdChild, ipMetadataDefault.nftMetadataURI);
+        assertSPGNFTMetadata(tokenIdChild, string.concat(testBaseURI, ipMetadataDefault.nftMetadataURI));
         assertMetadata(ipIdChild, ipMetadataDefault);
         (address licenseTemplateChild, uint256 licenseTermsIdChild) = licenseRegistry.getAttachedLicenseTerms(
             ipIdChild,
@@ -473,16 +478,18 @@ contract StoryProtocolGatewayTest is BaseTest {
         for (uint256 i = 0; i < 10; i++) {
             data[i] = abi.encodeWithSelector(
                 spg.createCollection.selector,
-                "Test Collection",
-                "TEST",
-                100,
-                100 * 10 ** mockToken.decimals(),
-                address(mockToken),
-                feeRecipient,
-                minter,
-                true,
-                false
-            );
+                ISPGNFT.InitParams({
+                name: "Test Collection",
+                symbol: "TEST",
+                baseURI: testBaseURI,
+                maxSupply: 100,
+                mintFee: 100 * 10 ** mockToken.decimals(),
+                mintFeeToken: address(mockToken),
+                mintFeeRecipient: feeRecipient,
+                owner: minter,
+                mintOpen: true,
+                isPublicMinting: false
+            }));
         }
 
         bytes[] memory results = spg.multicall(data);
@@ -523,7 +530,7 @@ contract StoryProtocolGatewayTest is BaseTest {
         for (uint256 i = 0; i < 10; i++) {
             (ipIds[i], tokenIds[i]) = abi.decode(results[i], (address, uint256));
             assertTrue(ipAssetRegistry.isRegistered(ipIds[i]));
-            assertSPGNFTMetadata(tokenIds[i], ipMetadataDefault.nftMetadataURI);
+            assertSPGNFTMetadata(tokenIds[i], string.concat(testBaseURI, ipMetadataDefault.nftMetadataURI));
             assertMetadata(ipIds[i], ipMetadataDefault);
         }
     }
@@ -567,7 +574,7 @@ contract StoryProtocolGatewayTest is BaseTest {
             (address ipIdChild, uint256 tokenIdChild) = abi.decode(results[i], (address, uint256));
             assertTrue(ipAssetRegistry.isRegistered(ipIdChild));
             assertEq(tokenIdChild, i + 2);
-            assertSPGNFTMetadata(tokenIdChild, ipMetadataDefault.nftMetadataURI);
+            assertSPGNFTMetadata(tokenIdChild, string.concat(testBaseURI, ipMetadataDefault.nftMetadataURI));
             assertMetadata(ipIdChild, ipMetadataDefault);
             (address licenseTemplateChild, uint256 licenseTermsIdChild) = licenseRegistry.getAttachedLicenseTerms(
                 ipIdChild,
@@ -624,7 +631,7 @@ contract StoryProtocolGatewayTest is BaseTest {
         });
         assertTrue(ipAssetRegistry.isRegistered(ipIdChild));
         assertEq(tokenIdChild, 2);
-        assertSPGNFTMetadata(tokenIdChild, ipMetadataDefault.nftMetadataURI);
+        assertSPGNFTMetadata(tokenIdChild, string.concat(testBaseURI, ipMetadataDefault.nftMetadataURI));
         assertMetadata(ipIdChild, ipMetadataDefault);
         (address licenseTemplateChild, uint256 licenseTermsIdChild) = licenseRegistry.getAttachedLicenseTerms(
             ipIdChild,
@@ -693,7 +700,7 @@ contract StoryProtocolGatewayTest is BaseTest {
         });
         assertEq(ipIdChildActual, ipIdChild);
         assertTrue(ipAssetRegistry.isRegistered(ipIdChild));
-        assertSPGNFTMetadata(tokenIdChild, ipMetadataEmpty.nftMetadataURI);
+        assertSPGNFTMetadata(tokenIdChild, string.concat(testBaseURI, tokenIdChild.toString()));
         assertMetadata(ipIdChild, ipMetadataDefault);
         (address licenseTemplateChild, uint256 licenseTermsIdChild) = licenseRegistry.getAttachedLicenseTerms(
             ipIdChild,

--- a/test/StoryProtocolGateway.t.sol
+++ b/test/StoryProtocolGateway.t.sol
@@ -48,18 +48,20 @@ contract StoryProtocolGatewayTest is BaseTest {
     function test_SPG_revert_mintAndRegisterIp_callerNotAuthorizedToMint() public {
         vm.prank(alice); // minter and admin of nftContract
         nftContract = ISPGNFT(
-            spg.createCollection(ISPGNFT.InitParams({
-                name: "Test Private Collection",
-                symbol: "TESTPRIV",
-                baseURI: testBaseURI,
-                maxSupply: 100,
-                mintFee: 100 * 10 ** mockToken.decimals(),
-                mintFeeToken: address(mockToken),
-                mintFeeRecipient: feeRecipient,
-                owner: minter,
-                mintOpen: true,
-                isPublicMinting: false // not public minting
-            }))
+            spg.createCollection(
+                ISPGNFT.InitParams({
+                    name: "Test Private Collection",
+                    symbol: "TESTPRIV",
+                    baseURI: testBaseURI,
+                    maxSupply: 100,
+                    mintFee: 100 * 10 ** mockToken.decimals(),
+                    mintFeeToken: address(mockToken),
+                    mintFeeRecipient: feeRecipient,
+                    owner: minter,
+                    mintOpen: true,
+                    isPublicMinting: false // not public minting
+                })
+            )
         );
 
         vm.expectRevert(Errors.SPG__CallerNotAuthorizedToMint.selector);
@@ -70,18 +72,20 @@ contract StoryProtocolGatewayTest is BaseTest {
     function test_SPG_mintAndRegisterIp_publicMint() public {
         vm.prank(alice); // minter and admin of nftContract
         nftContract = ISPGNFT(
-            spg.createCollection(ISPGNFT.InitParams({
-                name: "Test Public Collection",
-                symbol: "TESTPUB",
-                baseURI: testBaseURI,
-                maxSupply: 100,
-                mintFee: 1 * 10 ** mockToken.decimals(),
-                mintFeeToken: address(mockToken),
-                mintFeeRecipient: feeRecipient,
-                owner: minter,
-                mintOpen: true,
-                isPublicMinting: true // public minting is enabled
-            }))
+            spg.createCollection(
+                ISPGNFT.InitParams({
+                    name: "Test Public Collection",
+                    symbol: "TESTPUB",
+                    baseURI: testBaseURI,
+                    maxSupply: 100,
+                    mintFee: 1 * 10 ** mockToken.decimals(),
+                    mintFeeToken: address(mockToken),
+                    mintFeeRecipient: feeRecipient,
+                    owner: minter,
+                    mintOpen: true,
+                    isPublicMinting: true // public minting is enabled
+                })
+            )
         );
 
         vm.startPrank(bob); // caller does not have minter role
@@ -479,17 +483,18 @@ contract StoryProtocolGatewayTest is BaseTest {
             data[i] = abi.encodeWithSelector(
                 spg.createCollection.selector,
                 ISPGNFT.InitParams({
-                name: "Test Collection",
-                symbol: "TEST",
-                baseURI: testBaseURI,
-                maxSupply: 100,
-                mintFee: 100 * 10 ** mockToken.decimals(),
-                mintFeeToken: address(mockToken),
-                mintFeeRecipient: feeRecipient,
-                owner: minter,
-                mintOpen: true,
-                isPublicMinting: false
-            }));
+                    name: "Test Collection",
+                    symbol: "TEST",
+                    baseURI: testBaseURI,
+                    maxSupply: 100,
+                    mintFee: 100 * 10 ** mockToken.decimals(),
+                    mintFeeToken: address(mockToken),
+                    mintFeeRecipient: feeRecipient,
+                    owner: minter,
+                    mintOpen: true,
+                    isPublicMinting: false
+                })
+            );
         }
 
         bytes[] memory results = spg.multicall(data);

--- a/test/utils/BaseTest.t.sol
+++ b/test/utils/BaseTest.t.sol
@@ -103,18 +103,20 @@ contract BaseTest is Test {
 
     modifier withCollection() {
         nftContract = SPGNFT(
-            spg.createCollection(ISPGNFT.InitParams({
-                name: "Test Collection",
-                symbol: "TEST",
-                baseURI: testBaseURI,
-                maxSupply: 100,
-                mintFee: 100 * 10 ** mockToken.decimals(),
-                mintFeeToken: address(mockToken),
-                mintFeeRecipient: feeRecipient,
-                owner: minter,
-                mintOpen: true,
-                isPublicMinting: false
-            }))
+            spg.createCollection(
+                ISPGNFT.InitParams({
+                    name: "Test Collection",
+                    symbol: "TEST",
+                    baseURI: testBaseURI,
+                    maxSupply: 100,
+                    mintFee: 100 * 10 ** mockToken.decimals(),
+                    mintFeeToken: address(mockToken),
+                    mintFeeRecipient: feeRecipient,
+                    owner: minter,
+                    mintOpen: true,
+                    isPublicMinting: false
+                })
+            )
         );
         _;
     }

--- a/test/utils/BaseTest.t.sol
+++ b/test/utils/BaseTest.t.sol
@@ -99,11 +99,14 @@ contract BaseTest is Test {
     ISPG.IPMetadata internal ipMetadataEmpty;
     ISPG.IPMetadata internal ipMetadataDefault;
 
+    string internal testBaseURI = "https://test.com/";
+
     modifier withCollection() {
         nftContract = SPGNFT(
-            spg.createCollection({
+            spg.createCollection(ISPGNFT.InitParams({
                 name: "Test Collection",
                 symbol: "TEST",
+                baseURI: testBaseURI,
                 maxSupply: 100,
                 mintFee: 100 * 10 ** mockToken.decimals(),
                 mintFeeToken: address(mockToken),
@@ -111,7 +114,7 @@ contract BaseTest is Test {
                 owner: minter,
                 mintOpen: true,
                 isPublicMinting: false
-            })
+            }))
         );
         _;
     }
@@ -730,12 +733,12 @@ contract BaseTest is Test {
     }
 
     /// @dev Assert metadata for the SPGNFT.
-    function assertSPGNFTMetadata(uint256 tokenId, string memory expectedMetadata) internal {
+    function assertSPGNFTMetadata(uint256 tokenId, string memory expectedMetadata) internal view {
         assertEq(nftContract.tokenURI(tokenId), expectedMetadata);
     }
 
     /// @dev Assert metadata for the IP.
-    function assertMetadata(address ipId, ISPG.IPMetadata memory expectedMetadata) internal {
+    function assertMetadata(address ipId, ISPG.IPMetadata memory expectedMetadata) internal view {
         assertEq(coreMetadataViewModule.getMetadataURI(ipId), expectedMetadata.ipMetadataURI);
         assertEq(coreMetadataViewModule.getMetadataHash(ipId), expectedMetadata.ipMetadataHash);
         assertEq(coreMetadataViewModule.getNftMetadataHash(ipId), expectedMetadata.nftMetadataHash);


### PR DESCRIPTION
## Description
This PR adds support for base URIs in SPG and SPGNFT. The `baseURI` is optional. If set, the `tokenURI` will be either `baseURI + token ID` (if `nftMetadataURI` is empty) or `baseURI + nftMetadataURI`. When `baseURI` is empty, the `tokenURI` will be the `nftMetadataURI` provided during minting.

### Key Changes
- Added `_baseURI` storage to SPGNFT.
- Added `baseURI`, `setBaseURI`, and an internal `_baseURI` function in SPGNFT for setting and retrieving base URIs.
- Introduced an `InitParam` struct for SPGNFT to handle initialization parameters and avoid deep stack issues.
- Updated the `initialize` function in SPGNFT and `createCollection` function in SPG to use the new `InitParam` struct.
- Minor style and comment updates.

## Tests
- Added `test_SPGNFT_setBaseURI` to cover setting and retrieving base URIs, testing combinations of empty and non-empty `baseURI` and `nftMetadataURI`.
- Updated existing tests to align with the changes in SPG and SPGNFT.

All tests (new and existing) pass locally.

## Related Issue
- Closes #29

## Notes
This PR introduces interface changes to the `createCollection` function in SPG and functions in SPGNFT.