### PR TITLE
test: add integration tests to periphery

### DIFF
--- a/script/utils/StoryProtocolCoreAddressManager.sol
+++ b/script/utils/StoryProtocolCoreAddressManager.sol
@@ -13,6 +13,7 @@ contract StoryProtocolCoreAddressManager is Script {
     address internal licenseRegistryAddr;
     address internal royaltyModuleAddr;
     address internal coreMetadataModuleAddr;
+    address internal coreMetadataViewModuleAddr;
     address internal accessControllerAddr;
     address internal pilTemplateAddr;
     address internal licenseTokenAddr;
@@ -40,6 +41,7 @@ contract StoryProtocolCoreAddressManager is Script {
         licenseRegistryAddr = json.readAddress(".main.LicenseRegistry");
         royaltyModuleAddr = json.readAddress(".main.RoyaltyModule");
         coreMetadataModuleAddr = json.readAddress(".main.CoreMetadataModule");
+        coreMetadataViewModuleAddr = json.readAddress(".main.CoreMetadataViewModule");
         accessControllerAddr = json.readAddress(".main.AccessController");
         pilTemplateAddr = json.readAddress(".main.PILicenseTemplate");
         licenseTokenAddr = json.readAddress(".main.LicenseToken");

--- a/test/integration/BaseIntegration.t.sol
+++ b/test/integration/BaseIntegration.t.sol
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+/* solhint-disable no-console */
+
+// external
+import { console2 } from "forge-std/console2.sol";
+import { Script } from "forge-std/Script.sol";
+import { Test } from "forge-std/Test.sol";
+import { SUSD } from "@storyprotocol/test/mocks/token/SUSD.sol";
+import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+import { AccessPermission } from "@storyprotocol/core/lib/AccessPermission.sol";
+import { IAccessController } from "@storyprotocol/core/interfaces/access/IAccessController.sol";
+import { ICoreMetadataModule } from "@storyprotocol/core/interfaces/modules/metadata/ICoreMetadataModule.sol";
+import { ICoreMetadataViewModule } from "@storyprotocol/core/interfaces/modules/metadata/ICoreMetadataViewModule.sol";
+import { IGroupingModule } from "@storyprotocol/core/interfaces/modules/grouping/IGroupingModule.sol";
+import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
+import { IIPAssetRegistry } from "@storyprotocol/core/interfaces/registries/IIPAssetRegistry.sol";
+import { ILicenseRegistry } from "@storyprotocol/core/interfaces/registries/ILicenseRegistry.sol";
+import { ILicenseToken } from "@storyprotocol/core/interfaces/ILicenseToken.sol";
+import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingModule.sol";
+import { IPILicenseTemplate } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
+import { IRoyaltyModule } from "@storyprotocol/core/interfaces/modules/royalty/IRoyaltyModule.sol";
+import { MetaTx } from "@storyprotocol/core/lib/MetaTx.sol";
+
+// contracts
+import { DerivativeWorkflows } from "../../contracts/workflows/DerivativeWorkflows.sol";
+import { LicenseAttachmentWorkflows } from "../../contracts/workflows/LicenseAttachmentWorkflows.sol";
+import { GroupingWorkflows } from "../../contracts/workflows/GroupingWorkflows.sol";
+import { RegistrationWorkflows } from "../../contracts/workflows/RegistrationWorkflows.sol";
+import { RoyaltyWorkflows } from "../../contracts/workflows/RoyaltyWorkflows.sol";
+import { WorkflowStructs } from "../../contracts/lib/WorkflowStructs.sol";
+
+// script
+import { StoryProtocolCoreAddressManager } from "../../script/utils/StoryProtocolCoreAddressManager.sol";
+import { StoryProtocolPeripheryAddressManager } from "../../script/utils/StoryProtocolPeripheryAddressManager.sol";
+
+contract BaseIntegration is
+    Test,
+    Script,
+    StoryProtocolCoreAddressManager,
+    StoryProtocolPeripheryAddressManager
+{
+    /// @dev Test user
+    address internal testSender;
+    uint256 internal testSenderSk;
+
+    /// @dev Core contracts
+    ICoreMetadataViewModule internal coreMetadataViewModule;
+    IGroupingModule internal groupingModule;
+    IIPAssetRegistry internal ipAssetRegistry;
+    ILicenseRegistry internal licenseRegistry;
+    ILicenseToken internal licenseToken;
+    ILicensingModule internal licensingModule;
+    IPILicenseTemplate internal pilTemplate;
+    IRoyaltyModule internal royaltyModule;
+
+    /// @dev Periphery contracts
+    DerivativeWorkflows internal derivativeWorkflows;
+    LicenseAttachmentWorkflows internal licenseAttachmentWorkflows;
+    GroupingWorkflows internal groupingWorkflows;
+    RegistrationWorkflows internal registrationWorkflows;
+    RoyaltyWorkflows internal royaltyWorkflows;
+
+    /// @dev Story USD
+    SUSD internal StoryUSD = SUSD(0x91f6F05B08c16769d3c85867548615d270C42fC7);
+
+    /// @dev Mock even split group reward pool
+    address internal groupRewardPool = 0x69e0D5123bc0539a87a9dDcE82E803575e35cbb4;
+
+    /// @dev Test data
+    string internal testCollectionName;
+    string internal testCollectionSymbol;
+    string internal testBaseURI;
+    uint32 internal testMaxSupply;
+    uint256 internal testMintFee;
+    address internal testMintFeeToken;
+    WorkflowStructs.IPMetadata internal testIpMetadata;
+
+    function run() public virtual {
+        _setUp();
+    }
+
+    function _setUp() internal {
+        _readStoryProtocolCoreAddresses(); // StoryProtocolCoreAddressManager
+        _readStoryProtocolPeripheryAddresses(); // StoryProtocolPeripheryAddressManager
+
+        // read tester info from .env
+        testSender = vm.envAddress("TEST_SENDER_ADDRESS");
+        testSenderSk = vm.envUint("TEST_SENDER_SECRETKEY");
+
+        // set up core contracts
+        coreMetadataViewModule = ICoreMetadataViewModule(coreMetadataViewModuleAddr);
+        groupingModule = IGroupingModule(groupingModuleAddr);
+        ipAssetRegistry = IIPAssetRegistry(ipAssetRegistryAddr);
+        licenseRegistry = ILicenseRegistry(licenseRegistryAddr);
+        licenseToken = ILicenseToken(licenseTokenAddr);
+        licensingModule = ILicensingModule(licensingModuleAddr);
+        pilTemplate = IPILicenseTemplate(pilTemplateAddr);
+        royaltyModule = IRoyaltyModule(royaltyModuleAddr);
+
+        // set up periphery contracts
+        derivativeWorkflows = DerivativeWorkflows(derivativeWorkflowsAddr);
+        licenseAttachmentWorkflows = LicenseAttachmentWorkflows(licenseAttachmentWorkflowsAddr);
+        groupingWorkflows = GroupingWorkflows(groupingWorkflowsAddr);
+        registrationWorkflows = RegistrationWorkflows(registrationWorkflowsAddr);
+        royaltyWorkflows = RoyaltyWorkflows(royaltyWorkflowsAddr);
+
+        // set up test data
+        testCollectionName = "Test Collection";
+        testCollectionSymbol = "TEST";
+        testBaseURI = "https://test.com/";
+        testMaxSupply = 100_000;
+        testMintFee = 10 * 10 ** StoryUSD.decimals(); // 10 SUSD
+        testMintFeeToken = address(StoryUSD);
+        testIpMetadata = WorkflowStructs.IPMetadata({
+            ipMetadataURI: "test-ip-uri",
+            ipMetadataHash: "test-ip-hash",
+            nftMetadataURI: "test-nft-uri",
+            nftMetadataHash: "test-nft-hash"
+        });
+
+    }
+
+    function _beginBroadcast() internal {
+        vm.startBroadcast(testSenderSk);
+    }
+
+    function _endBroadcast() internal {
+        vm.stopBroadcast();
+    }
+
+    function _logTestStart(string memory testName) internal pure {
+        console2.log("==================================");
+        console2.log("Running test", testName, "...");
+    }
+
+    function _logTestEnd(string memory testName) internal pure {
+        console2.log("Test", testName, " passed!");
+        console2.log("==================================");
+    }
+
+    /*//////////////////////////////////////////////////////////////////////////
+                                      HELPERS
+    //////////////////////////////////////////////////////////////////////////*/
+
+    /// @dev Get the permission list for setting metadata and attaching license terms for the IP.
+    /// @param ipId The ID of the IP that the permissions are for.
+    /// @param to The address of the periphery contract to receive the permission.
+    /// @return permissionList The list of permissions for setting metadata and attaching license terms.
+    function _getMetadataAndAttachTermsPermissionList(
+        address ipId,
+        address to
+    ) internal view returns (AccessPermission.Permission[] memory permissionList) {
+        address[] memory modules = new address[](2);
+        bytes4[] memory selectors = new bytes4[](2);
+        permissionList = new AccessPermission.Permission[](2);
+
+        modules[0] = coreMetadataModuleAddr;
+        modules[1] = licensingModuleAddr;
+        selectors[0] = ICoreMetadataModule.setAll.selector;
+        selectors[1] = ILicensingModule.attachLicenseTerms.selector;
+
+        for (uint256 i = 0; i < 2; i++) {
+            permissionList[i] = AccessPermission.Permission({
+                ipAccount: ipId,
+                signer: to,
+                to: modules[i],
+                func: selectors[i],
+                permission: AccessPermission.ALLOW
+            });
+        }
+    }
+
+    /// @dev Get the signature for setting batch permission for the IP by the SPG.
+    /// @param ipId The ID of the IP to set the permissions for.
+    /// @param permissionList A list of permissions to set.
+    /// @param deadline The deadline for the signature.
+    /// @param state IPAccount's internal state
+    /// @param signerSk The secret key of the signer.
+    /// @return signature The signature for setting the batch permission.
+    /// @return expectedState The expected IPAccount's state after setting batch permission.
+    /// @return data The call data for executing the setBatchPermissions function.
+    function _getSetBatchPermissionSigForPeriphery(
+        address ipId,
+        AccessPermission.Permission[] memory permissionList,
+        uint256 deadline,
+        bytes32 state,
+        uint256 signerSk
+    ) internal view returns (bytes memory signature, bytes32 expectedState, bytes memory data) {
+        expectedState = keccak256(
+            abi.encode(
+                state, // ipAccount.state()
+                abi.encodeWithSelector(
+                    IIPAccount.execute.selector,
+                    address(accessControllerAddr),
+                    0, // amount of ether to send
+                    abi.encodeWithSelector(IAccessController.setBatchPermissions.selector, permissionList)
+                )
+            )
+        );
+
+        data = abi.encodeWithSelector(IAccessController.setBatchPermissions.selector, permissionList);
+
+        bytes32 digest = MessageHashUtils.toTypedDataHash(
+            MetaTx.calculateDomainSeparator(ipId),
+            MetaTx.getExecuteStructHash(
+                MetaTx.Execute({
+                    to: address(accessControllerAddr),
+                    value: 0,
+                    data: data,
+                    nonce: expectedState,
+                    deadline: deadline
+                })
+            )
+        );
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerSk, digest);
+        signature = abi.encodePacked(r, s, v);
+    }
+
+    /// @dev Get the signature for setting permission for the IP by the SPG.
+    /// @param ipId The ID of the IP.
+    /// @param to The address of the periphery contract to receive the permission.
+    /// @param module The address of the module to set the permission for.
+    /// @param selector The selector of the function to be permitted for execution.
+    /// @param deadline The deadline for the signature.
+    /// @param state IPAccount's internal nonce
+    /// @param signerSk The secret key of the signer.
+    /// @return signature The signature for setting the permission.
+    /// @return expectedState The expected IPAccount's state after setting the permission.
+    /// @return data The call data for executing the setPermission function.
+    function _getSetPermissionSigForPeriphery(
+        address ipId,
+        address to,
+        address module,
+        bytes4 selector,
+        uint256 deadline,
+        bytes32 state,
+        uint256 signerSk
+    ) internal view returns (bytes memory signature, bytes32 expectedState, bytes memory data) {
+        expectedState = keccak256(
+            abi.encode(
+                state, // ipAccount.state()
+                abi.encodeWithSelector(
+                    IIPAccount.execute.selector,
+                    address(accessControllerAddr),
+                    0, // amount of ether to send
+                    abi.encodeWithSelector(
+                        IAccessController.setPermission.selector,
+                        ipId,
+                        to,
+                        address(module),
+                        selector,
+                        AccessPermission.ALLOW
+                    )
+                )
+            )
+        );
+
+        data = abi.encodeWithSelector(
+            IAccessController.setPermission.selector,
+            ipId,
+            to,
+            address(module),
+            selector,
+            AccessPermission.ALLOW
+        );
+
+        bytes32 digest = MessageHashUtils.toTypedDataHash(
+            MetaTx.calculateDomainSeparator(ipId),
+            MetaTx.getExecuteStructHash(
+                MetaTx.Execute({
+                    to: address(accessControllerAddr),
+                    value: 0,
+                    data: data,
+                    nonce: expectedState,
+                    deadline: deadline
+                })
+            )
+        );
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerSk, digest);
+        signature = abi.encodePacked(r, s, v);
+    }
+
+    /// @dev Assert metadata for the IP.
+    function assertMetadata(address ipId, WorkflowStructs.IPMetadata memory expectedMetadata) internal view {
+        assertEq(coreMetadataViewModule.getMetadataURI(ipId), expectedMetadata.ipMetadataURI);
+        assertEq(coreMetadataViewModule.getMetadataHash(ipId), expectedMetadata.ipMetadataHash);
+        assertEq(coreMetadataViewModule.getNftMetadataHash(ipId), expectedMetadata.nftMetadataHash);
+    }
+}

