### PR TITLE
fix(upgrade script): add missing `super.run()` in upgrade scripts

### DIFF
--- a/script/upgrade/UpgradeDerivativeWorkflows.s.sol
+++ b/script/upgrade/UpgradeDerivativeWorkflows.s.sol
@@ -19,6 +19,7 @@ contract UpgradeDerivativeWorkflows is UpgradeHelper {
     ///
     /// For detailed examples, see the documentation in `../../docs/DEPLOY_UPGRADE.md`.
     function run() public override {
+        super.run();
         _beginBroadcast();
         _deployDerivativeWorkflows();
 

--- a/script/upgrade/UpgradeGroupingWorkflows.s.sol
+++ b/script/upgrade/UpgradeGroupingWorkflows.s.sol
@@ -19,6 +19,7 @@ contract UpgradeGroupingWorkflows is UpgradeHelper {
     ///
     /// For detailed examples, see the documentation in `../../docs/DEPLOY_UPGRADE.md`.
     function run() public override {
+        super.run();
         _beginBroadcast();
         _deployGroupingWorkflows();
 

--- a/script/upgrade/UpgradeLicenseAttachmentWorkflows.s.sol
+++ b/script/upgrade/UpgradeLicenseAttachmentWorkflows.s.sol
@@ -19,6 +19,7 @@ contract UpgradeLicenseAttachmentWorkflows is UpgradeHelper {
     ///
     /// For detailed examples, see the documentation in `../../docs/DEPLOY_UPGRADE.md`.
     function run() public override {
+        super.run();
         _beginBroadcast();
         _deployLicenseAttachmentWorkflows();
 

--- a/script/upgrade/UpgradeRegistrationWorkflows.s.sol
+++ b/script/upgrade/UpgradeRegistrationWorkflows.s.sol
@@ -19,6 +19,7 @@ contract UpgradeRegistrationWorkflows is UpgradeHelper {
     ///
     /// For detailed examples, see the documentation in `../../docs/DEPLOY_UPGRADE.md`.
     function run() public override {
+        super.run();
         _beginBroadcast();
         _deployRegistrationWorkflows();
 

--- a/script/upgrade/UpgradeRoyaltyWorkflows.s.sol
+++ b/script/upgrade/UpgradeRoyaltyWorkflows.s.sol
@@ -19,6 +19,7 @@ contract UpgradeRoyaltyWorkflows is UpgradeHelper {
     ///
     /// For detailed examples, see the documentation in `../../docs/DEPLOY_UPGRADE.md`.
     function run() public override {
+        super.run();
         _beginBroadcast();
         _deployRoyaltyWorkflows();
 

--- a/script/upgrade/UpgradeSPGNFT.s.sol
+++ b/script/upgrade/UpgradeSPGNFT.s.sol
@@ -20,7 +20,6 @@ contract UpgradeSPGNFT is UpgradeHelper {
     /// For detailed examples, see the documentation in `../../docs/DEPLOY_UPGRADE.md`.
     function run() public override {
         super.run();
-
         _beginBroadcast();
         _deploySPGNFT();
 

--- a/test/integration/workflows/DerivativeIntegration.t.sol
+++ b/test/integration/workflows/DerivativeIntegration.t.sol
@@ -38,7 +38,8 @@ contract DerivativeIntegration is BaseIntegration {
         _endBroadcast();
     }
 
-    function _test_mintAndRegisterIpAndMakeDerivative() private
+    function _test_mintAndRegisterIpAndMakeDerivative()
+        private
         logTest("test_DerivativeIntegration_mintAndRegisterIpAndMakeDerivative")
     {
         StoryUSD.mint(testSender, testMintFee * 2);
@@ -75,7 +76,8 @@ contract DerivativeIntegration is BaseIntegration {
         });
     }
 
-    function _test_registerIpAndMakeDerivative() private
+    function _test_registerIpAndMakeDerivative()
+        private
         logTest("test_DerivativeIntegration_registerIpAndMakeDerivative")
     {
         StoryUSD.mint(testSender, testMintFee);
@@ -149,7 +151,8 @@ contract DerivativeIntegration is BaseIntegration {
         });
     }
 
-    function _test_mintAndRegisterIpAndMakeDerivativeWithLicenseTokens() private
+    function _test_mintAndRegisterIpAndMakeDerivativeWithLicenseTokens()
+        private
         logTest("test_DerivativeIntegration_mintAndRegisterIpAndMakeDerivativeWithLicenseTokens")
     {
         StoryUSD.mint(testSender, testMintFee);
@@ -200,7 +203,8 @@ contract DerivativeIntegration is BaseIntegration {
         });
     }
 
-    function _test_registerIpAndMakeDerivativeWithLicenseTokens() private
+    function _test_registerIpAndMakeDerivativeWithLicenseTokens()
+        private
         logTest("test_DerivativeIntegration_registerIpAndMakeDerivativeWithLicenseTokens")
     {
         StoryUSD.mint(testSender, testMintFee);
@@ -281,7 +285,8 @@ contract DerivativeIntegration is BaseIntegration {
         });
     }
 
-    function _test_multicall_mintAndRegisterIpAndMakeDerivative() private
+    function _test_multicall_mintAndRegisterIpAndMakeDerivative()
+        private
         logTest("test_DerivativeIntegration_multicall_mintAndRegisterIpAndMakeDerivative")
     {
         uint256 numCalls = 10;

--- a/test/integration/workflows/GroupingIntegration.t.sol
+++ b/test/integration/workflows/GroupingIntegration.t.sol
@@ -40,7 +40,8 @@ contract GroupingIntegration is BaseIntegration {
         _endBroadcast();
     }
 
-    function _test_GroupingIntegration_mintAndRegisterIpAndAttachLicenseAndAddToGroup() private
+    function _test_GroupingIntegration_mintAndRegisterIpAndAttachLicenseAndAddToGroup()
+        private
         logTest("test_GroupingIntegration_mintAndRegisterIpAndAttachLicenseAndAddToGroup")
     {
         uint256 deadline = block.timestamp + 1000;
@@ -83,7 +84,8 @@ contract GroupingIntegration is BaseIntegration {
         assertEq(licenseTermsId, testLicenseTermsId);
     }
 
-    function _test_GroupingIntegration_registerIpAndAttachLicenseAndAddToGroup() private
+    function _test_GroupingIntegration_registerIpAndAttachLicenseAndAddToGroup()
+        private
         logTest("test_GroupingIntegration_registerIpAndAttachLicenseAndAddToGroup")
     {
         StoryUSD.mint(testSender, testMintFee);
@@ -145,7 +147,8 @@ contract GroupingIntegration is BaseIntegration {
         assertEq(licenseTermsId, testLicenseTermsId);
     }
 
-    function _test_GroupingIntegration_registerGroupAndAttachLicenseAndAddIps() private
+    function _test_GroupingIntegration_registerGroupAndAttachLicenseAndAddIps()
+        private
         logTest("test_GroupingIntegration_registerGroupAndAttachLicenseAndAddIps")
     {
         address newGroupId = groupingWorkflows.registerGroupAndAttachLicenseAndAddIps({
@@ -170,7 +173,8 @@ contract GroupingIntegration is BaseIntegration {
         assertEq(licenseTermsId, testLicenseTermsId);
     }
 
-    function _test_GroupingIntegration_multicall_mintAndRegisterIpAndAttachLicenseAndAddToGroup() private
+    function _test_GroupingIntegration_multicall_mintAndRegisterIpAndAttachLicenseAndAddToGroup()
+        private
         logTest("test_GroupingIntegration_multicall_mintAndRegisterIpAndAttachLicenseAndAddToGroup")
     {
         uint256 deadline = block.timestamp + 1000;
@@ -227,7 +231,8 @@ contract GroupingIntegration is BaseIntegration {
         }
     }
 
-    function _test_GroupingIntegration_multicall_registerIpAndAttachLicenseAndAddToGroup() private
+    function _test_GroupingIntegration_multicall_registerIpAndAttachLicenseAndAddToGroup()
+        private
         logTest("test_GroupingIntegration_multicall_registerIpAndAttachLicenseAndAddToGroup")
     {
         uint256 numCalls = 10;

--- a/test/integration/workflows/LicenseAttachmentIntegration.t.sol
+++ b/test/integration/workflows/LicenseAttachmentIntegration.t.sol
@@ -35,7 +35,8 @@ contract LicenseAttachmentIntegration is BaseIntegration {
         _endBroadcast();
     }
 
-    function _test_LicenseAttachmentIntegration_registerPILTermsAndAttach() private
+    function _test_LicenseAttachmentIntegration_registerPILTermsAndAttach()
+        private
         logTest("test_LicenseAttachmentIntegration_registerPILTermsAndAttach")
     {
         StoryUSD.mint(testSender, testMintFee);
@@ -75,7 +76,8 @@ contract LicenseAttachmentIntegration is BaseIntegration {
         assertEq(licenseTermsId, pilTemplate.getLicenseTermsId(commUseTerms));
     }
 
-    function _test_LicenseAttachmentIntegration_mintAndRegisterIpAndAttachPILTerms() private
+    function _test_LicenseAttachmentIntegration_mintAndRegisterIpAndAttachPILTerms()
+        private
         logTest("test_LicenseAttachmentIntegration_mintAndRegisterIpAndAttachPILTerms")
     {
         // IP 1
@@ -123,7 +125,8 @@ contract LicenseAttachmentIntegration is BaseIntegration {
         }
     }
 
-    function _test_LicenseAttachmentIntegration_registerIpAndAttachPILTerms() private
+    function _test_LicenseAttachmentIntegration_registerIpAndAttachPILTerms()
+        private
         logTest("test_LicenseAttachmentIntegration_registerIpAndAttachPILTerms")
     {
         StoryUSD.mint(testSender, testMintFee);

--- a/test/integration/workflows/RegistrationIntegration.t.sol
+++ b/test/integration/workflows/RegistrationIntegration.t.sol
@@ -68,7 +68,8 @@ contract RegistrationIntegration is BaseIntegration {
         assertTrue(spgNftContract.publicMinting());
     }
 
-    function _test_RegistrationIntegration_mintAndRegisterIp() private
+    function _test_RegistrationIntegration_mintAndRegisterIp()
+        private
         logTest("test_RegistrationIntegration_mintAndRegisterIp")
     {
         StoryUSD.mint(testSender, testMintFee);
@@ -121,7 +122,8 @@ contract RegistrationIntegration is BaseIntegration {
         assertMetadata(actualIpId, testIpMetadata);
     }
 
-    function _test_RegistrationIntegration_multicall_createCollection() private
+    function _test_RegistrationIntegration_multicall_createCollection()
+        private
         logTest("test_RegistrationIntegration_multicall_createCollection")
     {
         uint256 totalCollections = 10;
@@ -164,7 +166,8 @@ contract RegistrationIntegration is BaseIntegration {
         }
     }
 
-    function _test_RegistrationIntegration_multicall_mintAndRegisterIp() private
+    function _test_RegistrationIntegration_multicall_mintAndRegisterIp()
+        private
         logTest("test_RegistrationIntegration_multicall_mintAndRegisterIp")
     {
         uint256 totalIps = 10;

--- a/test/integration/workflows/RoyaltyIntegration.t.sol
+++ b/test/integration/workflows/RoyaltyIntegration.t.sol
@@ -59,7 +59,8 @@ contract RoyaltyIntegration is BaseIntegration {
         _endBroadcast();
     }
 
-    function _test_RoyaltyIntegration_transferToVaultAndSnapshotAndClaimByTokenBatch() private
+    function _test_RoyaltyIntegration_transferToVaultAndSnapshotAndClaimByTokenBatch()
+        private
         logTest("test_RoyaltyIntegration_transferToVaultAndSnapshotAndClaimByTokenBatch")
     {
         // setup IP graph with no snapshot
@@ -125,7 +126,8 @@ contract RoyaltyIntegration is BaseIntegration {
         );
     }
 
-    function _test_RoyaltyIntegration_transferToVaultAndSnapshotAndClaimBySnapshotBatch() private
+    function _test_RoyaltyIntegration_transferToVaultAndSnapshotAndClaimBySnapshotBatch()
+        private
         logTest("test_RoyaltyIntegration_transferToVaultAndSnapshotAndClaimBySnapshotBatch")
     {
         // setup IP graph and takes 3 snapshots of ancestor IP's royalty vault
@@ -192,7 +194,8 @@ contract RoyaltyIntegration is BaseIntegration {
         );
     }
 
-    function _test_RoyaltyIntegration_snapshotAndClaimByTokenBatch() private
+    function _test_RoyaltyIntegration_snapshotAndClaimByTokenBatch()
+        private
         logTest("test_RoyaltyIntegration_snapshotAndClaimByTokenBatch")
     {
         // setup IP graph with no snapshot
@@ -222,7 +225,8 @@ contract RoyaltyIntegration is BaseIntegration {
         );
     }
 
-    function _test_RoyaltyIntegration_snapshotAndClaimBySnapshotBatch() private
+    function _test_RoyaltyIntegration_snapshotAndClaimBySnapshotBatch()
+        private
         logTest("test_RoyaltyIntegration_snapshotAndClaimBySnapshotBatch")
     {
         // setup IP graph and takes 1 snapshot of ancestor IP's royalty vault


### PR DESCRIPTION
## Description

This PR fixes an issue in the upgrade script where deployment addresses were not properly handled due to missing calls to `UpgradeHelper`'s `run()` function. 

Additionally, this PR introduces minor linting adjustments to the integration tests.
