### PR TITLE
fix(test): change mock IPGraph precompile address to `0x1B`

### DIFF
--- a/test/utils/BaseTest.t.sol
+++ b/test/utils/BaseTest.t.sol
@@ -67,7 +67,7 @@ contract BaseTest is Test, DeployHelper {
 
     function setUp() public virtual {
         // mock IPGraph precompile
-        vm.etch(address(0x1A), address(new MockIPGraph()).code);
+        vm.etch(address(0x1B), address(new MockIPGraph()).code);
 
         // initialize users and their secret keys
         _setupUsers();

--- a/yarn.lock
+++ b/yarn.lock
@@ -404,9 +404,9 @@
   integrity sha512-3dcmCyAxIcxy036h1I7MQU/uEEBq8oLwf1CE3xeze+MPlgkdlb/+w6rGR/1dhp6Hqi17fRS6nvwnOzkESxEkOw==
 
 "@scure/base@~1.1.6":
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.8.tgz#8f23646c352f020c83bca750a82789e246d42b50"
-  integrity sha512-6CyAclxj3Nb0XT7GHK6K4zK6k2xJm6E4Ft0Ohjt4WgegiFUHEtFb2CGzmPmGBwoIhrLsqNLYfLr04Y1GePrzZg==
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.9.tgz#e5e142fbbfe251091f9c5f1dd4c834ac04c3dbd1"
+  integrity sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==
 
 "@scure/bip32@1.4.0":
   version "1.4.0"
@@ -441,7 +441,7 @@
 
 "@story-protocol/protocol-core@github:storyprotocol/protocol-core-v1#main":
   version "1.1.0"
-  resolved "https://codeload.github.com/storyprotocol/protocol-core-v1/tar.gz/78bcd0975e37346d33faffee4ebfff7e9076ba63"
+  resolved "https://codeload.github.com/storyprotocol/protocol-core-v1/tar.gz/de6de66918fc36f27950b98a285785ce1fe62141"
   dependencies:
     "@openzeppelin/contracts" "5.0.2"
     "@openzeppelin/contracts-upgradeable" "5.0.2"


### PR DESCRIPTION
## Description
[PR#247](https://github.com/storyprotocol/protocol-core-v1/pull/247) in the core protocol changes the IPGraph precompile address from `0x1A` to `0x1B`, causing the periphery tests to fail. This PR updates the mock IPGraph address in the tests to `0x1B` for consistency.

## Test 
<!-- The test plan section indicates detailed steps on how to verify and test code changes. 
You can list the test cases or test steps that need to be performed.-->
All existing tests pass locally