--- a/test/integration/BaseIntegration.t.sol
+++ b/test/integration/BaseIntegration.t.sol
@@ -34,12 +34,7 @@ import { WorkflowStructs } from "../../contracts/lib/WorkflowStructs.sol";
 import { StoryProtocolCoreAddressManager } from "../../script/utils/StoryProtocolCoreAddressManager.sol";
 import { StoryProtocolPeripheryAddressManager } from "../../script/utils/StoryProtocolPeripheryAddressManager.sol";
 
-contract BaseIntegration is
-    Test,
-    Script,
-    StoryProtocolCoreAddressManager,
-    StoryProtocolPeripheryAddressManager
-{
+contract BaseIntegration is Test, Script, StoryProtocolCoreAddressManager, StoryProtocolPeripheryAddressManager {
     /// @dev Test user
     address internal testSender;
     uint256 internal testSenderSk;
@@ -118,7 +113,6 @@ contract BaseIntegration is
             nftMetadataURI: "test-nft-uri",
             nftMetadataHash: "test-nft-hash"
         });
-
     }
 
     function _beginBroadcast() internal {

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -1,0 +1,16 @@
+## PoC Periphery Integration Tests
+
+Integration tests for the periphery v1 contracts. These tests are designed to be run against an actual deployment of the periphery v1 contracts and will send real transactions to the blockchain.
+
+#### To run the tests:
+
+- Have the following environment variables set in your `.env` file:
+  - `RPC_URL`
+  - `TEST_SENDER_ADDRESS`
+  - `TEST_SENDER_SECRETKEY`
+
+- Then run the following command:
+
+```bash
+forge script test/integration/workflows/[IntegrationTestFileName].t.sol:[IntegrationTestContractName] --rpc-url=$RPC_URL -vvvv --broadcast --priority-gas-price=1 --legacy
+```

--- a/test/integration/workflows/DerivativeIntegration.t.sol
+++ b/test/integration/workflows/DerivativeIntegration.t.sol
@@ -1,0 +1,377 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+// external
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
+import { ICoreMetadataModule } from "@storyprotocol/core/interfaces/modules/metadata/ICoreMetadataModule.sol";
+import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
+import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingModule.sol";
+import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
+
+// contracts
+import { ISPGNFT } from "../../../contracts/interfaces/ISPGNFT.sol";
+import { WorkflowStructs } from "../../../contracts/lib/WorkflowStructs.sol";
+
+// test
+import { BaseIntegration } from "../BaseIntegration.t.sol";
+
+contract DerivativeIntegration is BaseIntegration {
+    using Strings for uint256;
+
+    ISPGNFT private spgNftContract;
+    address[] private parentIpIds;
+    uint256[] private parentLicenseTermIds;
+    address private parentLicenseTemplate;
+
+    /// @dev To use, run the following command:
+    /// forge script test/integration/workflows/DerivativeIntegration.t.sol:DerivativeIntegration \
+    /// --rpc-url=$TESTNET_URL -vvvv --broadcast --priority-gas-price=1 --legacy
+    function run() public override {
+        super.run();
+        _beginBroadcast();
+        _logTestStart("DerivativeIntegration");
+        _setUpTest();
+        _test_mintAndRegisterIpAndMakeDerivative();
+        _test_registerIpAndMakeDerivative();
+        _test_mintAndRegisterIpAndMakeDerivativeWithLicenseTokens();
+        _test_registerIpAndMakeDerivativeWithLicenseTokens();
+        _test_multicall_mintAndRegisterIpAndMakeDerivative();
+        _logTestEnd("DerivativeIntegration");
+        _endBroadcast();
+    }
+
+    function _test_mintAndRegisterIpAndMakeDerivative() private {
+        StoryUSD.mint(testSender, testMintFee * 2);
+        StoryUSD.approve(address(spgNftContract), testMintFee); // for nft minting fee
+        StoryUSD.approve(derivativeWorkflowsAddr, testMintFee); // for derivative minting fee
+        (address childIpId, uint256 childTokenId) = derivativeWorkflows.mintAndRegisterIpAndMakeDerivative({
+            spgNftContract: address(spgNftContract),
+            derivData: WorkflowStructs.MakeDerivative({
+                parentIpIds: parentIpIds,
+                licenseTemplate: parentLicenseTemplate,
+                licenseTermsIds: parentLicenseTermIds,
+                royaltyContext: ""
+            }),
+            ipMetadata: testIpMetadata,
+            recipient: testSender
+        });
+
+        assertTrue(ipAssetRegistry.isRegistered(childIpId));
+        assertEq(childTokenId, spgNftContract.totalSupply());
+        assertEq(spgNftContract.tokenURI(childTokenId), string.concat(testBaseURI, testIpMetadata.nftMetadataURI));
+        assertMetadata(childIpId, testIpMetadata);
+        (address licenseTemplateChild, uint256 licenseTermsIdChild) = licenseRegistry.getAttachedLicenseTerms(
+            childIpId,
+            0
+        );
+        assertEq(licenseTemplateChild, parentLicenseTemplate);
+        assertEq(licenseTermsIdChild, parentLicenseTermIds[0]);
+        assertEq(IIPAccount(payable(childIpId)).owner(), testSender);
+        assertParentChild({
+            ipIdParent: parentIpIds[0],
+            ipIdChild: childIpId,
+            expectedParentCount: parentIpIds.length,
+            expectedParentIndex: 0
+        });
+    }
+
+    function _test_registerIpAndMakeDerivative() private {
+        StoryUSD.mint(testSender, testMintFee);
+        StoryUSD.approve(address(spgNftContract), testMintFee); // for nft minting fee
+
+        uint256 childTokenId = spgNftContract.mint(testSender, testIpMetadata.nftMetadataURI);
+        address childIpId = ipAssetRegistry.ipId(block.chainid, address(spgNftContract), childTokenId);
+
+        uint256 deadline = block.timestamp + 1000;
+
+        (bytes memory sigMetadata, bytes32 sigRegisterState, ) = _getSetPermissionSigForPeriphery({
+            ipId: childIpId,
+            to: derivativeWorkflowsAddr,
+            module: coreMetadataModuleAddr,
+            selector: ICoreMetadataModule.setAll.selector,
+            deadline: deadline,
+            state: bytes32(0),
+            signerSk: testSenderSk
+        });
+
+        (bytes memory sigRegister, bytes32 expectedState, ) = _getSetPermissionSigForPeriphery({
+            ipId: childIpId,
+            to: derivativeWorkflowsAddr,
+            module: licensingModuleAddr,
+            selector: ILicensingModule.registerDerivative.selector,
+            deadline: deadline,
+            state: sigRegisterState,
+            signerSk: testSenderSk
+        });
+
+        StoryUSD.mint(testSender, testMintFee);
+        StoryUSD.approve(derivativeWorkflowsAddr, testMintFee); // for derivative minting fee
+        derivativeWorkflows.registerIpAndMakeDerivative({
+            nftContract: address(spgNftContract),
+            tokenId: childTokenId,
+            derivData: WorkflowStructs.MakeDerivative({
+                parentIpIds: parentIpIds,
+                licenseTemplate: parentLicenseTemplate,
+                licenseTermsIds: parentLicenseTermIds,
+                royaltyContext: ""
+            }),
+            ipMetadata: testIpMetadata,
+            sigMetadata: WorkflowStructs.SignatureData({
+                signer: testSender,
+                deadline: deadline,
+                signature: sigMetadata
+            }),
+            sigRegister: WorkflowStructs.SignatureData({
+                signer: testSender,
+                deadline: deadline,
+                signature: sigRegister
+            })
+        });
+
+        assertTrue(ipAssetRegistry.isRegistered(childIpId));
+        assertEq(spgNftContract.tokenURI(childTokenId), string.concat(testBaseURI, testIpMetadata.nftMetadataURI));
+        assertMetadata(childIpId, testIpMetadata);
+        (address licenseTemplateChild, uint256 licenseTermsIdChild) = licenseRegistry.getAttachedLicenseTerms(
+            childIpId,
+            0
+        );
+        assertEq(licenseTemplateChild, parentLicenseTemplate);
+        assertEq(licenseTermsIdChild, parentLicenseTermIds[0]);
+        assertEq(IIPAccount(payable(childIpId)).owner(), testSender);
+        assertEq(IIPAccount(payable(childIpId)).state(), expectedState);
+        assertParentChild({
+            ipIdParent: parentIpIds[0],
+            ipIdChild: childIpId,
+            expectedParentCount: parentIpIds.length,
+            expectedParentIndex: 0
+        });
+    }
+
+    function _test_mintAndRegisterIpAndMakeDerivativeWithLicenseTokens() private {
+        StoryUSD.mint(testSender, testMintFee);
+        StoryUSD.approve(royaltyModuleAddr, testMintFee); // for license token minting fee
+        uint256 startLicenseTokenId = licensingModule.mintLicenseTokens({
+            licensorIpId: parentIpIds[0],
+            licenseTemplate: parentLicenseTemplate,
+            licenseTermsId: parentLicenseTermIds[0],
+            amount: 1,
+            receiver: testSender,
+            royaltyContext: ""
+        });
+
+        // Need so that derivative workflows can transfer the license tokens
+        licenseToken.approve(derivativeWorkflowsAddr, startLicenseTokenId);
+
+        uint256[] memory licenseTokenIds = new uint256[](1);
+        licenseTokenIds[0] = startLicenseTokenId;
+
+        StoryUSD.mint(testSender, testMintFee);
+        StoryUSD.approve(address(spgNftContract), testMintFee); // for nft minting fee
+        (address childIpId, uint256 childTokenId) = derivativeWorkflows
+            .mintAndRegisterIpAndMakeDerivativeWithLicenseTokens({
+                spgNftContract: address(spgNftContract),
+                licenseTokenIds: licenseTokenIds,
+                royaltyContext: "",
+                ipMetadata: testIpMetadata,
+                recipient: testSender
+            });
+
+        assertTrue(ipAssetRegistry.isRegistered(childIpId));
+        assertEq(childTokenId, spgNftContract.totalSupply());
+        assertEq(spgNftContract.tokenURI(childTokenId), string.concat(testBaseURI, testIpMetadata.nftMetadataURI));
+        assertMetadata(childIpId, testIpMetadata);
+        (address childLicenseTemplate, uint256 childLicenseTermsId) = licenseRegistry.getAttachedLicenseTerms(
+            childIpId,
+            0
+        );
+        assertEq(childLicenseTemplate, parentLicenseTemplate);
+        assertEq(childLicenseTermsId, parentLicenseTermIds[0]);
+        assertEq(IIPAccount(payable(childIpId)).owner(), testSender);
+
+        assertParentChild({
+            ipIdParent: parentIpIds[0],
+            ipIdChild: childIpId,
+            expectedParentCount: parentIpIds.length,
+            expectedParentIndex: 0
+        });
+    }
+
+    function _test_registerIpAndMakeDerivativeWithLicenseTokens() private {
+        StoryUSD.mint(testSender, testMintFee);
+        StoryUSD.approve(address(spgNftContract), testMintFee); // for nft minting fee
+        uint256 childTokenId = spgNftContract.mint(testSender, testIpMetadata.nftMetadataURI);
+        address childIpId = ipAssetRegistry.ipId(block.chainid, address(spgNftContract), childTokenId);
+
+        uint256 deadline = block.timestamp + 1000;
+
+        StoryUSD.mint(testSender, testMintFee);
+        StoryUSD.approve(royaltyModuleAddr, testMintFee); // for license token minting fee
+        uint256 startLicenseTokenId = licensingModule.mintLicenseTokens({
+            licensorIpId: parentIpIds[0],
+            licenseTemplate: parentLicenseTemplate,
+            licenseTermsId: parentLicenseTermIds[0],
+            amount: 1,
+            receiver: testSender,
+            royaltyContext: ""
+        });
+
+        uint256[] memory licenseTokenIds = new uint256[](1);
+        licenseTokenIds[0] = startLicenseTokenId;
+        licenseToken.approve(derivativeWorkflowsAddr, startLicenseTokenId);
+
+        (bytes memory sigMetadata, bytes32 sigRegisterState, ) = _getSetPermissionSigForPeriphery({
+            ipId: childIpId,
+            to: derivativeWorkflowsAddr,
+            module: coreMetadataModuleAddr,
+            selector: ICoreMetadataModule.setAll.selector,
+            deadline: deadline,
+            state: bytes32(0),
+            signerSk: testSenderSk
+        });
+        (bytes memory sigRegister, bytes32 expectedState, ) = _getSetPermissionSigForPeriphery({
+            ipId: childIpId,
+            to: derivativeWorkflowsAddr,
+            module: licensingModuleAddr,
+            selector: ILicensingModule.registerDerivativeWithLicenseTokens.selector,
+            deadline: deadline,
+            state: sigRegisterState,
+            signerSk: testSenderSk
+        });
+
+        derivativeWorkflows.registerIpAndMakeDerivativeWithLicenseTokens({
+            nftContract: address(spgNftContract),
+            tokenId: childTokenId,
+            licenseTokenIds: licenseTokenIds,
+            royaltyContext: "",
+            ipMetadata: testIpMetadata,
+            sigMetadata: WorkflowStructs.SignatureData({
+                signer: testSender,
+                deadline: deadline,
+                signature: sigMetadata
+            }),
+            sigRegister: WorkflowStructs.SignatureData({
+                signer: testSender,
+                deadline: deadline,
+                signature: sigRegister
+            })
+        });
+
+        assertTrue(ipAssetRegistry.isRegistered(childIpId));
+        assertEq(IIPAccount(payable(childIpId)).state(), expectedState);
+        assertMetadata(childIpId, testIpMetadata);
+        {
+            (address childLicenseTemplate, uint256 childLicenseTermsId) = licenseRegistry.getAttachedLicenseTerms(
+                childIpId,
+                0
+            );
+            assertEq(childLicenseTemplate, parentLicenseTemplate);
+            assertEq(childLicenseTermsId, parentLicenseTermIds[0]);
+        }
+        assertParentChild({
+            ipIdParent: parentIpIds[0],
+            ipIdChild: childIpId,
+            expectedParentCount: parentIpIds.length,
+            expectedParentIndex: 0
+        });
+    }
+
+    function _test_multicall_mintAndRegisterIpAndMakeDerivative() private {
+        uint256 numCalls = 10;
+        bytes[] memory data = new bytes[](numCalls);
+        for (uint256 i = 0; i < numCalls; i++) {
+            data[i] = abi.encodeWithSelector(
+                derivativeWorkflows.mintAndRegisterIpAndMakeDerivative.selector,
+                address(spgNftContract),
+                WorkflowStructs.MakeDerivative({
+                    parentIpIds: parentIpIds,
+                    licenseTemplate: parentLicenseTemplate,
+                    licenseTermsIds: parentLicenseTermIds,
+                    royaltyContext: ""
+                }),
+                testIpMetadata,
+                testSender
+            );
+        }
+
+        StoryUSD.mint(testSender, testMintFee * numCalls * 2);
+        StoryUSD.approve(address(spgNftContract), testMintFee * numCalls);
+        StoryUSD.approve(derivativeWorkflowsAddr, testMintFee * numCalls);
+
+        bytes[] memory results = derivativeWorkflows.multicall(data);
+
+        for (uint256 i = 0; i < numCalls; i++) {
+            (address childIpId, uint256 childTokenId) = abi.decode(results[i], (address, uint256));
+            assertTrue(ipAssetRegistry.isRegistered(childIpId));
+            assertEq(childTokenId, spgNftContract.totalSupply() - numCalls + i + 1);
+            assertEq(spgNftContract.tokenURI(childTokenId), string.concat(testBaseURI, testIpMetadata.nftMetadataURI));
+            assertMetadata(childIpId, testIpMetadata);
+            (address childLicenseTemplate, uint256 childLicenseTermsId) = licenseRegistry.getAttachedLicenseTerms(
+                childIpId,
+                0
+            );
+            assertEq(childLicenseTemplate, parentLicenseTemplate);
+            assertEq(childLicenseTermsId, parentLicenseTermIds[0]);
+            assertEq(IIPAccount(payable(childIpId)).owner(), testSender);
+            assertParentChild({
+                ipIdParent: parentIpIds[0],
+                ipIdChild: childIpId,
+                expectedParentCount: parentIpIds.length,
+                expectedParentIndex: 0
+            });
+        }
+    }
+
+    function _setUpTest() private {
+        spgNftContract = ISPGNFT(
+            registrationWorkflows.createCollection(
+                ISPGNFT.InitParams({
+                    name: testCollectionName,
+                    symbol: testCollectionSymbol,
+                    baseURI: testBaseURI,
+                    maxSupply: testMaxSupply,
+                    mintFee: testMintFee,
+                    mintFeeToken: testMintFeeToken,
+                    mintFeeRecipient: testSender,
+                    owner: testSender,
+                    mintOpen: true,
+                    isPublicMinting: true
+                })
+            )
+        );
+
+        StoryUSD.mint(testSender, testMintFee);
+        StoryUSD.approve(address(spgNftContract), testMintFee);
+        (address parentIpId, , uint256 licenseTermsIdParent) = licenseAttachmentWorkflows
+            .mintAndRegisterIpAndAttachPILTerms({
+                spgNftContract: address(spgNftContract),
+                recipient: testSender,
+                ipMetadata: testIpMetadata,
+                terms: PILFlavors.commercialUse({
+                    mintingFee: testMintFee,
+                    currencyToken: testMintFeeToken,
+                royaltyPolicy: royaltyPolicyLRPAddr
+                })
+            });
+
+        parentIpIds = new address[](1);
+        parentIpIds[0] = parentIpId;
+
+        parentLicenseTermIds = new uint256[](1);
+        parentLicenseTermIds[0] = licenseTermsIdParent;
+        parentLicenseTemplate = pilTemplateAddr;
+    }
+
+    /// @dev Assert parent and derivative relationship.
+    function assertParentChild(
+        address ipIdParent,
+        address ipIdChild,
+        uint256 expectedParentCount,
+        uint256 expectedParentIndex
+    ) internal view {
+        assertTrue(licenseRegistry.hasDerivativeIps(ipIdParent));
+        assertTrue(licenseRegistry.isDerivativeIp(ipIdChild));
+        assertTrue(licenseRegistry.isParentIp({ parentIpId: ipIdParent, childIpId: ipIdChild }));
+        assertEq(licenseRegistry.getParentIpCount(ipIdChild), expectedParentCount);
+        assertEq(licenseRegistry.getParentIp(ipIdChild, expectedParentIndex), ipIdParent);
+    }
+}

--- a/test/integration/workflows/DerivativeIntegration.t.sol
+++ b/test/integration/workflows/DerivativeIntegration.t.sol
@@ -349,7 +349,7 @@ contract DerivativeIntegration is BaseIntegration {
                 terms: PILFlavors.commercialUse({
                     mintingFee: testMintFee,
                     currencyToken: testMintFeeToken,
-                royaltyPolicy: royaltyPolicyLRPAddr
+                    royaltyPolicy: royaltyPolicyLRPAddr
                 })
             });
 

