### PR TITLE
chore: bump version pragma to 0.8.26

### DIFF
--- a/contracts/BaseWorkflow.sol
+++ b/contracts/BaseWorkflow.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 
 import { IAccessController } from "@storyprotocol/core/interfaces/access/IAccessController.sol";
 import { IIPAssetRegistry } from "@storyprotocol/core/interfaces/registries/IIPAssetRegistry.sol";

--- a/contracts/SPGNFT.sol
+++ b/contracts/SPGNFT.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 
 import { AccessControlUpgradeable } from "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 // solhint-disable-next-line max-line-length

--- a/contracts/interfaces/ISPGNFT.sol
+++ b/contracts/interfaces/ISPGNFT.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 
 import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
 import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";

--- a/contracts/interfaces/workflows/IDerivativeWorkflows.sol
+++ b/contracts/interfaces/workflows/IDerivativeWorkflows.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 
 import { WorkflowStructs } from "../../lib/WorkflowStructs.sol";
 

--- a/contracts/interfaces/workflows/IGroupingWorkflows.sol
+++ b/contracts/interfaces/workflows/IGroupingWorkflows.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 
 import { WorkflowStructs } from "../../lib/WorkflowStructs.sol";
 

--- a/contracts/interfaces/workflows/ILicenseAttachmentWorkflows.sol
+++ b/contracts/interfaces/workflows/ILicenseAttachmentWorkflows.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 
 import { PILTerms } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
 

--- a/contracts/interfaces/workflows/IRegistrationWorkflows.sol
+++ b/contracts/interfaces/workflows/IRegistrationWorkflows.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 
 import { ISPGNFT } from "../../interfaces/ISPGNFT.sol";
 import { WorkflowStructs } from "../../lib/WorkflowStructs.sol";

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 
 /// @title Errors Library
 /// @notice Library for all Story Protocol periphery contract errors.

--- a/contracts/lib/LicensingHelper.sol
+++ b/contracts/lib/LicensingHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 
 import { ILicenseRegistry } from "@storyprotocol/core/interfaces/registries/ILicenseRegistry.sol";
 import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingModule.sol";

--- a/contracts/lib/MetadataHelper.sol
+++ b/contracts/lib/MetadataHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 
 import { ICoreMetadataModule } from "@storyprotocol/core/interfaces/modules/metadata/ICoreMetadataModule.sol";
 

--- a/contracts/lib/PermissionHelper.sol
+++ b/contracts/lib/PermissionHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 
 import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
 import { AccessPermission } from "@storyprotocol/core/lib/AccessPermission.sol";

--- a/contracts/lib/SPGNFTLib.sol
+++ b/contracts/lib/SPGNFTLib.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 
 /// @title SPG NFT Library
 /// @notice Library for SPG NFT related functions.

--- a/contracts/lib/WorkflowStructs.sol
+++ b/contracts/lib/WorkflowStructs.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 
 /// @title Workflow Structs Library
 /// @notice Library for all the structs used in periphery workflows.

--- a/contracts/workflows/DerivativeWorkflows.sol
+++ b/contracts/workflows/DerivativeWorkflows.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 
 // solhint-disable-next-line max-line-length
 import { AccessManagedUpgradeable } from "@openzeppelin/contracts-upgradeable/access/manager/AccessManagedUpgradeable.sol";

--- a/contracts/workflows/GroupingWorkflows.sol
+++ b/contracts/workflows/GroupingWorkflows.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 
 // solhint-disable-next-line max-line-length
 import { AccessManagedUpgradeable } from "@openzeppelin/contracts-upgradeable/access/manager/AccessManagedUpgradeable.sol";

--- a/contracts/workflows/LicenseAttachmentWorkflows.sol
+++ b/contracts/workflows/LicenseAttachmentWorkflows.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 
 // solhint-disable-next-line max-line-length
 import { AccessManagedUpgradeable } from "@openzeppelin/contracts-upgradeable/access/manager/AccessManagedUpgradeable.sol";

--- a/contracts/workflows/RegistrationWorkflows.sol
+++ b/contracts/workflows/RegistrationWorkflows.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 
 // solhint-disable-next-line max-line-length
 import { AccessManagedUpgradeable } from "@openzeppelin/contracts-upgradeable/access/manager/AccessManagedUpgradeable.sol";

--- a/script/deployment/Main.s.sol
+++ b/script/deployment/Main.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 /* solhint-disable no-console */
 
 // script

--- a/script/deployment/MockRewardPool.s.sol
+++ b/script/deployment/MockRewardPool.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 /* solhint-disable no-console */
 
 // external

--- a/script/upgrade/UpgradeDerivativeWorkflows.s.sol
+++ b/script/upgrade/UpgradeDerivativeWorkflows.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 /* solhint-disable no-console */
 
 // external

