### PR TITLE
Add `RoyaltyWorkflows` to Release Branch

### DIFF
--- a/.github/workflows/foundry_ci.yml
+++ b/.github/workflows/foundry_ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - release-v1.x.x
 
 jobs:
 

--- a/contracts/RoyaltyWorkflows.sol
+++ b/contracts/RoyaltyWorkflows.sol
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+// solhint-disable-next-line max-line-length
+import { AccessManagedUpgradeable } from "@openzeppelin/contracts-upgradeable/access/manager/AccessManagedUpgradeable.sol";
+import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+import { MulticallUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/MulticallUpgradeable.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
+// solhint-disable-next-line max-line-length
+import { IGraphAwareRoyaltyPolicy } from "@storyprotocol/core/interfaces/modules/royalty/policies/IGraphAwareRoyaltyPolicy.sol";
+import { IIpRoyaltyVault } from "@storyprotocol/core/interfaces/modules/royalty/policies/IIpRoyaltyVault.sol";
+import { IRoyaltyModule } from "@storyprotocol/core/interfaces/modules/royalty/IRoyaltyModule.sol";
+
+import { Errors } from "./lib/Errors.sol";
+import { IRoyaltyWorkflows } from "./interfaces/IRoyaltyWorkflows.sol";
+
+/// @title Royalty Workflows
+/// @notice Each workflow bundles multiple core protocol operations into a single function to enable one-click
+/// IP revenue claiming in the Story Proof-of-Creativity Protocol.
+contract RoyaltyWorkflows is IRoyaltyWorkflows, MulticallUpgradeable, AccessManagedUpgradeable, UUPSUpgradeable {
+    using ERC165Checker for address;
+
+    /// @notice The address of the Royalty Module.
+    IRoyaltyModule public immutable ROYALTY_MODULE;
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor(address royaltyModule) {
+        if (royaltyModule == address(0)) revert Errors.RoyaltyWorkflows__ZeroAddressParam();
+
+        ROYALTY_MODULE = IRoyaltyModule(royaltyModule);
+
+        _disableInitializers();
+    }
+
+    /// @dev Initializes the contract.
+    /// @param accessManager The address of the protocol access manager.
+    function initialize(address accessManager) external initializer {
+        if (accessManager == address(0)) revert Errors.RoyaltyWorkflows__ZeroAddressParam();
+        __AccessManaged_init(accessManager);
+        __UUPSUpgradeable_init();
+    }
+
+    /// @notice Transfers royalties from royalty policy to the ancestor IP's royalty vault, takes a snapshot,
+    /// and claims revenue on that snapshot for each specified currency token.
+    /// @param ancestorIpId The address of the ancestor IP.
+    /// @param claimer The address of the claimer of the revenue tokens (must be a royalty token holder).
+    /// @param currencyTokens The addresses of the currency (revenue) tokens to claim (each address must be unique).
+    /// @param royaltyClaimDetails The details of the royalty claim from child IPs,
+    /// see {IRoyaltyWorkflows-RoyaltyClaimDetails}.
+    /// @return snapshotId The ID of the snapshot taken.
+    /// @return amountsClaimed The amount of revenue claimed for each currency token.
+    function transferToVaultAndSnapshotAndClaimByTokenBatch(
+        address ancestorIpId,
+        address claimer,
+        address[] calldata currencyTokens,
+        RoyaltyClaimDetails[] calldata royaltyClaimDetails
+    ) external returns (uint256 snapshotId, uint256[] memory amountsClaimed) {
+        // Transfers to ancestor's vault an amount of revenue tokens claimable via the given royalty policy
+        for (uint256 i = 0; i < royaltyClaimDetails.length; i++) {
+            IGraphAwareRoyaltyPolicy(royaltyClaimDetails[i].royaltyPolicy).transferToVault({
+                ipId: royaltyClaimDetails[i].childIpId,
+                ancestorIpId: ancestorIpId,
+                token: royaltyClaimDetails[i].currencyToken,
+                amount: royaltyClaimDetails[i].amount
+            });
+        }
+
+        // Gets the ancestor IP's royalty vault
+        IIpRoyaltyVault ancestorIpRoyaltyVault = IIpRoyaltyVault(ROYALTY_MODULE.ipRoyaltyVaults(ancestorIpId));
+
+        // Takes a snapshot of the ancestor IP's royalty vault
+        snapshotId = ancestorIpRoyaltyVault.snapshot();
+
+        // Claims revenue for each specified currency token from the latest snapshot
+        amountsClaimed = ancestorIpRoyaltyVault.claimRevenueOnBehalfByTokenBatch({
+            snapshotId: snapshotId,
+            tokenList: currencyTokens,
+            claimer: claimer
+        });
+    }
+
+    /// @notice Transfers royalties to the ancestor IP's royalty vault, takes a snapshot, claims revenue for each
+    /// specified currency token both on the new snapshot and on each specified unclaimed snapshots.
+    /// @param ancestorIpId The address of the ancestor IP.
+    /// @param claimer The address of the claimer of the revenue tokens (must be a royalty token holder).
+    /// @param currencyTokens The addresses of the currency (revenue) tokens to claim (each address must be unique).
+    /// @param unclaimedSnapshotIds The IDs of unclaimed snapshots to include in the claim.
+    /// @param royaltyClaimDetails The details of the royalty claim from child IPs,
+    /// see {IRoyaltyWorkflows-RoyaltyClaimDetails}.
+    /// @return snapshotId The ID of the snapshot taken.
+    /// @return amountsClaimed The amounts of revenue claimed for each currency token.
+    function transferToVaultAndSnapshotAndClaimBySnapshotBatch(
+        address ancestorIpId,
+        address claimer,
+        address[] calldata currencyTokens,
+        uint256[] calldata unclaimedSnapshotIds,
+        RoyaltyClaimDetails[] calldata royaltyClaimDetails
+    ) external returns (uint256 snapshotId, uint256[] memory amountsClaimed) {
+        // Transfers to ancestor's vault an amount of revenue tokens claimable via the given royalty policy
+        for (uint256 i = 0; i < royaltyClaimDetails.length; i++) {
+            IGraphAwareRoyaltyPolicy(royaltyClaimDetails[i].royaltyPolicy).transferToVault({
+                ipId: royaltyClaimDetails[i].childIpId,
+                ancestorIpId: ancestorIpId,
+                token: royaltyClaimDetails[i].currencyToken,
+                amount: royaltyClaimDetails[i].amount
+            });
+        }
+
+        // Gets the ancestor IP's royalty vault
+        IIpRoyaltyVault ancestorIpRoyaltyVault = IIpRoyaltyVault(ROYALTY_MODULE.ipRoyaltyVaults(ancestorIpId));
+
+        // Takes a snapshot of the ancestor IP's royalty vault
+        snapshotId = ancestorIpRoyaltyVault.snapshot();
+
+        // Claims revenue for each specified currency token from the latest snapshot
+        amountsClaimed = ancestorIpRoyaltyVault.claimRevenueOnBehalfByTokenBatch({
+            snapshotId: snapshotId,
+            tokenList: currencyTokens,
+            claimer: claimer
+        });
+
+        // Claims revenue for each specified currency token from the unclaimed snapshots
+        for (uint256 i = 0; i < currencyTokens.length; i++) {
+            try
+                ancestorIpRoyaltyVault.claimRevenueOnBehalfBySnapshotBatch({
+                    snapshotIds: unclaimedSnapshotIds,
+                    token: currencyTokens[i],
+                    claimer: claimer
+                })
+            returns (uint256 claimedAmount) {
+                amountsClaimed[i] += claimedAmount;
+            } catch {
+                amountsClaimed[i] += 0;
+            }
+        }
+    }
+
+    /// @notice Takes a snapshot of the IP's royalty vault and claims revenue on that snapshot for each
+    /// specified currency token.
+    /// @param ipId The address of the IP.
+    /// @param claimer The address of the claimer of the revenue tokens (must be a royalty token holder).
+    /// @param currencyTokens The addresses of the currency (revenue) tokens to claim.
+    /// @return snapshotId The ID of the snapshot taken.
+    /// @return amountsClaimed The amounts of revenue claimed for each currency token.
+    function snapshotAndClaimByTokenBatch(
+        address ipId,
+        address claimer,
+        address[] calldata currencyTokens
+    ) external returns (uint256 snapshotId, uint256[] memory amountsClaimed) {
+        // Gets the IP's royalty vault
+        IIpRoyaltyVault ipRoyaltyVault = IIpRoyaltyVault(ROYALTY_MODULE.ipRoyaltyVaults(ipId));
+
+        // Claims revenue for each specified currency token from the latest snapshot
+        snapshotId = ipRoyaltyVault.snapshot();
+        amountsClaimed = ipRoyaltyVault.claimRevenueOnBehalfByTokenBatch({
+            snapshotId: snapshotId,
+            tokenList: currencyTokens,
+            claimer: claimer
+        });
+    }
+
+    /// @notice Takes a snapshot of the IP's royalty vault and claims revenue for each specified currency token
+    /// both on the new snapshot and on each specified unclaimed snapshot.
+    /// @param ipId The address of the IP.
+    /// @param claimer The address of the claimer of the revenue tokens (must be a royalty token holder).
+    /// @param unclaimedSnapshotIds The IDs of unclaimed snapshots to include in the claim.
+    /// @param currencyTokens The addresses of the currency (revenue) tokens to claim.
+    /// @return snapshotId The ID of the snapshot taken.
+    /// @return amountsClaimed The amounts of revenue claimed for each currency token.
+    function snapshotAndClaimBySnapshotBatch(
+        address ipId,
+        address claimer,
+        uint256[] calldata unclaimedSnapshotIds,
+        address[] calldata currencyTokens
+    ) external returns (uint256 snapshotId, uint256[] memory amountsClaimed) {
+        // Gets the IP's royalty vault
+        IIpRoyaltyVault ipRoyaltyVault = IIpRoyaltyVault(ROYALTY_MODULE.ipRoyaltyVaults(ipId));
+
+        // Claims revenue for each specified currency token from the latest snapshot
+        snapshotId = ipRoyaltyVault.snapshot();
+        amountsClaimed = ipRoyaltyVault.claimRevenueOnBehalfByTokenBatch({
+            snapshotId: snapshotId,
+            tokenList: currencyTokens,
+            claimer: claimer
+        });
+
+        // Claims revenue for each specified currency token from the unclaimed snapshots
+        for (uint256 i = 0; i < currencyTokens.length; i++) {
+            try
+                ipRoyaltyVault.claimRevenueOnBehalfBySnapshotBatch({
+                    snapshotIds: unclaimedSnapshotIds,
+                    token: currencyTokens[i],
+                    claimer: claimer
+                })
+            returns (uint256 claimedAmount) {
+                amountsClaimed[i] += claimedAmount;
+            } catch {
+                // Continue to the next currency token
+                amountsClaimed[i] += 0;
+            }
+        }
+    }
+
+    //
+    // Upgrade
+    //
+
+    /// @dev Hook to authorize the upgrade according to UUPSUpgradeable
+    /// @param newImplementation The address of the new implementation
+    function _authorizeUpgrade(address newImplementation) internal override restricted {}
+}

--- a/contracts/interfaces/IRoyaltyWorkflows.sol
+++ b/contracts/interfaces/IRoyaltyWorkflows.sol
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+/// @title Royalty Workflows Interface
+/// @notice Interface for IP royalty workflows.
+interface IRoyaltyWorkflows {
+    /// @notice Details for claiming royalties from a child IP.
+    /// @param childIpId The address of the child IP.
+    /// @param royaltyPolicy The address of the royalty policy.
+    /// @param currencyToken The address of the currency (revenue) token to claim.
+    /// @param amount The amount of currency (revenue) token to claim.
+    struct RoyaltyClaimDetails {
+        address childIpId;
+        address royaltyPolicy;
+        address currencyToken;
+        uint256 amount;
+    }
+
+    /// @notice Transfers royalties from royalty policy to the ancestor IP's royalty vault, takes a snapshot,
+    /// and claims revenue on that snapshot for each specified currency token.
+    /// @param ancestorIpId The address of the ancestor IP.
+    /// @param claimer The address of the claimer of the revenue tokens (must be a royalty token holder).
+    /// @param currencyTokens The addresses of the currency (revenue) tokens to claim (each address must be unique).
+    /// @param royaltyClaimDetails The details of the royalty claim from child IPs,
+    /// see {IRoyaltyWorkflows-RoyaltyClaimDetails}.
+    /// @return snapshotId The ID of the snapshot taken.
+    /// @return amountsClaimed The amount of revenue claimed for each currency token.
+    function transferToVaultAndSnapshotAndClaimByTokenBatch(
+        address ancestorIpId,
+        address claimer,
+        address[] calldata currencyTokens,
+        RoyaltyClaimDetails[] calldata royaltyClaimDetails
+    ) external returns (uint256 snapshotId, uint256[] memory amountsClaimed);
+
+    /// @notice Transfers royalties to the ancestor IP's royalty vault, takes a snapshot, claims revenue for each
+    /// specified currency token both on the new snapshot and on each specified unclaimed snapshots.
+    /// @param ancestorIpId The address of the ancestor IP.
+    /// @param claimer The address of the claimer of the revenue tokens (must be a royalty token holder).
+    /// @param currencyTokens The addresses of the currency (revenue) tokens to claim (each address must be unique).
+    /// @param unclaimedSnapshotIds The IDs of unclaimed snapshots to include in the claim.
+    /// @param royaltyClaimDetails The details of the royalty claim from child IPs,
+    /// see {IRoyaltyWorkflows-RoyaltyClaimDetails}.
+    /// @return snapshotId The ID of the snapshot taken.
+    /// @return amountsClaimed The amounts of revenue claimed for each currency token.
+    function transferToVaultAndSnapshotAndClaimBySnapshotBatch(
+        address ancestorIpId,
+        address claimer,
+        address[] calldata currencyTokens,
+        uint256[] calldata unclaimedSnapshotIds,
+        RoyaltyClaimDetails[] calldata royaltyClaimDetails
+    ) external returns (uint256 snapshotId, uint256[] memory amountsClaimed);
+
+    /// @notice Takes a snapshot of the IP's royalty vault and claims revenue on that snapshot for each
+    /// specified currency token.
+    /// @param ipId The address of the IP.
+    /// @param claimer The address of the claimer of the revenue tokens (must be a royalty token holder).
+    /// @param currencyTokens The addresses of the currency (revenue) tokens to claim.
+    /// @return snapshotId The ID of the snapshot taken.
+    /// @return amountsClaimed The amounts of revenue claimed for each currency token.
+    function snapshotAndClaimByTokenBatch(
+        address ipId,
+        address claimer,
+        address[] calldata currencyTokens
+    ) external returns (uint256 snapshotId, uint256[] memory amountsClaimed);
+
+    /// @notice Takes a snapshot of the IP's royalty vault and claims revenue for each specified currency token
+    /// both on the new snapshot and on each specified unclaimed snapshot.
+    /// @param ipId The address of the IP.
+    /// @param claimer The address of the claimer of the revenue tokens (must be a royalty token holder).
+    /// @param unclaimedSnapshotIds The IDs of unclaimed snapshots to include in the claim.
+    /// @param currencyTokens The addresses of the currency (revenue) tokens to claim.
+    /// @return snapshotId The ID of the snapshot taken.
+    /// @return amountsClaimed The amounts of revenue claimed for each currency token.
+    function snapshotAndClaimBySnapshotBatch(
+        address ipId,
+        address claimer,
+        uint256[] calldata unclaimedSnapshotIds,
+        address[] calldata currencyTokens
+    ) external returns (uint256 snapshotId, uint256[] memory amountsClaimed);
+}

--- a/contracts/interfaces/IRoyaltyWorkflows.sol
+++ b/contracts/interfaces/IRoyaltyWorkflows.sol
@@ -20,7 +20,6 @@ interface IRoyaltyWorkflows {
     /// and claims revenue on that snapshot for each specified currency token.
     /// @param ancestorIpId The address of the ancestor IP.
     /// @param claimer The address of the claimer of the revenue tokens (must be a royalty token holder).
-    /// @param currencyTokens The addresses of the currency (revenue) tokens to claim (each address must be unique).
     /// @param royaltyClaimDetails The details of the royalty claim from child IPs,
     /// see {IRoyaltyWorkflows-RoyaltyClaimDetails}.
     /// @return snapshotId The ID of the snapshot taken.
@@ -28,7 +27,6 @@ interface IRoyaltyWorkflows {
     function transferToVaultAndSnapshotAndClaimByTokenBatch(
         address ancestorIpId,
         address claimer,
-        address[] calldata currencyTokens,
         RoyaltyClaimDetails[] calldata royaltyClaimDetails
     ) external returns (uint256 snapshotId, uint256[] memory amountsClaimed);
 
@@ -36,7 +34,6 @@ interface IRoyaltyWorkflows {
     /// specified currency token both on the new snapshot and on each specified unclaimed snapshots.
     /// @param ancestorIpId The address of the ancestor IP.
     /// @param claimer The address of the claimer of the revenue tokens (must be a royalty token holder).
-    /// @param currencyTokens The addresses of the currency (revenue) tokens to claim (each address must be unique).
     /// @param unclaimedSnapshotIds The IDs of unclaimed snapshots to include in the claim.
     /// @param royaltyClaimDetails The details of the royalty claim from child IPs,
     /// see {IRoyaltyWorkflows-RoyaltyClaimDetails}.
@@ -45,7 +42,6 @@ interface IRoyaltyWorkflows {
     function transferToVaultAndSnapshotAndClaimBySnapshotBatch(
         address ancestorIpId,
         address claimer,
-        address[] calldata currencyTokens,
         uint256[] calldata unclaimedSnapshotIds,
         RoyaltyClaimDetails[] calldata royaltyClaimDetails
     ) external returns (uint256 snapshotId, uint256[] memory amountsClaimed);

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -39,4 +39,7 @@ library Errors {
 
     /// @notice Zero address provided as a param to the GroupingWorkflows.
     error GroupingWorkflows__ZeroAddressParam();
+
+    /// @notice Zero address provided as a param to the RoyaltyWorkflows.
+    error RoyaltyWorkflows__ZeroAddressParam();
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@story-protocol/protocol-periphery",
-  "version": "v1.2.1",
+  "version": "v1.2.2",
   "description": "Story Proof-of-Creativity protocol periphery smart contracts",
   "main": "",
   "directories": {
@@ -40,7 +40,7 @@
     "@openzeppelin/contracts": "5.0.1",
     "@openzeppelin/contracts-upgradeable": "5.0.1",
     "@story-protocol/create3-deployer": "github:storyprotocol/create3-deployer#main",
-    "@story-protocol/protocol-core": "github:storyprotocol/protocol-core-v1#v1.2.1",
+    "@story-protocol/protocol-core": "github:storyprotocol/protocol-core-v1#v1.2.2",
     "erc6551": "^0.3.1",
     "solady": "^0.0.192"
   }

--- a/test/RoyaltyWorkflows.t.sol
+++ b/test/RoyaltyWorkflows.t.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.26;
 
 // external
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
+import { Errors as CoreErrors } from "@storyprotocol/core/lib/Errors.sol";
 import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
 import { IpRoyaltyVault } from "@storyprotocol/core/modules/royalty/policies/IpRoyaltyVault.sol";
 import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
@@ -64,7 +65,8 @@ contract RoyaltyWorkflowsTest is BaseTest {
 
     function test_RoyaltyWorkflows_transferToVaultAndSnapshotAndClaimByTokenBatch() public {
         // setup IP graph with no snapshot
-        _setupIpGraph(0);
+        uint256 numSnapshots = 0;
+        _setupIpGraph(numSnapshots);
 
         IRoyaltyWorkflows.RoyaltyClaimDetails[] memory claimDetails = new IRoyaltyWorkflows.RoyaltyClaimDetails[](4);
         claimDetails[0] = IRoyaltyWorkflows.RoyaltyClaimDetails({
@@ -97,10 +99,6 @@ contract RoyaltyWorkflowsTest is BaseTest {
             amount: (defaultMintingFeeC * defaultCommRevShareC) / royaltyModule.maxPercent() // 500 * 20% = 100
         });
 
-        address[] memory currencyTokens = new address[](2);
-        currencyTokens[0] = address(mockTokenA);
-        currencyTokens[1] = address(mockTokenC);
-
         uint256 claimerBalanceABefore = mockTokenA.balanceOf(u.admin);
         uint256 claimerBalanceCBefore = mockTokenC.balanceOf(u.admin);
 
@@ -108,13 +106,16 @@ contract RoyaltyWorkflowsTest is BaseTest {
             .transferToVaultAndSnapshotAndClaimByTokenBatch({
                 ancestorIpId: ancestorIpId,
                 claimer: u.admin,
-                currencyTokens: currencyTokens,
                 royaltyClaimDetails: claimDetails
             });
 
         uint256 claimerBalanceAAfter = mockTokenA.balanceOf(u.admin);
         uint256 claimerBalanceCAfter = mockTokenC.balanceOf(u.admin);
 
+        assertEq(snapshotId, numSnapshots + 1);
+        assertEq(amountsClaimed.length, 2); // there are 2 currency tokens
+        assertEq(claimerBalanceAAfter - claimerBalanceABefore, amountsClaimed[0]);
+        assertEq(claimerBalanceCAfter - claimerBalanceCBefore, amountsClaimed[1]);
         assertEq(
             claimerBalanceAAfter - claimerBalanceABefore,
             defaultMintingFeeA +
@@ -127,7 +128,6 @@ contract RoyaltyWorkflowsTest is BaseTest {
                 royaltyModule.maxPercent() // 1000 * 10% * 10% = 10 royalty from grandChildIp
             // TODO: should be 20 but MockIPGraph currently only supports single-path calculation
         );
-
         assertEq(
             claimerBalanceCAfter - claimerBalanceCBefore,
             defaultMintingFeeC + (defaultMintingFeeC * defaultCommRevShareC) / royaltyModule.maxPercent() // 500 from from minting fee of childIpC // 500 * 20% = 100 royalty from childIpC
@@ -136,7 +136,8 @@ contract RoyaltyWorkflowsTest is BaseTest {
 
     function test_RoyaltyWorkflows_transferToVaultAndSnapshotAndClaimBySnapshotBatch() public {
         // setup IP graph and takes 3 snapshots of ancestor IP's royalty vault
-        _setupIpGraph(3);
+        uint256 numSnapshots = 3;
+        _setupIpGraph(numSnapshots);
 
         IRoyaltyWorkflows.RoyaltyClaimDetails[] memory claimDetails = new IRoyaltyWorkflows.RoyaltyClaimDetails[](4);
         claimDetails[0] = IRoyaltyWorkflows.RoyaltyClaimDetails({
@@ -168,10 +169,6 @@ contract RoyaltyWorkflowsTest is BaseTest {
             amount: (defaultMintingFeeC * defaultCommRevShareC) / royaltyModule.maxPercent() // 500 * 20% = 100
         });
 
-        address[] memory currencyTokens = new address[](2);
-        currencyTokens[0] = address(mockTokenA);
-        currencyTokens[1] = address(mockTokenC);
-
         uint256 claimerBalanceABefore = mockTokenA.balanceOf(u.admin);
         uint256 claimerBalanceCBefore = mockTokenC.balanceOf(u.admin);
 
@@ -179,7 +176,6 @@ contract RoyaltyWorkflowsTest is BaseTest {
             .transferToVaultAndSnapshotAndClaimBySnapshotBatch({
                 ancestorIpId: ancestorIpId,
                 claimer: u.admin,
-                currencyTokens: currencyTokens,
                 unclaimedSnapshotIds: unclaimedSnapshotIds,
                 royaltyClaimDetails: claimDetails
             });
@@ -187,6 +183,10 @@ contract RoyaltyWorkflowsTest is BaseTest {
         uint256 claimerBalanceAAfter = mockTokenA.balanceOf(u.admin);
         uint256 claimerBalanceCAfter = mockTokenC.balanceOf(u.admin);
 
+        assertEq(snapshotId, numSnapshots + 1);
+        assertEq(amountsClaimed.length, 2); // there are 2 currency tokens
+        assertEq(claimerBalanceAAfter - claimerBalanceABefore, amountsClaimed[0]);
+        assertEq(claimerBalanceCAfter - claimerBalanceCBefore, amountsClaimed[1]);
         assertEq(
             claimerBalanceAAfter - claimerBalanceABefore,
             defaultMintingFeeA +
@@ -198,16 +198,62 @@ contract RoyaltyWorkflowsTest is BaseTest {
                 (((defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent()) * defaultCommRevShareA) /
                 royaltyModule.maxPercent() // 1000 * 10% * 10% = 10 royalty from grandChildIp
         );
-
         assertEq(
             claimerBalanceCAfter - claimerBalanceCBefore,
             defaultMintingFeeC + (defaultMintingFeeC * defaultCommRevShareC) / royaltyModule.maxPercent() // 500 from minting fee of childIpC // 500 * 20% = 100 royalty from childIpC
         );
     }
 
+    function test_RoyaltyWorkflows_revert_transferToVaultAndSnapshotAndClaimBySnapshotBatch() public {
+        // setup IP graph and takes 3 snapshots of ancestor IP's royalty vault
+        uint256 numSnapshots = 3;
+        _setupIpGraph(numSnapshots);
+
+        IRoyaltyWorkflows.RoyaltyClaimDetails[] memory claimDetails = new IRoyaltyWorkflows.RoyaltyClaimDetails[](4);
+        claimDetails[0] = IRoyaltyWorkflows.RoyaltyClaimDetails({
+            childIpId: childIpIdA,
+            royaltyPolicy: address(royaltyPolicyLRP),
+            currencyToken: address(mockTokenA),
+            amount: (defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent() // 1000 * 10% = 100
+        });
+
+        claimDetails[1] = IRoyaltyWorkflows.RoyaltyClaimDetails({
+            childIpId: childIpIdB,
+            royaltyPolicy: address(royaltyPolicyLRP),
+            currencyToken: address(mockTokenA),
+            amount: (defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent() // 1000 * 10% = 100
+        });
+
+        claimDetails[2] = IRoyaltyWorkflows.RoyaltyClaimDetails({
+            childIpId: grandChildIpId,
+            royaltyPolicy: address(royaltyPolicyLRP),
+            currencyToken: address(mockTokenA),
+            amount: (((defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent()) *
+                defaultCommRevShareA) / royaltyModule.maxPercent() // 1000 * 10% * 10% = 10
+        });
+
+        claimDetails[3] = IRoyaltyWorkflows.RoyaltyClaimDetails({
+            childIpId: childIpIdC,
+            royaltyPolicy: address(royaltyPolicyLAP),
+            currencyToken: address(mockTokenC),
+            amount: (defaultMintingFeeC * defaultCommRevShareC) / royaltyModule.maxPercent() // 500 * 20% = 100
+        });
+
+        address ancestorVault = royaltyModule.ipRoyaltyVaults(ancestorIpId);
+
+        vm.expectRevert(CoreErrors.IpRoyaltyVault__VaultsMustClaimAsSelf.selector);
+        royaltyWorkflows.transferToVaultAndSnapshotAndClaimBySnapshotBatch({
+            ancestorIpId: ancestorIpId,
+            claimer: ancestorVault,
+            unclaimedSnapshotIds: unclaimedSnapshotIds,
+            royaltyClaimDetails: claimDetails
+        });
+    }
+
     function test_RoyaltyWorkflows_snapshotAndClaimByTokenBatch() public {
         // setup IP graph with no snapshot
-        _setupIpGraph(0);
+        uint256 numSnapshots = 0;
+        _setupIpGraph(numSnapshots);
 
         address[] memory currencyTokens = new address[](2);
         currencyTokens[0] = address(mockTokenA);
@@ -225,11 +271,14 @@ contract RoyaltyWorkflowsTest is BaseTest {
         uint256 claimerBalanceAAfter = mockTokenA.balanceOf(u.admin);
         uint256 claimerBalanceCAfter = mockTokenC.balanceOf(u.admin);
 
+        assertEq(snapshotId, numSnapshots + 1);
+        assertEq(amountsClaimed.length, 2); // there are 2 currency tokens
+        assertEq(claimerBalanceAAfter - claimerBalanceABefore, amountsClaimed[0]);
+        assertEq(claimerBalanceCAfter - claimerBalanceCBefore, amountsClaimed[1]);
         assertEq(
             claimerBalanceAAfter - claimerBalanceABefore,
             defaultMintingFeeA + defaultMintingFeeA // 1000 + 1000 from minting fee of childIpA and childIpB
         );
-
         assertEq(
             claimerBalanceCAfter - claimerBalanceCBefore,
             defaultMintingFeeC // 500 from from minting fee of childIpC
@@ -238,7 +287,8 @@ contract RoyaltyWorkflowsTest is BaseTest {
 
     function test_RoyaltyWorkflows_snapshotAndClaimBySnapshotBatch() public {
         // setup IP graph and takes 1 snapshot of ancestor IP's royalty vault
-        _setupIpGraph(1);
+        uint256 numSnapshots = 1;
+        _setupIpGraph(numSnapshots);
 
         address[] memory currencyTokens = new address[](2);
         currencyTokens[0] = address(mockTokenA);
@@ -257,15 +307,38 @@ contract RoyaltyWorkflowsTest is BaseTest {
         uint256 claimerBalanceAAfter = mockTokenA.balanceOf(u.admin);
         uint256 claimerBalanceCAfter = mockTokenC.balanceOf(u.admin);
 
+        assertEq(snapshotId, numSnapshots + 1);
+        assertEq(amountsClaimed.length, 2); // there are 2 currency tokens
+        assertEq(claimerBalanceAAfter - claimerBalanceABefore, amountsClaimed[0]);
+        assertEq(claimerBalanceCAfter - claimerBalanceCBefore, amountsClaimed[1]);
         assertEq(
             claimerBalanceAAfter - claimerBalanceABefore,
             defaultMintingFeeA + defaultMintingFeeA // 1000 + 1000 from minting fee of childIpA and childIpB
         );
-
         assertEq(
             claimerBalanceCAfter - claimerBalanceCBefore,
             defaultMintingFeeC // 500 from from minting fee of childIpC
         );
+    }
+
+    function test_RoyaltyWorkflows_revert_snapshotAndClaimBySnapshotBatch() public {
+        // setup IP graph and takes 1 snapshot of ancestor IP's royalty vault
+        uint256 numSnapshots = 1;
+        _setupIpGraph(numSnapshots);
+
+        address[] memory currencyTokens = new address[](2);
+        currencyTokens[0] = address(mockTokenA);
+        currencyTokens[1] = address(mockTokenC);
+
+        address ancestorVault = royaltyModule.ipRoyaltyVaults(ancestorIpId);
+
+        vm.expectRevert(CoreErrors.IpRoyaltyVault__VaultsMustClaimAsSelf.selector);
+        royaltyWorkflows.snapshotAndClaimBySnapshotBatch({
+            ipId: ancestorIpId,
+            claimer: ancestorVault,
+            unclaimedSnapshotIds: unclaimedSnapshotIds,
+            currencyTokens: currencyTokens
+        });
     }
 
     function _setupCurrencyTokens() private {
@@ -310,7 +383,7 @@ contract RoyaltyWorkflowsTest is BaseTest {
     /// - `childIpC`: It has licenseTermsC attached, has 1 parent `ancestorIp`, and has 1 grandchild `grandChildIp`.
     /// - `grandChildIp`: It has all 3 license terms attached. It has 3 parents and 1 grandparent IPs.
     /// @param numSnapshots The number of snapshots to take of the ancestor IP's royalty vault.
-    function _setupIpGraph(uint32 numSnapshots) private {
+    function _setupIpGraph(uint256 numSnapshots) private {
         uint256 ancestorTokenId = mockNft.mint(u.admin);
         uint256 childTokenIdA = mockNft.mint(u.alice);
         uint256 childTokenIdB = mockNft.mint(u.bob);

--- a/test/RoyaltyWorkflows.t.sol
+++ b/test/RoyaltyWorkflows.t.sol
@@ -1,0 +1,597 @@
+//SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+// external
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
+import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
+import { IpRoyaltyVault } from "@storyprotocol/core/modules/royalty/policies/IpRoyaltyVault.sol";
+import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
+
+// contracts
+import { IRoyaltyWorkflows } from "../contracts/interfaces/IRoyaltyWorkflows.sol";
+import { IStoryProtocolGateway as ISPG } from "../contracts/interfaces/IStoryProtocolGateway.sol";
+
+// test
+import { BaseTest } from "./utils/BaseTest.t.sol";
+import { MockERC20 } from "./mocks/MockERC20.sol";
+import { MockERC721 } from "./mocks/MockERC721.sol";
+import { Users, UserSecretKeys, UsersLib } from "./utils/Users.t.sol";
+
+contract RoyaltyWorkflowsTest is BaseTest {
+    using Strings for uint256;
+
+    /// @dev Users struct to abstract away user management when testing
+    Users internal u;
+
+    /// @dev UserSecretKeys struct to abstract away user secret keys when testing
+    UserSecretKeys internal sk;
+
+    MockERC721 internal mockNft;
+
+    address internal ancestorIpId;
+    address internal childIpIdA;
+    address internal childIpIdB;
+    address internal childIpIdC;
+    address internal grandChildIpId;
+
+    uint256 internal commRemixTermsIdA;
+    MockERC20 internal mockTokenA;
+    uint256 internal defaultMintingFeeA = 1000 ether;
+    uint32 internal defaultCommRevShareA = 10 * 10 ** 6; // 10%
+
+    uint256 internal commRemixTermsIdC;
+    MockERC20 internal mockTokenC;
+    uint256 internal defaultMintingFeeC = 500 ether;
+    uint32 internal defaultCommRevShareC = 20 * 10 ** 6; // 20%
+
+    uint256 internal amountLicenseTokensToMint = 1;
+
+    uint256[] internal unclaimedSnapshotIds;
+
+    function setUp() public override {
+        super.setUp();
+
+        // setup users
+        (u, sk) = UsersLib.createMockUsers(vm);
+
+        // setup currency tokens
+        _setupCurrencyTokens();
+
+        // setup Mock NFT
+        mockNft = new MockERC721("TestNFT");
+        vm.label(address(mockNft), "MockERC721");
+    }
+
+    function test_RoyaltyWorkflows_transferToVaultAndSnapshotAndClaimByTokenBatch() public {
+        // setup IP graph with no snapshot
+        _setupIpGraph(0);
+
+        IRoyaltyWorkflows.RoyaltyClaimDetails[] memory claimDetails = new IRoyaltyWorkflows.RoyaltyClaimDetails[](4);
+        claimDetails[0] = IRoyaltyWorkflows.RoyaltyClaimDetails({
+            childIpId: childIpIdA,
+            royaltyPolicy: address(royaltyPolicyLRP),
+            currencyToken: address(mockTokenA),
+            amount: (defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent() // 1000 * 10% = 100
+        });
+
+        claimDetails[1] = IRoyaltyWorkflows.RoyaltyClaimDetails({
+            childIpId: childIpIdB,
+            royaltyPolicy: address(royaltyPolicyLRP),
+            currencyToken: address(mockTokenA),
+            amount: (defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent() // 1000 * 10% = 100
+        });
+
+        claimDetails[2] = IRoyaltyWorkflows.RoyaltyClaimDetails({
+            childIpId: grandChildIpId,
+            royaltyPolicy: address(royaltyPolicyLRP),
+            currencyToken: address(mockTokenA),
+            amount: (((defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent()) *
+                defaultCommRevShareA) / royaltyModule.maxPercent() // 1000 * 10% * 10% = 10
+            // TODO: should be (1000 * 10% * 10%) * 2 = 20 but MockIPGraph currently only supports single-path calculation
+        });
+
+        claimDetails[3] = IRoyaltyWorkflows.RoyaltyClaimDetails({
+            childIpId: childIpIdC,
+            royaltyPolicy: address(royaltyPolicyLAP),
+            currencyToken: address(mockTokenC),
+            amount: (defaultMintingFeeC * defaultCommRevShareC) / royaltyModule.maxPercent() // 500 * 20% = 100
+        });
+
+        address[] memory currencyTokens = new address[](2);
+        currencyTokens[0] = address(mockTokenA);
+        currencyTokens[1] = address(mockTokenC);
+
+        uint256 claimerBalanceABefore = mockTokenA.balanceOf(u.admin);
+        uint256 claimerBalanceCBefore = mockTokenC.balanceOf(u.admin);
+
+        (uint256 snapshotId, uint256[] memory amountsClaimed) = royaltyWorkflows
+            .transferToVaultAndSnapshotAndClaimByTokenBatch({
+                ancestorIpId: ancestorIpId,
+                claimer: u.admin,
+                currencyTokens: currencyTokens,
+                royaltyClaimDetails: claimDetails
+            });
+
+        uint256 claimerBalanceAAfter = mockTokenA.balanceOf(u.admin);
+        uint256 claimerBalanceCAfter = mockTokenC.balanceOf(u.admin);
+
+        assertEq(
+            claimerBalanceAAfter - claimerBalanceABefore,
+            defaultMintingFeeA +
+                defaultMintingFeeA + // 1000 + 1000 from minting fee of childIpA and childIpB
+                (defaultMintingFeeA * defaultCommRevShareA) /
+                royaltyModule.maxPercent() + // 1000 * 10% = 100 royalty from childIpA
+                (defaultMintingFeeA * defaultCommRevShareA) /
+                royaltyModule.maxPercent() + // 1000 * 10% = 100 royalty from childIpB
+                (((defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent()) * defaultCommRevShareA) /
+                royaltyModule.maxPercent() // 1000 * 10% * 10% = 10 royalty from grandChildIp
+            // TODO: should be 20 but MockIPGraph currently only supports single-path calculation
+        );
+
+        assertEq(
+            claimerBalanceCAfter - claimerBalanceCBefore,
+            defaultMintingFeeC + (defaultMintingFeeC * defaultCommRevShareC) / royaltyModule.maxPercent() // 500 from from minting fee of childIpC // 500 * 20% = 100 royalty from childIpC
+        );
+    }
+
+    function test_RoyaltyWorkflows_transferToVaultAndSnapshotAndClaimBySnapshotBatch() public {
+        // setup IP graph and takes 3 snapshots of ancestor IP's royalty vault
+        _setupIpGraph(3);
+
+        IRoyaltyWorkflows.RoyaltyClaimDetails[] memory claimDetails = new IRoyaltyWorkflows.RoyaltyClaimDetails[](4);
+        claimDetails[0] = IRoyaltyWorkflows.RoyaltyClaimDetails({
+            childIpId: childIpIdA,
+            royaltyPolicy: address(royaltyPolicyLRP),
+            currencyToken: address(mockTokenA),
+            amount: (defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent() // 1000 * 10% = 100
+        });
+
+        claimDetails[1] = IRoyaltyWorkflows.RoyaltyClaimDetails({
+            childIpId: childIpIdB,
+            royaltyPolicy: address(royaltyPolicyLRP),
+            currencyToken: address(mockTokenA),
+            amount: (defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent() // 1000 * 10% = 100
+        });
+
+        claimDetails[2] = IRoyaltyWorkflows.RoyaltyClaimDetails({
+            childIpId: grandChildIpId,
+            royaltyPolicy: address(royaltyPolicyLRP),
+            currencyToken: address(mockTokenA),
+            amount: (((defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent()) *
+                defaultCommRevShareA) / royaltyModule.maxPercent() // 1000 * 10% * 10% = 10
+        });
+
+        claimDetails[3] = IRoyaltyWorkflows.RoyaltyClaimDetails({
+            childIpId: childIpIdC,
+            royaltyPolicy: address(royaltyPolicyLAP),
+            currencyToken: address(mockTokenC),
+            amount: (defaultMintingFeeC * defaultCommRevShareC) / royaltyModule.maxPercent() // 500 * 20% = 100
+        });
+
+        address[] memory currencyTokens = new address[](2);
+        currencyTokens[0] = address(mockTokenA);
+        currencyTokens[1] = address(mockTokenC);
+
+        uint256 claimerBalanceABefore = mockTokenA.balanceOf(u.admin);
+        uint256 claimerBalanceCBefore = mockTokenC.balanceOf(u.admin);
+
+        (uint256 snapshotId, uint256[] memory amountsClaimed) = royaltyWorkflows
+            .transferToVaultAndSnapshotAndClaimBySnapshotBatch({
+                ancestorIpId: ancestorIpId,
+                claimer: u.admin,
+                currencyTokens: currencyTokens,
+                unclaimedSnapshotIds: unclaimedSnapshotIds,
+                royaltyClaimDetails: claimDetails
+            });
+
+        uint256 claimerBalanceAAfter = mockTokenA.balanceOf(u.admin);
+        uint256 claimerBalanceCAfter = mockTokenC.balanceOf(u.admin);
+
+        assertEq(
+            claimerBalanceAAfter - claimerBalanceABefore,
+            defaultMintingFeeA +
+                defaultMintingFeeA + // 1000 + 1000 from minting fee of childIpA and childIpB
+                (defaultMintingFeeA * defaultCommRevShareA) /
+                royaltyModule.maxPercent() + // 1000 * 10% = 100 royalty from childIpA
+                (defaultMintingFeeA * defaultCommRevShareA) /
+                royaltyModule.maxPercent() + // 1000 * 10% = 100 royalty from childIpB
+                (((defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent()) * defaultCommRevShareA) /
+                royaltyModule.maxPercent() // 1000 * 10% * 10% = 10 royalty from grandChildIp
+        );
+
+        assertEq(
+            claimerBalanceCAfter - claimerBalanceCBefore,
+            defaultMintingFeeC + (defaultMintingFeeC * defaultCommRevShareC) / royaltyModule.maxPercent() // 500 from minting fee of childIpC // 500 * 20% = 100 royalty from childIpC
+        );
+    }
+
+    function test_RoyaltyWorkflows_snapshotAndClaimByTokenBatch() public {
+        // setup IP graph with no snapshot
+        _setupIpGraph(0);
+
+        address[] memory currencyTokens = new address[](2);
+        currencyTokens[0] = address(mockTokenA);
+        currencyTokens[1] = address(mockTokenC);
+
+        uint256 claimerBalanceABefore = mockTokenA.balanceOf(u.admin);
+        uint256 claimerBalanceCBefore = mockTokenC.balanceOf(u.admin);
+
+        (uint256 snapshotId, uint256[] memory amountsClaimed) = royaltyWorkflows.snapshotAndClaimByTokenBatch({
+            ipId: ancestorIpId,
+            claimer: u.admin,
+            currencyTokens: currencyTokens
+        });
+
+        uint256 claimerBalanceAAfter = mockTokenA.balanceOf(u.admin);
+        uint256 claimerBalanceCAfter = mockTokenC.balanceOf(u.admin);
+
+        assertEq(
+            claimerBalanceAAfter - claimerBalanceABefore,
+            defaultMintingFeeA + defaultMintingFeeA // 1000 + 1000 from minting fee of childIpA and childIpB
+        );
+
+        assertEq(
+            claimerBalanceCAfter - claimerBalanceCBefore,
+            defaultMintingFeeC // 500 from from minting fee of childIpC
+        );
+    }
+
+    function test_RoyaltyWorkflows_snapshotAndClaimBySnapshotBatch() public {
+        // setup IP graph and takes 1 snapshot of ancestor IP's royalty vault
+        _setupIpGraph(1);
+
+        address[] memory currencyTokens = new address[](2);
+        currencyTokens[0] = address(mockTokenA);
+        currencyTokens[1] = address(mockTokenC);
+
+        uint256 claimerBalanceABefore = mockTokenA.balanceOf(u.admin);
+        uint256 claimerBalanceCBefore = mockTokenC.balanceOf(u.admin);
+
+        (uint256 snapshotId, uint256[] memory amountsClaimed) = royaltyWorkflows.snapshotAndClaimBySnapshotBatch({
+            ipId: ancestorIpId,
+            claimer: u.admin,
+            unclaimedSnapshotIds: unclaimedSnapshotIds,
+            currencyTokens: currencyTokens
+        });
+
+        uint256 claimerBalanceAAfter = mockTokenA.balanceOf(u.admin);
+        uint256 claimerBalanceCAfter = mockTokenC.balanceOf(u.admin);
+
+        assertEq(
+            claimerBalanceAAfter - claimerBalanceABefore,
+            defaultMintingFeeA + defaultMintingFeeA // 1000 + 1000 from minting fee of childIpA and childIpB
+        );
+
+        assertEq(
+            claimerBalanceCAfter - claimerBalanceCBefore,
+            defaultMintingFeeC // 500 from from minting fee of childIpC
+        );
+    }
+
+    function _setupCurrencyTokens() private {
+        mockTokenA = new MockERC20("MockTokenA", "MTA");
+        mockTokenC = new MockERC20("MockTokenC", "MTC");
+
+        mockTokenA.mint(u.alice, 100_000 ether);
+        mockTokenA.mint(u.bob, 100_000 ether);
+        mockTokenA.mint(u.dan, 100_000 ether);
+        mockTokenC.mint(u.carl, 100_000 ether);
+
+        vm.label(address(mockTokenA), "MockTokenA");
+        vm.label(address(mockTokenC), "MockTokenC");
+
+        vm.startPrank(deployer);
+        royaltyModule.whitelistRoyaltyToken(address(mockTokenA), true);
+        royaltyModule.whitelistRoyaltyToken(address(mockTokenC), true);
+        vm.stopPrank();
+    }
+
+    /// @dev Builds an IP graph as follows (TermsA is LRP, TermsC is LAP):
+    ///                                        ancestorIp (root)
+    ///                                (owner: admin，TermsA + TermsC)
+    ///                      _________________________|___________________________
+    ///                    /                          |                           \
+    ///                   /                           |                            \
+    ///                childIpA                   childIpB                      childIpC
+    ///        (owner: alice, TermsA)        (owner: bob, TermsA)          (owner: carl, TermsC)
+    ///                   \                          /                             /
+    ///                    \________________________/                             /
+    ///                                |                                         /
+    ///                            grandChildIp                                 /
+    ///                        (owner: dan, TermsA)                            /
+    ///                                 \                                     /
+    ///                                  \___________________________________/
+    ///                                                    |
+    ///    user 0xbeef mints `amountLicenseTokensToMint` grandChildIp and childIpC license tokens.
+    ///
+    /// - `ancestorIp`: It has 3 different commercial remix license terms attached. It has 3 child and 1 grandchild IPs.
+    /// - `childIpA`: It has licenseTermsA attached, has 1 parent `ancestorIp`, and has 1 grandchild `grandChildIp`.
+    /// - `childIpB`: It has licenseTermsB attached, has 1 parent `ancestorIp`, and has 1 grandchild `grandChildIp`.
+    /// - `childIpC`: It has licenseTermsC attached, has 1 parent `ancestorIp`, and has 1 grandchild `grandChildIp`.
+    /// - `grandChildIp`: It has all 3 license terms attached. It has 3 parents and 1 grandparent IPs.
+    /// @param numSnapshots The number of snapshots to take of the ancestor IP's royalty vault.
+    function _setupIpGraph(uint32 numSnapshots) private {
+        uint256 ancestorTokenId = mockNft.mint(u.admin);
+        uint256 childTokenIdA = mockNft.mint(u.alice);
+        uint256 childTokenIdB = mockNft.mint(u.bob);
+        uint256 childTokenIdC = mockNft.mint(u.carl);
+        uint256 grandChildTokenId = mockNft.mint(u.dan);
+
+        ISPG.IPMetadata memory emptyIpMetadata = ISPG.IPMetadata({
+            ipMetadataURI: "",
+            ipMetadataHash: "",
+            nftMetadataURI: "",
+            nftMetadataHash: ""
+        });
+
+        ISPG.SignatureData memory emptySigData = ISPG.SignatureData({ signer: address(0), deadline: 0, signature: "" });
+
+        unclaimedSnapshotIds = new uint256[](numSnapshots);
+
+        // register ancestor IP
+        ancestorIpId = ipAssetRegistry.register(block.chainid, address(mockNft), ancestorTokenId);
+        vm.label(ancestorIpId, "AncestorIp");
+
+        uint256 deadline = block.timestamp + 1000;
+
+        // set permission for licensing module to attach license terms to ancestor IP
+        {
+            (bytes memory signature, , bytes memory data) = _getSetPermissionSigForPeriphery({
+                ipId: ancestorIpId,
+                to: address(spg),
+                module: address(licensingModule),
+                selector: licensingModule.attachLicenseTerms.selector,
+                deadline: deadline,
+                state: IIPAccount(payable(ancestorIpId)).state(),
+                signerPk: sk.admin
+            });
+
+            IIPAccount(payable(ancestorIpId)).executeWithSig({
+                to: address(accessController),
+                value: 0,
+                data: data,
+                signer: u.admin,
+                deadline: deadline,
+                signature: signature
+            });
+        }
+
+        // register and attach Terms A and C to ancestor IP
+        commRemixTermsIdA = spg.registerPILTermsAndAttach({
+            ipId: ancestorIpId,
+            terms: PILFlavors.commercialRemix({
+                mintingFee: defaultMintingFeeA,
+                commercialRevShare: defaultCommRevShareA,
+                royaltyPolicy: address(royaltyPolicyLRP),
+                currencyToken: address(mockTokenA)
+            })
+        });
+
+        commRemixTermsIdC = spg.registerPILTermsAndAttach({
+            ipId: ancestorIpId,
+            terms: PILFlavors.commercialRemix({
+                mintingFee: defaultMintingFeeC,
+                commercialRevShare: defaultCommRevShareC,
+                royaltyPolicy: address(royaltyPolicyLAP),
+                currencyToken: address(mockTokenC)
+            })
+        });
+
+        // register childIpA as derivative of ancestorIp under Terms A
+        {
+            (bytes memory sigRegisterAlice, , ) = _getSetPermissionSigForPeriphery({
+                ipId: ipAssetRegistry.ipId(block.chainid, address(mockNft), childTokenIdA),
+                to: address(spg),
+                module: address(licensingModule),
+                selector: licensingModule.registerDerivative.selector,
+                deadline: deadline,
+                state: bytes32(0),
+                signerPk: sk.alice
+            });
+
+            address[] memory parentIpIds = new address[](1);
+            uint256[] memory licenseTermsIds = new uint256[](1);
+            parentIpIds[0] = ancestorIpId;
+            licenseTermsIds[0] = commRemixTermsIdA;
+
+            vm.startPrank(u.alice);
+            mockTokenA.approve(address(spg), defaultMintingFeeA);
+            childIpIdA = spg.registerIpAndMakeDerivative({
+                nftContract: address(mockNft),
+                tokenId: childTokenIdA,
+                derivData: ISPG.MakeDerivative({
+                    parentIpIds: parentIpIds,
+                    licenseTemplate: address(pilTemplate),
+                    licenseTermsIds: licenseTermsIds,
+                    royaltyContext: ""
+                }),
+                ipMetadata: emptyIpMetadata,
+                sigMetadata: emptySigData,
+                sigRegister: ISPG.SignatureData({ signer: u.alice, deadline: deadline, signature: sigRegisterAlice })
+            });
+            vm.stopPrank();
+            vm.label(childIpIdA, "ChildIpA");
+        }
+
+        IpRoyaltyVault ancestorIpRoyaltyVault = IpRoyaltyVault(royaltyModule.ipRoyaltyVaults(ancestorIpId));
+
+        // transfer all ancestor royalties tokens to the claimer of the ancestor IP
+        {
+            vm.startPrank(ancestorIpId);
+            ancestorIpRoyaltyVault.transfer(u.admin, ancestorIpRoyaltyVault.totalSupply());
+            vm.stopPrank();
+        }
+
+        // takes a snapshot of the ancestor IP's royalty vault and populates unclaimedSnapshotIds
+        // In this snapshot:
+        // - admin has all the royalty tokens from ancestorIp
+        // - ancestorIp's royalty vault has `defaultMintingFeeA` tokens from alice for registering childIpA
+        // as derivative of ancestorIp under Terms A
+        if (numSnapshots >= 1) {
+            unclaimedSnapshotIds[0] = ancestorIpRoyaltyVault.snapshot();
+            numSnapshots--;
+        }
+
+        // register childIpB as derivative of ancestorIp under Terms A
+        {
+            (bytes memory sigRegisterBob, , ) = _getSetPermissionSigForPeriphery({
+                ipId: ipAssetRegistry.ipId(block.chainid, address(mockNft), childTokenIdB),
+                to: address(spg),
+                module: address(licensingModule),
+                selector: licensingModule.registerDerivative.selector,
+                deadline: deadline,
+                state: bytes32(0),
+                signerPk: sk.bob
+            });
+
+            address[] memory parentIpIds = new address[](1);
+            uint256[] memory licenseTermsIds = new uint256[](1);
+            parentIpIds[0] = ancestorIpId;
+            licenseTermsIds[0] = commRemixTermsIdA;
+
+            vm.startPrank(u.bob);
+            mockTokenA.approve(address(spg), defaultMintingFeeA);
+            childIpIdB = spg.registerIpAndMakeDerivative({
+                nftContract: address(mockNft),
+                tokenId: childTokenIdB,
+                derivData: ISPG.MakeDerivative({
+                    parentIpIds: parentIpIds,
+                    licenseTemplate: address(pilTemplate),
+                    licenseTermsIds: licenseTermsIds,
+                    royaltyContext: ""
+                }),
+                ipMetadata: emptyIpMetadata,
+                sigMetadata: emptySigData,
+                sigRegister: ISPG.SignatureData({ signer: u.bob, deadline: deadline, signature: sigRegisterBob })
+            });
+            vm.stopPrank();
+            vm.label(childIpIdB, "ChildIpB");
+        }
+
+        // takes a snapshot of the ancestor IP's royalty vault and populates unclaimedSnapshotIds
+        // In this snapshot:
+        // - admin has all the royalty tokens from ancestorIp
+        // - ancestorIp's royalty vault has `defaultMintingFeeA` tokens from bob for registering childIpB
+        // as derivative of ancestorIp under Terms A
+        if (numSnapshots >= 1) {
+            unclaimedSnapshotIds[1] = IpRoyaltyVault(royaltyModule.ipRoyaltyVaults(ancestorIpId)).snapshot();
+            numSnapshots--;
+        }
+
+        /// register childIpC as derivative of ancestorIp under Terms C
+        {
+            (bytes memory sigRegisterCarl, , ) = _getSetPermissionSigForPeriphery({
+                ipId: ipAssetRegistry.ipId(block.chainid, address(mockNft), childTokenIdC),
+                to: address(spg),
+                module: address(licensingModule),
+                selector: licensingModule.registerDerivative.selector,
+                deadline: deadline,
+                state: bytes32(0),
+                signerPk: sk.carl
+            });
+
+            address[] memory parentIpIds = new address[](1);
+            uint256[] memory licenseTermsIds = new uint256[](1);
+            parentIpIds[0] = ancestorIpId;
+            licenseTermsIds[0] = commRemixTermsIdC;
+
+            vm.startPrank(u.carl);
+            mockTokenC.approve(address(spg), defaultMintingFeeC);
+            childIpIdC = spg.registerIpAndMakeDerivative({
+                nftContract: address(mockNft),
+                tokenId: childTokenIdC,
+                derivData: ISPG.MakeDerivative({
+                    parentIpIds: parentIpIds,
+                    licenseTemplate: address(pilTemplate),
+                    licenseTermsIds: licenseTermsIds,
+                    royaltyContext: ""
+                }),
+                ipMetadata: emptyIpMetadata,
+                sigMetadata: emptySigData,
+                sigRegister: ISPG.SignatureData({ signer: u.carl, deadline: deadline, signature: sigRegisterCarl })
+            });
+            vm.stopPrank();
+            vm.label(childIpIdC, "ChildIpC");
+        }
+
+        // takes a snapshot of the ancestor IP's royalty vault and populates unclaimedSnapshotIds
+        // In this snapshot:
+        // - admin has all the royalty tokens from ancestorIp
+        // - ancestorIp's royalty vault has `defaultMintingFeeC` tokens from carl for registering childIpC
+        // as derivative of ancestorIp under Terms C
+        if (numSnapshots >= 1) {
+            unclaimedSnapshotIds[2] = IpRoyaltyVault(royaltyModule.ipRoyaltyVaults(ancestorIpId)).snapshot();
+            numSnapshots--;
+        }
+
+        // register grandChildIp as derivative for childIp A and B under Terms A
+        {
+            (bytes memory sigRegisterDan, , ) = _getSetPermissionSigForPeriphery({
+                ipId: ipAssetRegistry.ipId(block.chainid, address(mockNft), grandChildTokenId),
+                to: address(spg),
+                module: address(licensingModule),
+                selector: licensingModule.registerDerivative.selector,
+                deadline: deadline,
+                state: bytes32(0),
+                signerPk: sk.dan
+            });
+
+            address[] memory parentIpIds = new address[](2);
+            uint256[] memory licenseTermsIds = new uint256[](2);
+            parentIpIds[0] = childIpIdA;
+            parentIpIds[1] = childIpIdB;
+            for (uint256 i = 0; i < licenseTermsIds.length; i++) {
+                licenseTermsIds[i] = commRemixTermsIdA;
+            }
+
+            vm.startPrank(u.dan);
+            mockTokenA.approve(address(spg), defaultMintingFeeA * parentIpIds.length);
+            grandChildIpId = spg.registerIpAndMakeDerivative({
+                nftContract: address(mockNft),
+                tokenId: grandChildTokenId,
+                derivData: ISPG.MakeDerivative({
+                    parentIpIds: parentIpIds,
+                    licenseTemplate: address(pilTemplate),
+                    licenseTermsIds: licenseTermsIds,
+                    royaltyContext: ""
+                }),
+                ipMetadata: emptyIpMetadata,
+                sigMetadata: emptySigData,
+                sigRegister: ISPG.SignatureData({ signer: u.dan, deadline: deadline, signature: sigRegisterDan })
+            });
+            vm.stopPrank();
+            vm.label(grandChildIpId, "GrandChildIp");
+        }
+
+        // uesr 0xbeef mints `amountLicenseTokensToMint` grandChildIp and childIpC license tokens
+        {
+            vm.startPrank(address(0xbeef));
+            mockTokenA.mint(address(0xbeef), defaultMintingFeeA * amountLicenseTokensToMint);
+            mockTokenA.approve(address(royaltyModule), defaultMintingFeeA * amountLicenseTokensToMint);
+
+            // mint `amountLicenseTokensToMint` grandChildIp's license tokens
+            licensingModule.mintLicenseTokens({
+                licensorIpId: grandChildIpId,
+                licenseTemplate: address(pilTemplate),
+                licenseTermsId: commRemixTermsIdA,
+                amount: amountLicenseTokensToMint,
+                receiver: address(0xbeef),
+                royaltyContext: ""
+            });
+
+            mockTokenC.mint(address(0xbeef), defaultMintingFeeC * amountLicenseTokensToMint);
+            mockTokenC.approve(address(royaltyModule), defaultMintingFeeC * amountLicenseTokensToMint);
+
+            // mint `amountLicenseTokensToMint` childIpC's license tokens
+            licensingModule.mintLicenseTokens({
+                licensorIpId: childIpIdC,
+                licenseTemplate: address(pilTemplate),
+                licenseTermsId: commRemixTermsIdC,
+                amount: amountLicenseTokensToMint,
+                receiver: address(0xbeef),
+                royaltyContext: ""
+            });
+            vm.stopPrank();
+        }
+    }
+}

--- a/test/mocks/MockERC20.sol
+++ b/test/mocks/MockERC20.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.23;
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
 contract MockERC20 is ERC20 {
-    constructor() ERC20("MockERC20", "MERC20") {}
+    constructor(string memory _name, string memory _symbol) ERC20(_name, _symbol) {}
 
     function mint(address to, uint256 amount) external {
         _mint(to, amount);

--- a/test/utils/Users.t.sol
+++ b/test/utils/Users.t.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import { Vm } from "forge-std/Vm.sol";
+
+struct Users {
+    // Default admin
+    address payable admin;
+    // Random users
+    address payable alice;
+    address payable bob;
+    address payable carl;
+    address payable dan;
+}
+
+struct UserSecretKeys {
+    // Default admin
+    uint256 admin;
+    // Random users
+    uint256 alice;
+    uint256 bob;
+    uint256 carl;
+    uint256 dan;
+}
+
+library UsersLib {
+    function createUser(string memory name, Vm vm) public returns (address payable user, uint256 sk) {
+        sk = uint256(keccak256(abi.encodePacked(name)));
+        user = payable(vm.addr(sk));
+        vm.deal(user, 1000 ether); // set balance to 1000 ether
+        vm.label(user, name);
+        return (user, sk);
+    }
+
+    function createMockUsers(Vm vm) public returns (Users memory, UserSecretKeys memory) {
+        (address payable admin, uint256 adminSk) = createUser("Admin", vm);
+        (address payable alice, uint256 aliceSk) = createUser("Alice", vm);
+        (address payable bob, uint256 bobSk) = createUser("Bob", vm);
+        (address payable carl, uint256 carlSk) = createUser("Carl", vm);
+        (address payable dan, uint256 danSk) = createUser("Dan", vm);
+
+        return (
+            Users({ admin: admin, alice: alice, bob: bob, carl: carl, dan: dan }),
+            UserSecretKeys({ admin: adminSk, alice: aliceSk, bob: bobSk, carl: carlSk, dan: danSk })
+        );
+    }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -404,9 +404,9 @@
   integrity sha512-3dcmCyAxIcxy036h1I7MQU/uEEBq8oLwf1CE3xeze+MPlgkdlb/+w6rGR/1dhp6Hqi17fRS6nvwnOzkESxEkOw==
 
 "@scure/base@~1.1.6":
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.8.tgz#8f23646c352f020c83bca750a82789e246d42b50"
-  integrity sha512-6CyAclxj3Nb0XT7GHK6K4zK6k2xJm6E4Ft0Ohjt4WgegiFUHEtFb2CGzmPmGBwoIhrLsqNLYfLr04Y1GePrzZg==
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/@scure/base/-/base-1.1.9.tgz#e5e142fbbfe251091f9c5f1dd4c834ac04c3dbd1"
+  integrity sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==
 
 "@scure/bip32@1.4.0":
   version "1.4.0"
@@ -439,9 +439,9 @@
   version "0.0.0"
   resolved "https://codeload.github.com/storyprotocol/create3-deployer/tar.gz/094147bda866490dd1c3e8261bb3dfee65e7af54"
 
-"@story-protocol/protocol-core@github:storyprotocol/protocol-core-v1#v1.2.1":
+"@story-protocol/protocol-core@github:storyprotocol/protocol-core-v1#v1.2.2":
   version "1.1.0"
-  resolved "https://codeload.github.com/storyprotocol/protocol-core-v1/tar.gz/73f655e191195e27bc55c97520f8a97d768f19b6"
+  resolved "https://codeload.github.com/storyprotocol/protocol-core-v1/tar.gz/ae0ab988ff17418db9a17d75490bcf12b302758f"
   dependencies:
     "@openzeppelin/contracts" "5.0.2"
     "@openzeppelin/contracts-upgradeable" "5.0.2"
@@ -495,9 +495,9 @@
   integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
 "@types/node@*":
-  version "22.5.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.5.5.tgz#52f939dd0f65fc552a4ad0b392f3c466cc5d7a44"
-  integrity sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==
+  version "22.6.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.6.1.tgz#e531a45f4d78f14a8468cb9cdc29dc9602afc7ac"
+  integrity sha512-V48tCfcKb/e6cVUigLAaJDAILdMP0fUW6BidkPK4GpGjXcfbnoHasCZDwz3N3yVt5we2RHm4XTQCpv0KJz9zqw==
   dependencies:
     undici-types "~6.19.2"
 


### PR DESCRIPTION
## Description:

This PR adds the changes from PRs #74 and #75 to the release branch. It introduces the `RoyaltyWorkflows` contract, which enables IP royalty token holders to claim revenue across multiple revenue tokens and snapshots in a single function call. 

Additionally, the `package.json` is updated to reference `protocol-core` version **v1.2.2**.

## Test
All existing and new tests pass locally.