--- a/test/integration/workflows/GroupingIntegration.t.sol
+++ b/test/integration/workflows/GroupingIntegration.t.sol
@@ -161,10 +161,7 @@ contract GroupingIntegration is BaseIntegration {
         }
 
         // check the license terms is correctly attached to the group IPA
-        (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(
-            newGroupId,
-            0
-        );
+        (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(newGroupId, 0);
         assertEq(licenseTemplate, testLicenseTemplate);
         assertEq(licenseTermsId, testLicenseTermsId);
     }

--- a/test/integration/workflows/GroupingIntegration.t.sol
+++ b/test/integration/workflows/GroupingIntegration.t.sol
@@ -1,0 +1,386 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+// external
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
+import { IGroupingModule } from "@storyprotocol/core/interfaces/modules/grouping/IGroupingModule.sol";
+import { IGroupIPAssetRegistry } from "@storyprotocol/core/interfaces/registries/IGroupIPAssetRegistry.sol";
+import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
+import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
+
+// contracts
+import { ISPGNFT } from "../../../contracts/interfaces/ISPGNFT.sol";
+import { LicensingHelper } from "../../../contracts/lib/LicensingHelper.sol";
+import { WorkflowStructs } from "../../../contracts/lib/WorkflowStructs.sol";
+
+// test
+import { BaseIntegration } from "../BaseIntegration.t.sol";
+
+contract GroupingIntegration is BaseIntegration {
+    using Strings for uint256;
+
+    ISPGNFT private spgNftContract;
+    address private groupId;
+    address private testLicenseTemplate;
+    uint256 private testLicenseTermsId;
+    address[] private ipIds;
+
+    /// @dev To use, run the following command:
+    /// forge script test/integration/workflows/GroupingIntegration.t.sol:GroupingIntegration \
+    /// --rpc-url=$TESTNET_URL -vvvv --broadcast --priority-gas-price=1 --legacy
+    function run() public override {
+        super.run();
+        _beginBroadcast();
+        _logTestStart("GroupingIntegration");
+        _setUpTest();
+        _test_GroupingIntegration_mintAndRegisterIpAndAttachLicenseAndAddToGroup();
+        _test_GroupingIntegration_registerIpAndAttachLicenseAndAddToGroup();
+        _test_GroupingIntegration_registerGroupAndAttachLicenseAndAddIps();
+        _test_GroupingIntegration_multicall_mintAndRegisterIpAndAttachLicenseAndAddToGroup();
+        _test_GroupingIntegration_multicall_registerIpAndAttachLicenseAndAddToGroup();
+        _logTestEnd("GroupingIntegration");
+        _endBroadcast();
+    }
+
+    function _test_GroupingIntegration_mintAndRegisterIpAndAttachLicenseAndAddToGroup() private {
+        uint256 deadline = block.timestamp + 1000;
+
+        // Get the signature for setting the permission for calling `addIp` function in `GroupingModule`
+        // from the Group IP owner
+        (bytes memory sigAddToGroup, bytes32 expectedState, ) = _getSetPermissionSigForPeriphery({
+            ipId: groupId,
+            to: groupingWorkflowsAddr,
+            module: groupingModuleAddr,
+            selector: IGroupingModule.addIp.selector,
+            deadline: deadline,
+            state: IIPAccount(payable(groupId)).state(),
+            signerSk: testSenderSk
+        });
+
+        StoryUSD.mint(testSender, testMintFee);
+        StoryUSD.approve(address(spgNftContract), testMintFee);
+        (address ipId, uint256 tokenId) = groupingWorkflows.mintAndRegisterIpAndAttachLicenseAndAddToGroup({
+            spgNftContract: address(spgNftContract),
+            groupId: groupId,
+            recipient: testSender,
+            ipMetadata: testIpMetadata,
+            licenseTemplate: testLicenseTemplate,
+            licenseTermsId: testLicenseTermsId,
+            sigAddToGroup: WorkflowStructs.SignatureData({
+                signer: testSender,
+                deadline: deadline,
+                signature: sigAddToGroup
+            })
+        });
+
+        assertEq(IIPAccount(payable(groupId)).state(), expectedState);
+        assertTrue(ipAssetRegistry.isRegistered(ipId));
+        assertTrue(IGroupIPAssetRegistry(ipAssetRegistryAddr).containsIp(groupId, ipId));
+        assertEq(spgNftContract.tokenURI(tokenId), string.concat(testBaseURI, testIpMetadata.nftMetadataURI));
+        assertMetadata(ipId, testIpMetadata);
+        (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId, 0);
+        assertEq(licenseTemplate, testLicenseTemplate);
+        assertEq(licenseTermsId, testLicenseTermsId);
+    }
+
+    function _test_GroupingIntegration_registerIpAndAttachLicenseAndAddToGroup() private {
+        StoryUSD.mint(testSender, testMintFee);
+        StoryUSD.approve(address(spgNftContract), testMintFee);
+        uint256 tokenId = spgNftContract.mint(testSender, testIpMetadata.nftMetadataURI);
+
+        // get the expected IP ID
+        address expectedIpId = ipAssetRegistry.ipId(block.chainid, address(spgNftContract), tokenId);
+
+        uint256 deadline = block.timestamp + 1000;
+
+        // Get the signature for setting the permission for calling `setAll` (IP metadata) and `attachLicenseTerms`
+        // functions in `coreMetadataModule` and `licensingModule` from the IP owner
+        (bytes memory sigMetadataAndAttach, , ) = _getSetBatchPermissionSigForPeriphery({
+            ipId: expectedIpId,
+            permissionList: _getMetadataAndAttachTermsPermissionList(expectedIpId, groupingWorkflowsAddr),
+            deadline: deadline,
+            state: bytes32(0),
+            signerSk: testSenderSk
+        });
+
+        // Get the signature for setting the permission for calling `addIp` function in `GroupingModule`
+        // from the Group IP owner
+        (bytes memory sigAddToGroup, , ) = _getSetPermissionSigForPeriphery({
+            ipId: groupId,
+            to: groupingWorkflowsAddr,
+            module: groupingModuleAddr,
+            selector: IGroupingModule.addIp.selector,
+            deadline: deadline,
+            state: IIPAccount(payable(groupId)).state(),
+            signerSk: testSenderSk
+        });
+
+        address ipId = groupingWorkflows.registerIpAndAttachLicenseAndAddToGroup({
+            nftContract: address(spgNftContract),
+            tokenId: tokenId,
+            groupId: groupId,
+            licenseTemplate: testLicenseTemplate,
+            licenseTermsId: testLicenseTermsId,
+            ipMetadata: testIpMetadata,
+            sigMetadataAndAttach: WorkflowStructs.SignatureData({
+                signer: testSender,
+                deadline: deadline,
+                signature: sigMetadataAndAttach
+            }),
+            sigAddToGroup: WorkflowStructs.SignatureData({
+                signer: testSender,
+                deadline: deadline,
+                signature: sigAddToGroup
+            })
+        });
+
+        assertEq(ipId, expectedIpId);
+        assertTrue(ipAssetRegistry.isRegistered(ipId));
+        assertTrue(IGroupIPAssetRegistry(ipAssetRegistryAddr).containsIp(groupId, ipId));
+        assertMetadata(ipId, testIpMetadata);
+        (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId, 0);
+        assertEq(licenseTemplate, testLicenseTemplate);
+        assertEq(licenseTermsId, testLicenseTermsId);
+    }
+
+    function _test_GroupingIntegration_registerGroupAndAttachLicenseAndAddIps() private {
+        address newGroupId = groupingWorkflows.registerGroupAndAttachLicenseAndAddIps({
+            groupPool: groupRewardPool,
+            ipIds: ipIds,
+            licenseTemplate: testLicenseTemplate,
+            licenseTermsId: testLicenseTermsId
+        });
+
+        // check the group IPA is registered
+        assertTrue(IGroupIPAssetRegistry(ipAssetRegistryAddr).isRegisteredGroup(newGroupId));
+
+        // check all the individual IPs are added to the new group
+        assertEq(IGroupIPAssetRegistry(ipAssetRegistryAddr).totalMembers(newGroupId), ipIds.length);
+        for (uint256 i = 0; i < ipIds.length; i++) {
+            assertTrue(IGroupIPAssetRegistry(ipAssetRegistryAddr).containsIp(newGroupId, ipIds[i]));
+        }
+
+        // check the license terms is correctly attached to the group IPA
+        (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(
+            newGroupId,
+            0
+        );
+        assertEq(licenseTemplate, testLicenseTemplate);
+        assertEq(licenseTermsId, testLicenseTermsId);
+    }
+
+    function _test_GroupingIntegration_multicall_mintAndRegisterIpAndAttachLicenseAndAddToGroup() private {
+        uint256 deadline = block.timestamp + 1000;
+        uint256 numCalls = 10;
+        // Get the signatures for setting the permission for calling `addIp` function in `GroupingModule`
+        // from the Group IP owner
+        bytes[] memory sigsAddToGroup = new bytes[](numCalls);
+        bytes32 expectedStates = IIPAccount(payable(groupId)).state();
+        for (uint256 i = 0; i < numCalls; i++) {
+            (sigsAddToGroup[i], expectedStates, ) = _getSetPermissionSigForPeriphery({
+                ipId: groupId,
+                to: groupingWorkflowsAddr,
+                module: groupingModuleAddr,
+                selector: IGroupingModule.addIp.selector,
+                deadline: deadline,
+                state: expectedStates,
+                signerSk: testSenderSk
+            });
+        }
+
+        // setup call data for batch calling `numCalls` `mintAndRegisterIpAndAttachLicenseAndAddToGroup`
+        bytes[] memory data = new bytes[](numCalls);
+        for (uint256 i = 0; i < numCalls; i++) {
+            data[i] = abi.encodeWithSelector(
+                groupingWorkflows.mintAndRegisterIpAndAttachLicenseAndAddToGroup.selector,
+                address(spgNftContract),
+                groupId,
+                testSender,
+                testLicenseTemplate,
+                testLicenseTermsId,
+                testIpMetadata,
+                WorkflowStructs.SignatureData({ signer: testSender, deadline: deadline, signature: sigsAddToGroup[i] })
+            );
+        }
+
+        StoryUSD.mint(testSender, testMintFee * numCalls);
+        StoryUSD.approve(address(spgNftContract), testMintFee * numCalls);
+
+        // batch call `mintAndRegisterIpAndAttachLicenseAndAddToGroup`
+        bytes[] memory results = groupingWorkflows.multicall(data);
+
+        // check each IP is registered, added to the group, and metadata is set, license terms are attached
+        address ipId;
+        uint256 tokenId;
+        for (uint256 i = 0; i < numCalls; i++) {
+            (ipId, tokenId) = abi.decode(results[i], (address, uint256));
+            assertTrue(ipAssetRegistry.isRegistered(ipId));
+            assertTrue(IGroupIPAssetRegistry(ipAssetRegistryAddr).containsIp(groupId, ipId));
+            assertEq(spgNftContract.tokenURI(tokenId), string.concat(testBaseURI, testIpMetadata.nftMetadataURI));
+            assertMetadata(ipId, testIpMetadata);
+            (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId, 0);
+            assertEq(licenseTemplate, testLicenseTemplate);
+            assertEq(licenseTermsId, testLicenseTermsId);
+        }
+    }
+
+    function _test_GroupingIntegration_multicall_registerIpAndAttachLicenseAndAddToGroup() private {
+        uint256 numCalls = 10;
+
+        StoryUSD.mint(testSender, testMintFee * numCalls);
+        StoryUSD.approve(address(spgNftContract), testMintFee * numCalls);
+        // mint a NFT from the spgNftContract
+        uint256[] memory tokenIds = new uint256[](numCalls);
+        for (uint256 i = 0; i < numCalls; i++) {
+            tokenIds[i] = spgNftContract.mint(testSender, testIpMetadata.nftMetadataURI);
+        }
+
+        // get the expected IP ID
+        address[] memory expectedIpIds = new address[](numCalls);
+        for (uint256 i = 0; i < numCalls; i++) {
+            expectedIpIds[i] = ipAssetRegistry.ipId(block.chainid, address(spgNftContract), tokenIds[i]);
+        }
+
+        uint256 deadline = block.timestamp + 1000;
+
+        // Get the signatures for setting the permission for calling `setAll` (IP metadata) and `attachLicenseTerms`
+        // functions in `coreMetadataModule` and `licensingModule` from the IP owner
+        bytes[] memory sigsMetadataAndAttach = new bytes[](numCalls);
+        for (uint256 i = 0; i < numCalls; i++) {
+            (sigsMetadataAndAttach[i], , ) = _getSetBatchPermissionSigForPeriphery({
+                ipId: expectedIpIds[i],
+                permissionList: _getMetadataAndAttachTermsPermissionList(expectedIpIds[i], address(groupingWorkflows)),
+                deadline: deadline,
+                state: bytes32(0),
+                signerSk: testSenderSk
+            });
+        }
+
+        // Get the signatures for setting the permission for calling `addIp` function in `GroupingModule`
+        // from the Group IP owner
+        bytes[] memory sigsAddToGroup = new bytes[](numCalls);
+        bytes32 expectedStates = IIPAccount(payable(groupId)).state();
+        for (uint256 i = 0; i < numCalls; i++) {
+            (sigsAddToGroup[i], expectedStates, ) = _getSetPermissionSigForPeriphery({
+                ipId: groupId,
+                to: groupingWorkflowsAddr,
+                module: groupingModuleAddr,
+                selector: IGroupingModule.addIp.selector,
+                deadline: deadline,
+                state: expectedStates,
+                signerSk: testSenderSk
+            });
+        }
+
+        // setup call data for batch calling 10 `registerIpAndAttachLicenseAndAddToGroup`
+        bytes[] memory data = new bytes[](numCalls);
+        for (uint256 i = 0; i < numCalls; i++) {
+            data[i] = abi.encodeWithSelector(
+                groupingWorkflows.registerIpAndAttachLicenseAndAddToGroup.selector,
+                address(spgNftContract),
+                tokenIds[i],
+                groupId,
+                testLicenseTemplate,
+                testLicenseTermsId,
+                testIpMetadata,
+                WorkflowStructs.SignatureData({
+                    signer: testSender,
+                    deadline: deadline,
+                    signature: sigsMetadataAndAttach[i]
+                }),
+                WorkflowStructs.SignatureData({ signer: testSender, deadline: deadline, signature: sigsAddToGroup[i] })
+            );
+        }
+
+        // batch call `registerIpAndAttachLicenseAndAddToGroup`
+        bytes[] memory results = groupingWorkflows.multicall(data);
+
+        // check each IP is registered, added to the group, and metadata is set, license terms are attached
+        address ipId;
+        for (uint256 i = 0; i < numCalls; i++) {
+            ipId = abi.decode(results[i], (address));
+            assertEq(ipId, expectedIpIds[i]);
+            assertTrue(ipAssetRegistry.isRegistered(ipId));
+            assertTrue(IGroupIPAssetRegistry(ipAssetRegistryAddr).containsIp(groupId, ipId));
+            assertMetadata(ipId, testIpMetadata);
+            (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId, 0);
+            assertEq(licenseTemplate, testLicenseTemplate);
+            assertEq(licenseTermsId, testLicenseTermsId);
+        }
+    }
+
+    function _setUpTest() private {
+        testLicenseTemplate = pilTemplateAddr;
+        testLicenseTermsId = pilTemplate.registerLicenseTerms(
+            // minting fee is set to 0 beacause currently core protocol requires group IP's minting fee to be 0
+            PILFlavors.commercialUse(0, testMintFeeToken, royaltyPolicyLRPAddr)
+        );
+
+        // setup a group
+        {
+            groupId = groupingModule.registerGroup(groupRewardPool);
+            LicensingHelper.attachLicenseTerms(
+                groupId,
+                licensingModuleAddr,
+                licenseRegistryAddr,
+                testLicenseTemplate,
+                testLicenseTermsId
+            );
+        }
+
+        // setup a collection and IPs
+        {
+            spgNftContract = ISPGNFT(
+                registrationWorkflows.createCollection(
+                    ISPGNFT.InitParams({
+                        name: testCollectionName,
+                        symbol: testCollectionSymbol,
+                        baseURI: testBaseURI,
+                        maxSupply: testMaxSupply,
+                        mintFee: testMintFee,
+                        mintFeeToken: testMintFeeToken,
+                        mintFeeRecipient: testSender,
+                        owner: testSender,
+                        mintOpen: true,
+                        isPublicMinting: true
+                    })
+                )
+            );
+
+            uint256 numIps = 10;
+
+            bytes[] memory data = new bytes[](numIps);
+            for (uint256 i = 0; i < numIps; i++) {
+                data[i] = abi.encodeWithSelector(
+                    registrationWorkflows.mintAndRegisterIp.selector,
+                    address(spgNftContract),
+                    testSender,
+                    testIpMetadata
+                );
+            }
+
+            StoryUSD.mint(testSender, testMintFee * numIps);
+            StoryUSD.approve(address(spgNftContract), testMintFee * numIps);
+
+            // batch call `mintAndRegisterIp`
+            bytes[] memory results = registrationWorkflows.multicall(data);
+
+            // decode the multicall results to get the IP IDs
+            ipIds = new address[](numIps);
+            for (uint256 i = 0; i < numIps; i++) {
+                (ipIds[i], ) = abi.decode(results[i], (address, uint256));
+            }
+
+            // attach license terms to the IPs
+            for (uint256 i = 0; i < numIps; i++) {
+                LicensingHelper.attachLicenseTerms(
+                    ipIds[i],
+                    licensingModuleAddr,
+                    licenseRegistryAddr,
+                    pilTemplateAddr,
+                    testLicenseTermsId
+                );
+            }
+        }
+    }
+}

--- a/test/integration/workflows/LicenseAttachmentIntegration.t.sol
+++ b/test/integration/workflows/LicenseAttachmentIntegration.t.sol
@@ -1,0 +1,203 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+// external
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
+import { ICoreMetadataModule } from "@storyprotocol/core/interfaces/modules/metadata/ICoreMetadataModule.sol";
+import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
+import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingModule.sol";
+import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
+import { PILTerms } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
+
+// contracts
+import { ISPGNFT } from "../../../contracts/interfaces/ISPGNFT.sol";
+import { WorkflowStructs } from "../../../contracts/lib/WorkflowStructs.sol";
+
+// test
+import { BaseIntegration } from "../BaseIntegration.t.sol";
+
+contract LicenseAttachmentIntegration is BaseIntegration {
+    using Strings for uint256;
+
+    ISPGNFT private spgNftContract;
+    PILTerms private commUseTerms;
+
+    /// @dev To use, run the following command:
+    /// forge script test/integration/workflows/LicenseAttachmentIntegration.t.sol:LicenseAttachmentIntegration \
+    /// --rpc-url=$TESTNET_URL -vvvv --broadcast --priority-gas-price=1 --legacy
+    function run() public override {
+        super.run();
+        _beginBroadcast();
+        _logTestStart("LicenseAttachmentIntegration");
+        _setUpTest();
+        _test_LicenseAttachmentIntegration_registerPILTermsAndAttach();
+        _test_LicenseAttachmentIntegration_mintAndRegisterIpAndAttachPILTerms();
+        _test_LicenseAttachmentIntegration_registerIpAndAttachPILTerms();
+        _logTestEnd("LicenseAttachmentIntegration");
+        _endBroadcast();
+    }
+
+    function _test_LicenseAttachmentIntegration_registerPILTermsAndAttach() private {
+        StoryUSD.mint(testSender, testMintFee);
+        StoryUSD.approve(address(spgNftContract), testMintFee);
+
+        (address ipId, ) = registrationWorkflows.mintAndRegisterIp({
+            spgNftContract: address(spgNftContract),
+            recipient: testSender,
+            ipMetadata: testIpMetadata
+        });
+
+        uint256 deadline = block.timestamp + 1000;
+        (bytes memory signature, , bytes memory data) = _getSetPermissionSigForPeriphery({
+            ipId: ipId,
+            to: licenseAttachmentWorkflowsAddr,
+            module: licensingModuleAddr,
+            selector: ILicensingModule.attachLicenseTerms.selector,
+            deadline: deadline,
+            state: IIPAccount(payable(ipId)).state(),
+            signerSk: testSenderSk
+        });
+
+        IIPAccount(payable(ipId)).executeWithSig({
+            to: accessControllerAddr,
+            value: 0,
+            data: data,
+            signer: testSender,
+            deadline: deadline,
+            signature: signature
+        });
+
+        uint256 licenseTermsId = licenseAttachmentWorkflows.registerPILTermsAndAttach({
+            ipId: ipId,
+            terms: commUseTerms
+        });
+
+        assertEq(licenseTermsId, pilTemplate.getLicenseTermsId(commUseTerms));
+    }
+
+    function _test_LicenseAttachmentIntegration_mintAndRegisterIpAndAttachPILTerms() private {
+        // IP 1
+        {
+            StoryUSD.mint(testSender, testMintFee);
+            StoryUSD.approve(address(spgNftContract), testMintFee);
+
+            (address ipId1, uint256 tokenId1, uint256 licenseTermsId1) = licenseAttachmentWorkflows
+            .mintAndRegisterIpAndAttachPILTerms({
+                spgNftContract: address(spgNftContract),
+                recipient: testSender,
+                ipMetadata: testIpMetadata,
+                terms: commUseTerms
+            });
+            assertTrue(ipAssetRegistry.isRegistered(ipId1));
+            assertEq(tokenId1, spgNftContract.totalSupply());
+            assertEq(licenseTermsId1, pilTemplate.getLicenseTermsId(commUseTerms));
+            assertEq(spgNftContract.tokenURI(tokenId1), string.concat(testBaseURI, testIpMetadata.nftMetadataURI));
+            assertMetadata(ipId1, testIpMetadata);
+            (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId1, 0);
+            assertEq(licenseTemplate, pilTemplateAddr);
+            assertEq(licenseTermsId, licenseTermsId1);
+        }
+
+        // IP 2
+        {
+            StoryUSD.mint(testSender, testMintFee);
+            StoryUSD.approve(address(spgNftContract), testMintFee);
+
+            (address ipId2, uint256 tokenId2, uint256 licenseTermsId2) = licenseAttachmentWorkflows
+                .mintAndRegisterIpAndAttachPILTerms({
+                    spgNftContract: address(spgNftContract),
+                    recipient: testSender,
+                    ipMetadata: testIpMetadata,
+                    terms: commUseTerms
+                });
+            assertTrue(ipAssetRegistry.isRegistered(ipId2));
+            assertEq(tokenId2, spgNftContract.totalSupply());
+            assertEq(licenseTermsId2, pilTemplate.getLicenseTermsId(commUseTerms));
+            assertEq(spgNftContract.tokenURI(tokenId2), string.concat(testBaseURI, testIpMetadata.nftMetadataURI));
+            assertMetadata(ipId2, testIpMetadata);
+            (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId2, 0);
+            assertEq(licenseTemplate, pilTemplateAddr);
+            assertEq(licenseTermsId, licenseTermsId2);
+        }
+    }
+
+    function _test_LicenseAttachmentIntegration_registerIpAndAttachPILTerms() private {
+        StoryUSD.mint(testSender, testMintFee);
+        StoryUSD.approve(address(spgNftContract), testMintFee);
+
+        uint256 tokenId = spgNftContract.mint(testSender, "");
+        address expectedIpId = ipAssetRegistry.ipId(block.chainid, address(spgNftContract), tokenId);
+
+        uint256 deadline = block.timestamp + 1000;
+
+        (bytes memory sigMetadata, bytes32 sigAttachState, ) = _getSetPermissionSigForPeriphery({
+            ipId: expectedIpId,
+            to: licenseAttachmentWorkflowsAddr,
+            module: coreMetadataModuleAddr,
+            selector: ICoreMetadataModule.setAll.selector,
+            deadline: deadline,
+            state: bytes32(0),
+            signerSk: testSenderSk
+        });
+
+        (bytes memory sigAttach, bytes32 expectedState, ) = _getSetPermissionSigForPeriphery({
+            ipId: expectedIpId,
+            to: licenseAttachmentWorkflowsAddr,
+            module: licensingModuleAddr,
+            selector: ILicensingModule.attachLicenseTerms.selector,
+            deadline: deadline,
+            state: sigAttachState,
+            signerSk: testSenderSk
+        });
+
+        (address ipId, uint256 licenseTermsId) = licenseAttachmentWorkflows.registerIpAndAttachPILTerms({
+            nftContract: address(spgNftContract),
+            tokenId: tokenId,
+            ipMetadata: testIpMetadata,
+            terms: commUseTerms,
+            sigMetadata: WorkflowStructs.SignatureData({
+                signer: testSender,
+                deadline: deadline,
+                signature: sigMetadata
+            }),
+            sigAttach: WorkflowStructs.SignatureData({
+                signer: testSender,
+                deadline: deadline,
+                signature: sigAttach
+            })
+        });
+
+        assertEq(ipId, expectedIpId);
+        assertTrue(ipAssetRegistry.isRegistered(ipId));
+        assertEq(IIPAccount(payable(ipId)).state(), expectedState);
+        (address expectedLicenseTemplate, uint256 expectedLicenseTermsId) = licenseRegistry
+            .getAttachedLicenseTerms(expectedIpId, 0);
+        assertEq(expectedLicenseTemplate, pilTemplateAddr);
+        assertEq(expectedLicenseTermsId, licenseTermsId);
+    }
+
+    function _setUpTest() private {
+        spgNftContract = ISPGNFT(
+            registrationWorkflows.createCollection(
+                ISPGNFT.InitParams({
+                    name: testCollectionName,
+                    symbol: testCollectionSymbol,
+                    baseURI: testBaseURI,
+                    maxSupply: testMaxSupply,
+                    mintFee: testMintFee,
+                    mintFeeToken: testMintFeeToken,
+                    mintFeeRecipient: testSender,
+                    owner: testSender,
+                    mintOpen: true,
+                    isPublicMinting: true
+                })
+            )
+        );
+
+        commUseTerms = PILFlavors.commercialUse({
+            mintingFee: testMintFee,
+            currencyToken: testMintFeeToken,
+            royaltyPolicy: royaltyPolicyLRPAddr
+        });
+    }
+}

--- a/test/integration/workflows/LicenseAttachmentIntegration.t.sol
+++ b/test/integration/workflows/LicenseAttachmentIntegration.t.sol
@@ -82,12 +82,12 @@ contract LicenseAttachmentIntegration is BaseIntegration {
             StoryUSD.approve(address(spgNftContract), testMintFee);
 
             (address ipId1, uint256 tokenId1, uint256 licenseTermsId1) = licenseAttachmentWorkflows
-            .mintAndRegisterIpAndAttachPILTerms({
-                spgNftContract: address(spgNftContract),
-                recipient: testSender,
-                ipMetadata: testIpMetadata,
-                terms: commUseTerms
-            });
+                .mintAndRegisterIpAndAttachPILTerms({
+                    spgNftContract: address(spgNftContract),
+                    recipient: testSender,
+                    ipMetadata: testIpMetadata,
+                    terms: commUseTerms
+                });
             assertTrue(ipAssetRegistry.isRegistered(ipId1));
             assertEq(tokenId1, spgNftContract.totalSupply());
             assertEq(licenseTermsId1, pilTemplate.getLicenseTermsId(commUseTerms));
@@ -160,18 +160,16 @@ contract LicenseAttachmentIntegration is BaseIntegration {
                 deadline: deadline,
                 signature: sigMetadata
             }),
-            sigAttach: WorkflowStructs.SignatureData({
-                signer: testSender,
-                deadline: deadline,
-                signature: sigAttach
-            })
+            sigAttach: WorkflowStructs.SignatureData({ signer: testSender, deadline: deadline, signature: sigAttach })
         });
 
         assertEq(ipId, expectedIpId);
         assertTrue(ipAssetRegistry.isRegistered(ipId));
         assertEq(IIPAccount(payable(ipId)).state(), expectedState);