--- a/script/upgrade/UpgradeGroupingWorkflows.s.sol
+++ b/script/upgrade/UpgradeGroupingWorkflows.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 /* solhint-disable no-console */
 
 // external

--- a/script/upgrade/UpgradeLicenseAttachmentWorkflows.s.sol
+++ b/script/upgrade/UpgradeLicenseAttachmentWorkflows.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 /* solhint-disable no-console */
 
 // external

--- a/script/upgrade/UpgradeRegistrationWorkflows.s.sol
+++ b/script/upgrade/UpgradeRegistrationWorkflows.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 /* solhint-disable no-console */
 
 // external

--- a/script/upgrade/UpgradeRoyaltyWorkflows.s.sol
+++ b/script/upgrade/UpgradeRoyaltyWorkflows.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 /* solhint-disable no-console */
 
 // external

--- a/script/upgrade/UpgradeSPGNFT.s.sol
+++ b/script/upgrade/UpgradeSPGNFT.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 /* solhint-disable no-console */
 
 // external

--- a/script/utils/BroadcastManager.s.sol
+++ b/script/utils/BroadcastManager.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 
 import { Script } from "forge-std/Script.sol";
 

--- a/script/utils/DeployHelper.sol
+++ b/script/utils/DeployHelper.sol
@@ -1,6 +1,6 @@
 /* solhint-disable no-console */
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 
 // external
 import { console2 } from "forge-std/console2.sol";

--- a/script/utils/JsonDeploymentHandler.s.sol
+++ b/script/utils/JsonDeploymentHandler.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 
 import { Script } from "forge-std/Script.sol";
 import { stdJson } from "forge-std/StdJson.sol";

--- a/script/utils/StoryProtocolCoreAddressManager.sol
+++ b/script/utils/StoryProtocolCoreAddressManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 
 import { Script, stdJson } from "forge-std/Script.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";

--- a/script/utils/StoryProtocolPeripheryAddressManager.sol
+++ b/script/utils/StoryProtocolPeripheryAddressManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 
 import { Script, stdJson } from "forge-std/Script.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";

--- a/script/utils/StringUtil.sol
+++ b/script/utils/StringUtil.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 
 /// @title String Utility Library
 library StringUtil {

--- a/script/utils/upgrades/ERC7201Helper.s.sol
+++ b/script/utils/upgrades/ERC7201Helper.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 /* solhint-disable no-console */
 
 import { Script } from "forge-std/Script.sol";

--- a/script/utils/upgrades/UpgradeHelper.s.sol
+++ b/script/utils/upgrades/UpgradeHelper.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 /* solhint-disable no-console */
 
 // external

--- a/test/SPGNFT.t.sol
+++ b/test/SPGNFT.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 
 import { BeaconProxy } from "@openzeppelin/contracts/proxy/beacon/BeaconProxy.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";

--- a/test/mocks/MockERC20.sol
+++ b/test/mocks/MockERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/test/mocks/MockERC721.sol
+++ b/test/mocks/MockERC721.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 
 import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 

--- a/test/utils/BaseTest.t.sol
+++ b/test/utils/BaseTest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 
 // external
 import { Test } from "forge-std/Test.sol";

--- a/test/utils/TestProxyHelper.t.sol
+++ b/test/utils/TestProxyHelper.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 
 import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
 import { ICreate3Deployer } from "@create3-deployer/contracts/ICreate3Deployer.sol";

--- a/test/utils/Users.t.sol
+++ b/test/utils/Users.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 
 import { Vm } from "forge-std/Vm.sol";
 

--- a/test/workflows/DerivativeWorkflows.t.sol
+++ b/test/workflows/DerivativeWorkflows.t.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 /* solhint-disable no-console */
 
 // external

--- a/test/workflows/GroupingWorkflows.t.sol
+++ b/test/workflows/GroupingWorkflows.t.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 /* solhint-disable no-console */
 
 // external

--- a/test/workflows/LicenseAttachmentWorkflows.t.sol
+++ b/test/workflows/LicenseAttachmentWorkflows.t.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 /* solhint-disable no-console */
 
 // external

--- a/test/workflows/RegistrationWorkflows.t.sol
+++ b/test/workflows/RegistrationWorkflows.t.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.8.23;
+pragma solidity 0.8.26;
 /* solhint-disable no-console */
 
 // external


### PR DESCRIPTION
## Description
<!-- Add a description of the changes that this PR introduces -->
This PR updates the Solidity compiler version to the latest 0.8.26. This change ensures that the project benefits from the latest features, optimizations, and security improvements provided by the new compiler version.

## Related Issue
- Closes #73