-        (address expectedLicenseTemplate, uint256 expectedLicenseTermsId) = licenseRegistry
-            .getAttachedLicenseTerms(expectedIpId, 0);
+        (address expectedLicenseTemplate, uint256 expectedLicenseTermsId) = licenseRegistry.getAttachedLicenseTerms(
+            expectedIpId,
+            0
+        );
         assertEq(expectedLicenseTemplate, pilTemplateAddr);
         assertEq(expectedLicenseTermsId, licenseTermsId);
     }

--- a/test/integration/workflows/RegistrationIntegration.t.sol
+++ b/test/integration/workflows/RegistrationIntegration.t.sol
@@ -40,17 +40,18 @@ contract RegistrationIntegration is BaseIntegration {
         spgNftContract = ISPGNFT(
             registrationWorkflows.createCollection(
                 ISPGNFT.InitParams({
-                name: testCollectionName,
-                symbol: testCollectionSymbol,
-                baseURI: testBaseURI,
-                maxSupply: testMaxSupply,
-                mintFee: testMintFee,
-                mintFeeToken: testMintFeeToken,
-                mintFeeRecipient: testSender,
-                owner: testSender,
-                mintOpen: true,
-                isPublicMinting: true
-            }))
+                    name: testCollectionName,
+                    symbol: testCollectionSymbol,
+                    baseURI: testBaseURI,
+                    maxSupply: testMaxSupply,
+                    mintFee: testMintFee,
+                    mintFeeToken: testMintFeeToken,
+                    mintFeeRecipient: testSender,
+                    owner: testSender,
+                    mintOpen: true,
+                    isPublicMinting: true
+                })
+            )
         );
 
         assertEq(spgNftContract.name(), testCollectionName);
@@ -77,13 +78,9 @@ contract RegistrationIntegration is BaseIntegration {
 
         assertEq(tokenId, 1);
         assertTrue(ipAssetRegistry.isRegistered(ipId));
-        assertEq(
-            spgNftContract.tokenURI(tokenId),
-            string.concat(testBaseURI, testIpMetadata.nftMetadataURI)
-        );
+        assertEq(spgNftContract.tokenURI(tokenId), string.concat(testBaseURI, testIpMetadata.nftMetadataURI));
         assertMetadata(ipId, testIpMetadata);
     }
-
 
     function _test_RegistrationIntegration_registerIp() private {
         StoryUSD.mint(testSender, testMintFee);
@@ -117,10 +114,7 @@ contract RegistrationIntegration is BaseIntegration {
         assertEq(actualIpId, expectedIpId);
         assertEq(IIPAccount(payable(actualIpId)).state(), expectedState);
         assertTrue(ipAssetRegistry.isRegistered(actualIpId));
-        assertEq(
-            spgNftContract.tokenURI(tokenId),
-            string.concat(testBaseURI, tokenId.toString())
-        );
+        assertEq(spgNftContract.tokenURI(tokenId), string.concat(testBaseURI, tokenId.toString()));
         assertMetadata(actualIpId, testIpMetadata);
     }
 
@@ -186,10 +180,7 @@ contract RegistrationIntegration is BaseIntegration {
         for (uint256 i = 0; i < totalIps; i++) {
             (ipIds[i], tokenIds[i]) = abi.decode(results[i], (address, uint256));
             assertTrue(ipAssetRegistry.isRegistered(ipIds[i]));
-            assertEq(
-                spgNftContract.tokenURI(tokenIds[i]),
-                string.concat(testBaseURI, testIpMetadata.nftMetadataURI)
-            );
+            assertEq(spgNftContract.tokenURI(tokenIds[i]), string.concat(testBaseURI, testIpMetadata.nftMetadataURI));
             assertMetadata(ipIds[i], testIpMetadata);
         }
     }

--- a/test/integration/workflows/RegistrationIntegration.t.sol
+++ b/test/integration/workflows/RegistrationIntegration.t.sol
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+// external
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
+import { ICoreMetadataModule } from "@storyprotocol/core/interfaces/modules/metadata/ICoreMetadataModule.sol";
+import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
+
+// contracts
+import { ISPGNFT } from "../../../contracts/interfaces/ISPGNFT.sol";
+import { SPGNFTLib } from "../../../contracts/lib/SPGNFTLib.sol";
+import { WorkflowStructs } from "../../../contracts/lib/WorkflowStructs.sol";
+
+// test
+import { BaseIntegration } from "../BaseIntegration.t.sol";
+
+contract RegistrationIntegration is BaseIntegration {
+    using Strings for uint256;
+
+    ISPGNFT private spgNftContract;
+
+    /// @dev To use, run the following command:
+    /// forge script test/integration/workflows/RegistrationIntegration.t.sol:RegistrationIntegration \
+    /// --rpc-url=$TESTNET_URL -vvvv --broadcast --priority-gas-price=1 --legacy
+    function run() public override {
+        super.run();
+        _beginBroadcast();
+        _logTestStart("RegistrationIntegration");
+        _test_RegistrationIntegration_createCollection();
+        _test_RegistrationIntegration_createCollection();
+        _test_RegistrationIntegration_mintAndRegisterIp();
+        _test_RegistrationIntegration_registerIp();
+        _test_RegistrationIntegration_multicall_createCollection();
+        _test_RegistrationIntegration_multicall_mintAndRegisterIp();
+        _logTestEnd("RegistrationIntegration");
+        _endBroadcast();
+    }
+
+    function _test_RegistrationIntegration_createCollection() private {
+        spgNftContract = ISPGNFT(
+            registrationWorkflows.createCollection(
+                ISPGNFT.InitParams({
+                name: testCollectionName,
+                symbol: testCollectionSymbol,
+                baseURI: testBaseURI,
+                maxSupply: testMaxSupply,
+                mintFee: testMintFee,
+                mintFeeToken: testMintFeeToken,
+                mintFeeRecipient: testSender,
+                owner: testSender,
+                mintOpen: true,
+                isPublicMinting: true
+            }))
+        );
+
+        assertEq(spgNftContract.name(), testCollectionName);
+        assertEq(spgNftContract.symbol(), testCollectionSymbol);
+        assertEq(spgNftContract.baseURI(), testBaseURI);
+        assertEq(spgNftContract.totalSupply(), 0);
+        assertEq(spgNftContract.mintFee(), testMintFee);
+        assertEq(spgNftContract.mintFeeToken(), testMintFeeToken);
+        assertEq(spgNftContract.mintFeeRecipient(), testSender);
+        assertTrue(spgNftContract.hasRole(SPGNFTLib.MINTER_ROLE, testSender));
+        assertTrue(spgNftContract.hasRole(SPGNFTLib.ADMIN_ROLE, testSender));
+        assertTrue(spgNftContract.mintOpen());
+        assertTrue(spgNftContract.publicMinting());
+    }
+
+    function _test_RegistrationIntegration_mintAndRegisterIp() private {
+        StoryUSD.mint(testSender, testMintFee);
+        StoryUSD.approve(address(spgNftContract), testMintFee);
+        (address ipId, uint256 tokenId) = registrationWorkflows.mintAndRegisterIp({
+            spgNftContract: address(spgNftContract),
+            recipient: testSender,
+            ipMetadata: testIpMetadata
+        });
+
+        assertEq(tokenId, 1);
+        assertTrue(ipAssetRegistry.isRegistered(ipId));
+        assertEq(
+            spgNftContract.tokenURI(tokenId),
+            string.concat(testBaseURI, testIpMetadata.nftMetadataURI)
+        );
+        assertMetadata(ipId, testIpMetadata);
+    }
+
+
+    function _test_RegistrationIntegration_registerIp() private {
+        StoryUSD.mint(testSender, testMintFee);
+        StoryUSD.approve(address(spgNftContract), testMintFee);
+        uint256 tokenId = spgNftContract.mint(testSender, "");
+
+        // get signature for setting IP metadata
+        uint256 deadline = block.timestamp + 1000;
+        address expectedIpId = ipAssetRegistry.ipId(block.chainid, address(spgNftContract), tokenId);
+        (bytes memory sigMetadata, bytes32 expectedState, ) = _getSetPermissionSigForPeriphery({
+            ipId: expectedIpId,
+            to: registrationWorkflowsAddr,
+            module: coreMetadataModuleAddr,
+            selector: ICoreMetadataModule.setAll.selector,
+            deadline: deadline,
+            state: bytes32(0),
+            signerSk: testSenderSk
+        });
+
+        address actualIpId = registrationWorkflows.registerIp({
+            nftContract: address(spgNftContract),
+            tokenId: tokenId,
+            ipMetadata: testIpMetadata,
+            sigMetadata: WorkflowStructs.SignatureData({
+                signer: testSender,
+                deadline: deadline,
+                signature: sigMetadata
+            })
+        });
+
+        assertEq(actualIpId, expectedIpId);
+        assertEq(IIPAccount(payable(actualIpId)).state(), expectedState);
+        assertTrue(ipAssetRegistry.isRegistered(actualIpId));
+        assertEq(
+            spgNftContract.tokenURI(tokenId),
+            string.concat(testBaseURI, tokenId.toString())
+        );
+        assertMetadata(actualIpId, testIpMetadata);
+    }
+
+    function _test_RegistrationIntegration_multicall_createCollection() private {
+        uint256 totalCollections = 10;
+
+        ISPGNFT[] memory nftContracts = new ISPGNFT[](totalCollections);
+        bytes[] memory data = new bytes[](totalCollections);
+        for (uint256 i = 0; i < totalCollections; i++) {
+            data[i] = abi.encodeWithSelector(
+                registrationWorkflows.createCollection.selector,
+                ISPGNFT.InitParams({
+                    name: testCollectionName,
+                    symbol: testCollectionSymbol,
+                    baseURI: testBaseURI,
+                    maxSupply: testMaxSupply,
+                    mintFee: testMintFee,
+                    mintFeeToken: testMintFeeToken,
+                    mintFeeRecipient: testSender,
+                    owner: testSender,
+                    mintOpen: true,
+                    isPublicMinting: false
+                })
+            );
+        }
+
+        bytes[] memory results = registrationWorkflows.multicall(data);
+        for (uint256 i = 0; i < totalCollections; i++) {
+            nftContracts[i] = ISPGNFT(abi.decode(results[i], (address)));
+        }
+
+        for (uint256 i = 0; i < totalCollections; i++) {
+            assertEq(nftContracts[i].name(), testCollectionName);
+            assertEq(nftContracts[i].symbol(), testCollectionSymbol);
+            assertEq(nftContracts[i].totalSupply(), 0);
+            assertTrue(nftContracts[i].hasRole(SPGNFTLib.MINTER_ROLE, testSender));
+            assertEq(nftContracts[i].mintFee(), testMintFee);
+            assertEq(nftContracts[i].mintFeeToken(), testMintFeeToken);
+            assertEq(nftContracts[i].mintFeeRecipient(), testSender);
+            assertTrue(nftContracts[i].mintOpen());
+            assertFalse(nftContracts[i].publicMinting());
+        }
+    }
+
+    function _test_RegistrationIntegration_multicall_mintAndRegisterIp() private {
+        uint256 totalIps = 10;
+        StoryUSD.mint(testSender, testMintFee * totalIps);
+        StoryUSD.approve(address(spgNftContract), testMintFee * totalIps);
+
+        bytes[] memory data = new bytes[](totalIps);
+        for (uint256 i = 0; i < totalIps; i++) {
+            data[i] = abi.encodeWithSelector(
+                registrationWorkflows.mintAndRegisterIp.selector,
+                address(spgNftContract),
+                testSender,
+                testIpMetadata
+            );
+        }
+        bytes[] memory results = registrationWorkflows.multicall(data);
+        address[] memory ipIds = new address[](totalIps);
+        uint256[] memory tokenIds = new uint256[](totalIps);
+
+        for (uint256 i = 0; i < totalIps; i++) {
+            (ipIds[i], tokenIds[i]) = abi.decode(results[i], (address, uint256));
+            assertTrue(ipAssetRegistry.isRegistered(ipIds[i]));
+            assertEq(
+                spgNftContract.tokenURI(tokenIds[i]),
+                string.concat(testBaseURI, testIpMetadata.nftMetadataURI)
+            );
+            assertMetadata(ipIds[i], testIpMetadata);
+        }
+    }
+}

--- a/test/integration/workflows/RoyaltyIntegration.t.sol
+++ b/test/integration/workflows/RoyaltyIntegration.t.sol
@@ -126,7 +126,7 @@ contract RoyaltyIntegration is BaseIntegration {
     }
 
     function _test_RoyaltyIntegration_transferToVaultAndSnapshotAndClaimBySnapshotBatch() private {
-          // setup IP graph and takes 3 snapshots of ancestor IP's royalty vault
+        // setup IP graph and takes 3 snapshots of ancestor IP's royalty vault
         uint256 numSnapshots = 3;
         _setupIpGraph(numSnapshots);
 
@@ -191,7 +191,7 @@ contract RoyaltyIntegration is BaseIntegration {
     }
 
     function _test_RoyaltyIntegration_snapshotAndClaimByTokenBatch() private {
-         // setup IP graph with no snapshot
+        // setup IP graph with no snapshot
         uint256 numSnapshots = 0;
         _setupIpGraph(numSnapshots);
 
@@ -219,7 +219,7 @@ contract RoyaltyIntegration is BaseIntegration {
     }
 
     function _test_RoyaltyIntegration_snapshotAndClaimBySnapshotBatch() private {
-         // setup IP graph and takes 1 snapshot of ancestor IP's royalty vault
+        // setup IP graph and takes 1 snapshot of ancestor IP's royalty vault
         uint256 numSnapshots = 1;
         _setupIpGraph(numSnapshots);
 
@@ -391,11 +391,7 @@ contract RoyaltyIntegration is BaseIntegration {
                 ancestorIpRoyaltyVault.totalSupply()
             );
 
-            IIPAccount(payable(ancestorIpId)).execute({
-                to: address(ancestorIpRoyaltyVault),
-                value: 0,
-                data: data
-            });
+            IIPAccount(payable(ancestorIpId)).execute({ to: address(ancestorIpRoyaltyVault), value: 0, data: data });
         }
 
         // takes a snapshot of the ancestor IP's royalty vault and populates unclaimedSnapshotIds

--- a/test/integration/workflows/RoyaltyIntegration.t.sol
+++ b/test/integration/workflows/RoyaltyIntegration.t.sol
@@ -1,0 +1,596 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+/* solhint-disable no-console */
+
+// external
+import { console2 } from "forge-std/console2.sol";
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
+import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
+import { IpRoyaltyVault } from "@storyprotocol/core/modules/royalty/policies/IpRoyaltyVault.sol";
+import { IVaultController } from "@storyprotocol/core/interfaces/modules/royalty/policies/IVaultController.sol";
+import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
+
+// contracts
+import { ISPGNFT } from "../../../contracts/interfaces/ISPGNFT.sol";
+import { IRoyaltyWorkflows } from "../../../contracts/interfaces/workflows/IRoyaltyWorkflows.sol";
+import { WorkflowStructs } from "../../../contracts/lib/WorkflowStructs.sol";
+// test
+import { BaseIntegration } from "../BaseIntegration.t.sol";
+
+contract RoyaltyIntegration is BaseIntegration {
+    using Strings for uint256;
+
+    ISPGNFT private spgNftContract;
+
+    address internal ancestorIpId;
+    address internal childIpIdA;
+    address internal childIpIdB;
+    address internal childIpIdC;
+    address internal grandChildIpId;
+
+    uint256 internal commRemixTermsIdA;
+    uint256 internal defaultMintingFeeA = 1000 * 10 ** StoryUSD.decimals(); // 1000 SUSD
+    uint32 internal defaultCommRevShareA = 10 * 10 ** 6; // 10%
+
+    uint256 internal commRemixTermsIdC;
+    uint256 internal defaultMintingFeeC = 500 * 10 ** StoryUSD.decimals(); // 500 SUSD
+    uint32 internal defaultCommRevShareC = 20 * 10 ** 6; // 20%
+
+    uint256 internal amountLicenseTokensToMint = 1;
+
+    uint256[] internal unclaimedSnapshotIds;
+
+    /// @notice This test can only be run when royalty module's snapshot interval is 0.
+    /// @dev To use, run the following command:
+    /// forge script test/integration/workflows/RoyaltyIntegration.t.sol:RoyaltyIntegration \
+    /// --rpc-url=$TESTNET_URL -vvvv --broadcast --priority-gas-price=1 --legacy
+    function run() public override {
+        super.run();
+        _beginBroadcast();
+        if (IVaultController(royaltyModuleAddr).snapshotInterval() != 0) {
+            console2.log("RoyaltyIntegration did not run: snapshot interval is not zero");
+            return;
+        }
+        _logTestStart("RoyaltyIntegration");
+        _setupTest();
+        _test_RoyaltyIntegration_transferToVaultAndSnapshotAndClaimByTokenBatch();
+        _test_RoyaltyIntegration_snapshotAndClaimByTokenBatch();
+        _test_RoyaltyIntegration_transferToVaultAndSnapshotAndClaimBySnapshotBatch();
+        _test_RoyaltyIntegration_snapshotAndClaimBySnapshotBatch();
+        _logTestEnd("RoyaltyIntegration");
+        _endBroadcast();
+    }
+
+    function _test_RoyaltyIntegration_transferToVaultAndSnapshotAndClaimByTokenBatch() private {
+        // setup IP graph with no snapshot
+        uint256 numSnapshots = 0;
+        _setupIpGraph(numSnapshots);
+
+        IRoyaltyWorkflows.RoyaltyClaimDetails[] memory claimDetails = new IRoyaltyWorkflows.RoyaltyClaimDetails[](4);
+        claimDetails[0] = IRoyaltyWorkflows.RoyaltyClaimDetails({
+            childIpId: childIpIdA,
+            royaltyPolicy: royaltyPolicyLRPAddr,
+            currencyToken: address(StoryUSD),
+            amount: (defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent() // 1000 * 10% = 100
+        });
+
+        claimDetails[1] = IRoyaltyWorkflows.RoyaltyClaimDetails({
+            childIpId: childIpIdB,
+            royaltyPolicy: royaltyPolicyLRPAddr,
+            currencyToken: address(StoryUSD),
+            amount: (defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent() // 1000 * 10% = 100
+        });
+
+        claimDetails[2] = IRoyaltyWorkflows.RoyaltyClaimDetails({
+            childIpId: grandChildIpId,
+            royaltyPolicy: royaltyPolicyLRPAddr,
+            currencyToken: address(StoryUSD),
+            amount: (((defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent()) *
+                defaultCommRevShareA) / royaltyModule.maxPercent() // 1000 * 10% * 10% * 2 = 20
+        });
+
+        claimDetails[3] = IRoyaltyWorkflows.RoyaltyClaimDetails({
+            childIpId: childIpIdC,
+            royaltyPolicy: royaltyPolicyLAPAddr,
+            currencyToken: address(StoryUSD),
+            amount: (defaultMintingFeeC * defaultCommRevShareC) / royaltyModule.maxPercent() // 500 * 20% = 100
+        });
+
+        uint256 claimerBalanceBefore = StoryUSD.balanceOf(testSender);
+
+        (uint256 snapshotId, uint256[] memory amountsClaimed) = royaltyWorkflows
+            .transferToVaultAndSnapshotAndClaimByTokenBatch({
+                ancestorIpId: ancestorIpId,
+                claimer: testSender,
+                royaltyClaimDetails: claimDetails
+            });
+
+        uint256 claimerBalanceAfter = StoryUSD.balanceOf(testSender);
+
+        assertEq(snapshotId, numSnapshots + 1);
+        assertEq(amountsClaimed.length, 2); // there are 2 currency tokens
+        assertEq(claimerBalanceAfter - claimerBalanceBefore, amountsClaimed[0]);
+        assertEq(
+            claimerBalanceAfter - claimerBalanceBefore,
+            defaultMintingFeeA +
+                defaultMintingFeeA + // 1000 + 1000 from minting fee of childIpA and childIpB
+                (defaultMintingFeeA * defaultCommRevShareA) /
+                royaltyModule.maxPercent() + // 1000 * 10% = 100 royalty from childIpA
+                (defaultMintingFeeA * defaultCommRevShareA) /
+                royaltyModule.maxPercent() + // 1000 * 10% = 100 royalty from childIpB
+                (((defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent()) * defaultCommRevShareA) /
+                royaltyModule.maxPercent() + // 1000 * 10% * 10% * 2 = 20 royalty from grandChildIp
+                (defaultMintingFeeC * defaultCommRevShareC) /
+                royaltyModule.maxPercent() // 500 * 20% = 100 royalty from childIpC
+        );
+    }
+
+    function _test_RoyaltyIntegration_transferToVaultAndSnapshotAndClaimBySnapshotBatch() private {
+          // setup IP graph and takes 3 snapshots of ancestor IP's royalty vault
+        uint256 numSnapshots = 3;
+        _setupIpGraph(numSnapshots);
+
+        IRoyaltyWorkflows.RoyaltyClaimDetails[] memory claimDetails = new IRoyaltyWorkflows.RoyaltyClaimDetails[](4);
+        claimDetails[0] = IRoyaltyWorkflows.RoyaltyClaimDetails({
+            childIpId: childIpIdA,
+            royaltyPolicy: royaltyPolicyLRPAddr,
+            currencyToken: address(StoryUSD),
+            amount: (defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent() // 1000 * 10% = 100
+        });
+
+        claimDetails[1] = IRoyaltyWorkflows.RoyaltyClaimDetails({
+            childIpId: childIpIdB,
+            royaltyPolicy: royaltyPolicyLRPAddr,
+            currencyToken: address(StoryUSD),
+            amount: (defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent() // 1000 * 10% = 100
+        });
+
+        claimDetails[2] = IRoyaltyWorkflows.RoyaltyClaimDetails({
+            childIpId: grandChildIpId,
+            royaltyPolicy: royaltyPolicyLRPAddr,
+            currencyToken: address(StoryUSD),
+            amount: (((defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent()) *
+                defaultCommRevShareA) / royaltyModule.maxPercent() // 1000 * 10% * 10% = 10
+        });
+
+        claimDetails[3] = IRoyaltyWorkflows.RoyaltyClaimDetails({
+            childIpId: childIpIdC,
+            royaltyPolicy: royaltyPolicyLAPAddr,
+            currencyToken: address(StoryUSD),
+            amount: (defaultMintingFeeC * defaultCommRevShareC) / royaltyModule.maxPercent() // 500 * 20% = 100
+        });
+
+        uint256 claimerBalanceBefore = StoryUSD.balanceOf(testSender);
+
+        (uint256 snapshotId, uint256[] memory amountsClaimed) = royaltyWorkflows
+            .transferToVaultAndSnapshotAndClaimBySnapshotBatch({
+                ancestorIpId: ancestorIpId,
+                claimer: testSender,
+                unclaimedSnapshotIds: unclaimedSnapshotIds,
+                royaltyClaimDetails: claimDetails
+            });
+
+        uint256 claimerBalanceAfter = StoryUSD.balanceOf(testSender);
+
+        assertEq(snapshotId, numSnapshots + 1);
+        assertEq(amountsClaimed.length, 1); // there is 1 currency token
+        assertEq(claimerBalanceAfter - claimerBalanceBefore, amountsClaimed[0]);
+        assertEq(
+            claimerBalanceAfter - claimerBalanceBefore,
+            defaultMintingFeeA +
+                defaultMintingFeeA + // 1000 + 1000 from minting fee of childIpA and childIpB
+                (defaultMintingFeeA * defaultCommRevShareA) /
+                royaltyModule.maxPercent() + // 1000 * 10% = 100 royalty from childIpA
+                (defaultMintingFeeA * defaultCommRevShareA) /
+                royaltyModule.maxPercent() + // 1000 * 10% = 100 royalty from childIpB
+                (((defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent()) * defaultCommRevShareA) /
+                royaltyModule.maxPercent() + // 1000 * 10% * 10% = 10 royalty from grandChildIp
+                (defaultMintingFeeC * defaultCommRevShareC) /
+                royaltyModule.maxPercent() // 500 * 20% = 100 royalty from childIpC
+        );
+    }
+
+    function _test_RoyaltyIntegration_snapshotAndClaimByTokenBatch() private {
+         // setup IP graph with no snapshot
+        uint256 numSnapshots = 0;
+        _setupIpGraph(numSnapshots);
+
+        address[] memory currencyTokens = new address[](1);
+        currencyTokens[0] = address(StoryUSD);
+
+        uint256 claimerBalanceBefore = StoryUSD.balanceOf(testSender);
+
+        (uint256 snapshotId, uint256[] memory amountsClaimed) = royaltyWorkflows.snapshotAndClaimByTokenBatch({
+            ipId: ancestorIpId,
+            claimer: testSender,
+            currencyTokens: currencyTokens
+        });
+
+        uint256 claimerBalanceAfter = StoryUSD.balanceOf(testSender);
+
+        assertEq(snapshotId, numSnapshots + 1);
+        assertEq(amountsClaimed.length, 1); // there is 1 currency token
+        assertEq(claimerBalanceAfter - claimerBalanceBefore, amountsClaimed[0]);
+        assertEq(
+            claimerBalanceAfter - claimerBalanceBefore,
+            // 1000 + 1000 + 500 from minting fee of childIpA, childIpB, and childIpC
+            defaultMintingFeeA + defaultMintingFeeA + defaultMintingFeeC
+        );
+    }
+
+    function _test_RoyaltyIntegration_snapshotAndClaimBySnapshotBatch() private {
+         // setup IP graph and takes 1 snapshot of ancestor IP's royalty vault
+        uint256 numSnapshots = 1;
+        _setupIpGraph(numSnapshots);
+
+        address[] memory currencyTokens = new address[](1);
+        currencyTokens[0] = address(StoryUSD);
+
+        uint256 claimerBalanceBefore = StoryUSD.balanceOf(testSender);
+
+        (uint256 snapshotId, uint256[] memory amountsClaimed) = royaltyWorkflows.snapshotAndClaimBySnapshotBatch({
+            ipId: ancestorIpId,
+            claimer: testSender,
+            unclaimedSnapshotIds: unclaimedSnapshotIds,
+            currencyTokens: currencyTokens
+        });
+
+        uint256 claimerBalanceAfter = StoryUSD.balanceOf(testSender);
+
+        assertEq(snapshotId, numSnapshots + 1);
+        assertEq(amountsClaimed.length, 2); // there are 2 currency tokens
+        assertEq(claimerBalanceAfter - claimerBalanceBefore, amountsClaimed[0]);
+        assertEq(
+            claimerBalanceAfter - claimerBalanceBefore,
+            // 1000 + 1000 + 500 from minting fee of childIpA, childIpB, and childIpC
+            defaultMintingFeeA + defaultMintingFeeA + defaultMintingFeeC
+        );
+    }
+
+    /// @dev Builds an IP graph as follows (TermsA is LRP, TermsC is LAP):
+    ///                                        ancestorIp (root)
+    ///                                        (TermsA + TermsC)
+    ///                      _________________________|___________________________
+    ///                    /                          |                           \
+    ///                   /                           |                            \
+    ///                childIpA                   childIpB                      childIpC
+    ///                (TermsA)                  (TermsA)                      (TermsC)
+    ///                   \                          /                             /
+    ///                    \________________________/                             /
+    ///                                |                                         /
+    ///                            grandChildIp                                 /
+    ///                             (TermsA)                                   /
+    ///                                 \                                     /
+    ///                                  \___________________________________/
+    ///                                                    |
+    ///             mints `amountLicenseTokensToMint` grandChildIp and childIpC license tokens.
+    ///
+    /// - `ancestorIp`: It has 3 different commercial remix license terms attached. It has 3 child and 1 grandchild IPs.
+    /// - `childIpA`: It has licenseTermsA attached, has 1 parent `ancestorIp`, and has 1 grandchild `grandChildIp`.
+    /// - `childIpB`: It has licenseTermsA attached, has 1 parent `ancestorIp`, and has 1 grandchild `grandChildIp`.
+    /// - `childIpC`: It has licenseTermsC attached, has 1 parent `ancestorIp`, and has 1 grandchild `grandChildIp`.
+    /// - `grandChildIp`: It has all 3 license terms attached. It has 3 parents and 1 grandparent IPs.
+    /// @param numSnapshots The number of snapshots to take of the ancestor IP's royalty vault.
+    function _setupIpGraph(uint256 numSnapshots) private {
+        uint256 ancestorTokenId = spgNftContract.mint(testSender, "");
+        uint256 childTokenIdA = spgNftContract.mint(testSender, "");
+        uint256 childTokenIdB = spgNftContract.mint(testSender, "");
+        uint256 childTokenIdC = spgNftContract.mint(testSender, "");
+        uint256 grandChildTokenId = spgNftContract.mint(testSender, "");
+
+        WorkflowStructs.IPMetadata memory emptyIpMetadata = WorkflowStructs.IPMetadata({
+            ipMetadataURI: "",
+            ipMetadataHash: "",
+            nftMetadataURI: "",
+            nftMetadataHash: ""
+        });
+
+        WorkflowStructs.SignatureData memory emptySigData = WorkflowStructs.SignatureData({
+            signer: address(0),
+            deadline: 0,
+            signature: ""
+        });
+
+        unclaimedSnapshotIds = new uint256[](numSnapshots);
+
+        // register ancestor IP
+        ancestorIpId = ipAssetRegistry.register(block.chainid, address(spgNftContract), ancestorTokenId);
+        vm.label(ancestorIpId, "AncestorIp");
+
+        uint256 deadline = block.timestamp + 1000;
+
+        // set permission for licensing module to attach license terms to ancestor IP
+        {
+            (bytes memory signature, , bytes memory data) = _getSetPermissionSigForPeriphery({
+                ipId: ancestorIpId,
+                to: licenseAttachmentWorkflowsAddr,
+                module: licensingModuleAddr,
+                selector: licensingModule.attachLicenseTerms.selector,
+                deadline: deadline,
+                state: IIPAccount(payable(ancestorIpId)).state(),
+                signerSk: testSenderSk
+            });
+
+            IIPAccount(payable(ancestorIpId)).executeWithSig({
+                to: accessControllerAddr,
+                value: 0,
+                data: data,
+                signer: testSender,
+                deadline: deadline,
+                signature: signature
+            });
+        }
+
+        // register and attach Terms A and C to ancestor IP
+        commRemixTermsIdA = licenseAttachmentWorkflows.registerPILTermsAndAttach({
+            ipId: ancestorIpId,
+            terms: PILFlavors.commercialRemix({
+                mintingFee: defaultMintingFeeA,
+                commercialRevShare: defaultCommRevShareA,
+                royaltyPolicy: royaltyPolicyLRPAddr,
+                currencyToken: address(StoryUSD)
+            })
+        });
+
+        commRemixTermsIdC = licenseAttachmentWorkflows.registerPILTermsAndAttach({
+            ipId: ancestorIpId,
+            terms: PILFlavors.commercialRemix({
+                mintingFee: defaultMintingFeeC,
+                commercialRevShare: defaultCommRevShareC,
+                royaltyPolicy: royaltyPolicyLAPAddr,
+                currencyToken: address(StoryUSD)
+            })
+        });
+
+        // register childIpA as derivative of ancestorIp under Terms A
+        {
+            (bytes memory sigRegister, , ) = _getSetPermissionSigForPeriphery({
+                ipId: ipAssetRegistry.ipId(block.chainid, address(spgNftContract), childTokenIdA),
+                to: derivativeWorkflowsAddr,
+                module: licensingModuleAddr,
+                selector: licensingModule.registerDerivative.selector,
+                deadline: deadline,
+                state: bytes32(0),
+                signerSk: testSenderSk
+            });
+
+            address[] memory parentIpIds = new address[](1);
+            uint256[] memory licenseTermsIds = new uint256[](1);
+            parentIpIds[0] = ancestorIpId;
+            licenseTermsIds[0] = commRemixTermsIdA;
+
+            StoryUSD.mint(testSender, defaultMintingFeeA);
+            StoryUSD.approve(derivativeWorkflowsAddr, defaultMintingFeeA);
+            childIpIdA = derivativeWorkflows.registerIpAndMakeDerivative({
+                nftContract: address(spgNftContract),
+                tokenId: childTokenIdA,
+                derivData: WorkflowStructs.MakeDerivative({
+                    parentIpIds: parentIpIds,
+                    licenseTemplate: pilTemplateAddr,
+                    licenseTermsIds: licenseTermsIds,
+                    royaltyContext: ""
+                }),
+                ipMetadata: emptyIpMetadata,
+                sigMetadata: emptySigData,
+                sigRegister: WorkflowStructs.SignatureData({
+                    signer: testSender,
+                    deadline: deadline,
+                    signature: sigRegister
+                })
+            });
+            vm.label(childIpIdA, "ChildIpA");
+        }
+
+        IpRoyaltyVault ancestorIpRoyaltyVault = IpRoyaltyVault(royaltyModule.ipRoyaltyVaults(ancestorIpId));
+
+        // transfer all ancestor royalties tokens to the claimer of the ancestor IP
+        {
+            bytes memory data = abi.encodeWithSelector(
+                ancestorIpRoyaltyVault.transfer.selector,
+                testSender,
+                ancestorIpRoyaltyVault.totalSupply()
+            );
+
+            IIPAccount(payable(ancestorIpId)).execute({
+                to: address(ancestorIpRoyaltyVault),
+                value: 0,
+                data: data
+            });
+        }
+
+        // takes a snapshot of the ancestor IP's royalty vault and populates unclaimedSnapshotIds
+        // In this snapshot:
+        // - admin has all the royalty tokens from ancestorIp
+        // - ancestorIp's royalty vault has `defaultMintingFeeA` tokens from alice for registering childIpA
+        // as derivative of ancestorIp under Terms A
+        if (numSnapshots >= 1) {
+            unclaimedSnapshotIds[0] = ancestorIpRoyaltyVault.snapshot();
+            numSnapshots--;
+        }
+
+        // register childIpB as derivative of ancestorIp under Terms A
+        {
+            (bytes memory sigRegister, , ) = _getSetPermissionSigForPeriphery({
+                ipId: ipAssetRegistry.ipId(block.chainid, address(spgNftContract), childTokenIdB),
+                to: derivativeWorkflowsAddr,
+                module: licensingModuleAddr,
+                selector: licensingModule.registerDerivative.selector,
+                deadline: deadline,
+                state: bytes32(0),
+                signerSk: testSenderSk
+            });
+
+            address[] memory parentIpIds = new address[](1);
+            uint256[] memory licenseTermsIds = new uint256[](1);
+            parentIpIds[0] = ancestorIpId;
+            licenseTermsIds[0] = commRemixTermsIdA;
+
+            StoryUSD.mint(testSender, defaultMintingFeeA);
+            StoryUSD.approve(derivativeWorkflowsAddr, defaultMintingFeeA);
+            childIpIdB = derivativeWorkflows.registerIpAndMakeDerivative({
+                nftContract: address(spgNftContract),
+                tokenId: childTokenIdB,
+                derivData: WorkflowStructs.MakeDerivative({
+                    parentIpIds: parentIpIds,
+                    licenseTemplate: address(pilTemplate),
+                    licenseTermsIds: licenseTermsIds,
+                    royaltyContext: ""
+                }),
+                ipMetadata: emptyIpMetadata,
+                sigMetadata: emptySigData,
+                sigRegister: WorkflowStructs.SignatureData({
+                    signer: testSender,
+                    deadline: deadline,
+                    signature: sigRegister
+                })
+            });
+            vm.label(childIpIdB, "ChildIpB");
+        }
+
+        // takes a snapshot of the ancestor IP's royalty vault and populates unclaimedSnapshotIds
+        // In this snapshot:
+        // - admin has all the royalty tokens from ancestorIp
+        // - ancestorIp's royalty vault has `defaultMintingFeeA` tokens from bob for registering childIpB
+        // as derivative of ancestorIp under Terms A
+        if (numSnapshots >= 1) {
+            unclaimedSnapshotIds[1] = IpRoyaltyVault(royaltyModule.ipRoyaltyVaults(ancestorIpId)).snapshot();
+            numSnapshots--;
+        }
+
+        /// register childIpC as derivative of ancestorIp under Terms C
+        {
+            (bytes memory sigRegister, , ) = _getSetPermissionSigForPeriphery({
+                ipId: ipAssetRegistry.ipId(block.chainid, address(spgNftContract), childTokenIdC),
+                to: derivativeWorkflowsAddr,
+                module: licensingModuleAddr,
+                selector: licensingModule.registerDerivative.selector,
+                deadline: deadline,
+                state: bytes32(0),
+                signerSk: testSenderSk
+            });
+
+            address[] memory parentIpIds = new address[](1);
+            uint256[] memory licenseTermsIds = new uint256[](1);
+            parentIpIds[0] = ancestorIpId;
+            licenseTermsIds[0] = commRemixTermsIdC;
+
+            StoryUSD.mint(testSender, defaultMintingFeeC);
+            StoryUSD.approve(derivativeWorkflowsAddr, defaultMintingFeeC);
+            childIpIdC = derivativeWorkflows.registerIpAndMakeDerivative({
+                nftContract: address(spgNftContract),
+                tokenId: childTokenIdC,
+                derivData: WorkflowStructs.MakeDerivative({
+                    parentIpIds: parentIpIds,
+                    licenseTemplate: address(pilTemplate),
+                    licenseTermsIds: licenseTermsIds,
+                    royaltyContext: ""
+                }),
+                ipMetadata: emptyIpMetadata,
+                sigMetadata: emptySigData,
+                sigRegister: WorkflowStructs.SignatureData({
+                    signer: testSender,
+                    deadline: deadline,
+                    signature: sigRegister
+                })
+            });
+            vm.label(childIpIdC, "ChildIpC");
+        }
+
+        // takes a snapshot of the ancestor IP's royalty vault and populates unclaimedSnapshotIds
+        // In this snapshot:
+        // - admin has all the royalty tokens from ancestorIp
+        // - ancestorIp's royalty vault has `defaultMintingFeeC` tokens from carl for registering childIpC
+        // as derivative of ancestorIp under Terms C
+        if (numSnapshots >= 1) {
+            unclaimedSnapshotIds[2] = IpRoyaltyVault(royaltyModule.ipRoyaltyVaults(ancestorIpId)).snapshot();
+            numSnapshots--;
+        }
+
+        // register grandChildIp as derivative for childIp A and B under Terms A
+        {
+            (bytes memory sigRegister, , ) = _getSetPermissionSigForPeriphery({
+                ipId: ipAssetRegistry.ipId(block.chainid, address(spgNftContract), grandChildTokenId),
+                to: derivativeWorkflowsAddr,
+                module: address(licensingModule),
+                selector: licensingModule.registerDerivative.selector,
+                deadline: deadline,
+                state: bytes32(0),
+                signerSk: testSenderSk
+            });
+
+            address[] memory parentIpIds = new address[](2);
+            uint256[] memory licenseTermsIds = new uint256[](2);
+            parentIpIds[0] = childIpIdA;
+            parentIpIds[1] = childIpIdB;
+            for (uint256 i = 0; i < licenseTermsIds.length; i++) {
+                licenseTermsIds[i] = commRemixTermsIdA;
+            }
+
+            StoryUSD.mint(testSender, defaultMintingFeeA * parentIpIds.length);
+            StoryUSD.approve(derivativeWorkflowsAddr, defaultMintingFeeA * parentIpIds.length);
+            grandChildIpId = derivativeWorkflows.registerIpAndMakeDerivative({
+                nftContract: address(spgNftContract),
+                tokenId: grandChildTokenId,
+                derivData: WorkflowStructs.MakeDerivative({
+                    parentIpIds: parentIpIds,
+                    licenseTemplate: address(pilTemplate),
+                    licenseTermsIds: licenseTermsIds,
+                    royaltyContext: ""
+                }),
+                ipMetadata: emptyIpMetadata,
+                sigMetadata: emptySigData,
+                sigRegister: WorkflowStructs.SignatureData({
+                    signer: testSender,
+                    deadline: deadline,
+                    signature: sigRegister
+                })
+            });
+            vm.label(grandChildIpId, "GrandChildIp");
+        }
+
+        // mints `amountLicenseTokensToMint` grandChildIp and childIpC license tokens
+        {
+            StoryUSD.mint(testSender, (defaultMintingFeeA + defaultMintingFeeC) * amountLicenseTokensToMint);
+            StoryUSD.approve(royaltyModuleAddr, (defaultMintingFeeA + defaultMintingFeeC) * amountLicenseTokensToMint);
+
+            // mint `amountLicenseTokensToMint` grandChildIp's license tokens
+            licensingModule.mintLicenseTokens({
+                licensorIpId: grandChildIpId,
+                licenseTemplate: pilTemplateAddr,
+                licenseTermsId: commRemixTermsIdA,
+                amount: amountLicenseTokensToMint,
+                receiver: testSender,
+                royaltyContext: ""
+            });
+
+            // mint `amountLicenseTokensToMint` childIpC's license tokens
+            licensingModule.mintLicenseTokens({
+                licensorIpId: childIpIdC,
+                licenseTemplate: pilTemplateAddr,
+                licenseTermsId: commRemixTermsIdC,
+                amount: amountLicenseTokensToMint,
+                receiver: testSender,
+                royaltyContext: ""
+            });
+        }
+    }
+
+    function _setupTest() private {
+        spgNftContract = ISPGNFT(
+            registrationWorkflows.createCollection(
+                ISPGNFT.InitParams({
+                    name: testCollectionName,
+                    symbol: testCollectionSymbol,
+                    baseURI: testBaseURI,
+                    maxSupply: testMaxSupply,
+                    mintFee: 0,
+                    mintFeeToken: testMintFeeToken,
+                    mintFeeRecipient: testSender,
+                    owner: testSender,
+                    mintOpen: true,
+                    isPublicMinting: true
+                })
+            )
+        );
+    }
+}

--- a/test/workflows/DerivativeWorkflows.t.sol
+++ b/test/workflows/DerivativeWorkflows.t.sol
@@ -109,7 +109,7 @@ contract DerivativeWorkflowsTest is BaseTest {
             royaltyContext: ""
         });
 
-        // Need so that SPG can transfer the license tokens
+        // Need so that derivative workflows can transfer the license tokens
         licenseToken.setApprovalForAll(address(derivativeWorkflows), true);
 
         uint256[] memory licenseTokenIds = new uint256[](1);

--- a/test/workflows/RoyaltyWorkflows.t.sol
+++ b/test/workflows/RoyaltyWorkflows.t.sol
@@ -360,7 +360,7 @@ contract RoyaltyWorkflowsTest is BaseTest {
     ///
     /// - `ancestorIp`: It has 3 different commercial remix license terms attached. It has 3 child and 1 grandchild IPs.
     /// - `childIpA`: It has licenseTermsA attached, has 1 parent `ancestorIp`, and has 1 grandchild `grandChildIp`.
-    /// - `childIpB`: It has licenseTermsB attached, has 1 parent `ancestorIp`, and has 1 grandchild `grandChildIp`.
+    /// - `childIpB`: It has licenseTermsA attached, has 1 parent `ancestorIp`, and has 1 grandchild `grandChildIp`.
     /// - `childIpC`: It has licenseTermsC attached, has 1 parent `ancestorIp`, and has 1 grandchild `grandChildIp`.
     /// - `grandChildIp`: It has all 3 license terms attached. It has 3 parents and 1 grandparent IPs.
     /// @param numSnapshots The number of snapshots to take of the ancestor IP's royalty vault.

--- a/yarn.lock
+++ b/yarn.lock
@@ -441,7 +441,7 @@
 
 "@story-protocol/protocol-core@github:storyprotocol/protocol-core-v1#main":
   version "1.1.0"
-  resolved "https://codeload.github.com/storyprotocol/protocol-core-v1/tar.gz/602740e71d10beab9279c9bf53e9f1ec21fb8a4b"
+  resolved "https://codeload.github.com/storyprotocol/protocol-core-v1/tar.gz/0aed667579299c8a263a60236cb6d93f0ac8aa72"
   dependencies:
     "@openzeppelin/contracts" "5.0.2"
     "@openzeppelin/contracts-upgradeable" "5.0.2"
@@ -495,9 +495,9 @@
   integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
 "@types/node@*":
-  version "22.5.5"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.5.5.tgz#52f939dd0f65fc552a4ad0b392f3c466cc5d7a44"
-  integrity sha512-Xjs4y5UPO/CLdzpgR6GirZJx36yScjh73+2NlLlkFRSoQN8B0DpfXPdZGnvVmLRLOsqDpOfTNv7D9trgGhmOIA==
+  version "22.7.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.7.3.tgz#7ddf1ddf13078692b4cfadb835852b2a718ee1ef"
+  integrity sha512-qXKfhXXqGTyBskvWEzJZPUxSslAiLaB6JGP1ic/XTH9ctGgzdgYguuLP1C601aRTSDNlLb0jbKqXjZ48GNraSA==
   dependencies:
     undici-types "~6.19.2"
 
@@ -1210,9 +1210,9 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fast-uri@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.0.1.tgz#cddd2eecfc83a71c1be2cc2ef2061331be8a7134"
-  integrity sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.0.2.tgz#d78b298cf70fd3b752fd951175a3da6a7b48f024"
+  integrity sha512-GR6f0hD7XXyNJa25Tb9BuIdN0tdr+0BMi6/CJPH3wJO1JjNG3n/VsSw38AwRdKZABm8lGbPfakLRkYzx2V9row==
 
 fastq@^1.6.0:
   version "1.17.1"


### PR DESCRIPTION
## Description
This PR introduces integration tests for the periphery contracts. These tests are intended to be run against a live deployment of the PoC periphery contracts, sending real transactions to the blockchain. The new integration tests include:
- `DerivativeIntegration`
- `GroupingIntegration`
- `LicenseAttachmentIntegration`
- `RegistrationIntegration`
- `RoyaltyIntegration`

### Additional Changes:
- Added documentation outlining how to run these integration tests (details see `/test/integration/README.md`).
- Corrected several typos in existing code comments.

## Testing
All existing tests have passed, and the newly added integration tests have been run locally to ensure everything works as expected. For detailed test output and transaction hashes, refer to: [TestOutput.md](https://github.com/user-attachments/files/17158717/TestOutput.md).

## Related Issue
- Closes #41.

## Notes
Please note that the `RoyaltyIntegration` test currently cannot be executed against the production PoC core protocol due to limitations related to snapshot intervals.