### PR TITLE
 feat(license attachment): add permission handling in registerPILTermsAndAttach

### DIFF
--- a/contracts/interfaces/workflows/ILicenseAttachmentWorkflows.sol
+++ b/contracts/interfaces/workflows/ILicenseAttachmentWorkflows.sol
@@ -11,8 +11,13 @@ interface ILicenseAttachmentWorkflows {
     /// @notice Register Programmable IP License Terms (if unregistered) and attach it to IP.
     /// @param ipId The ID of the IP.
     /// @param terms The PIL terms to be registered.
+    /// @param sigAttach Signature data for attachLicenseTerms to the IP via the Licensing Module.
     /// @return licenseTermsId The ID of the newly registered PIL terms.
-    function registerPILTermsAndAttach(address ipId, PILTerms calldata terms) external returns (uint256 licenseTermsId);
+    function registerPILTermsAndAttach(
+        address ipId,
+        PILTerms calldata terms,
+        WorkflowStructs.SignatureData calldata sigAttach
+    ) external returns (uint256 licenseTermsId);
 
     /// @notice Mint an NFT from a SPGNFT collection, register it with metadata as an IP,
     /// register Programmable IPLicense

--- a/contracts/workflows/LicenseAttachmentWorkflows.sol
+++ b/contracts/workflows/LicenseAttachmentWorkflows.sol
@@ -92,11 +92,21 @@ contract LicenseAttachmentWorkflows is
     /// @notice Register Programmable IP License Terms (if unregistered) and attach it to IP.
     /// @param ipId The ID of the IP.
     /// @param terms The PIL terms to be registered.
+    /// @param sigAttach Signature data for attachLicenseTerms to the IP via the Licensing Module.
     /// @return licenseTermsId The ID of the newly registered PIL terms.
     function registerPILTermsAndAttach(
         address ipId,
-        PILTerms calldata terms
+        PILTerms calldata terms,
+        WorkflowStructs.SignatureData calldata sigAttach
     ) external returns (uint256 licenseTermsId) {
+        PermissionHelper.setPermissionForModule(
+            ipId,
+            address(LICENSING_MODULE),
+            address(ACCESS_CONTROLLER),
+            ILicensingModule.attachLicenseTerms.selector,
+            sigAttach
+        );
+
         licenseTermsId = LicensingHelper.registerPILTermsAndAttach(
             ipId,
             address(PIL_TEMPLATE),

--- a/test/integration/workflows/LicenseAttachmentIntegration.t.sol
+++ b/test/integration/workflows/LicenseAttachmentIntegration.t.sol
@@ -49,7 +49,7 @@ contract LicenseAttachmentIntegration is BaseIntegration {
         });
 
         uint256 deadline = block.timestamp + 1000;
-        (bytes memory signature, , bytes memory data) = _getSetPermissionSigForPeriphery({
+        (bytes memory signature, , ) = _getSetPermissionSigForPeriphery({
             ipId: ipId,
             to: licenseAttachmentWorkflowsAddr,
             module: licensingModuleAddr,
@@ -59,18 +59,14 @@ contract LicenseAttachmentIntegration is BaseIntegration {
             signerSk: testSenderSk
         });
 
-        IIPAccount(payable(ipId)).executeWithSig({
-            to: accessControllerAddr,
-            value: 0,
-            data: data,
-            signer: testSender,
-            deadline: deadline,
-            signature: signature
-        });
-
         uint256 licenseTermsId = licenseAttachmentWorkflows.registerPILTermsAndAttach({
             ipId: ipId,
-            terms: commUseTerms
+            terms: commUseTerms,
+            sigAttach: WorkflowStructs.SignatureData({
+                signer: testSender,
+                deadline: deadline,
+                signature: signature
+            })
         });
 
         assertEq(licenseTermsId, pilTemplate.getLicenseTermsId(commUseTerms));

--- a/test/integration/workflows/LicenseAttachmentIntegration.t.sol
+++ b/test/integration/workflows/LicenseAttachmentIntegration.t.sol
@@ -62,11 +62,7 @@ contract LicenseAttachmentIntegration is BaseIntegration {
         uint256 licenseTermsId = licenseAttachmentWorkflows.registerPILTermsAndAttach({
             ipId: ipId,
             terms: commUseTerms,
-            sigAttach: WorkflowStructs.SignatureData({
-                signer: testSender,
-                deadline: deadline,
-                signature: signature
-            })
+            sigAttach: WorkflowStructs.SignatureData({ signer: testSender, deadline: deadline, signature: signature })
         });
 
         assertEq(licenseTermsId, pilTemplate.getLicenseTermsId(commUseTerms));

--- a/test/integration/workflows/RoyaltyIntegration.t.sol
+++ b/test/integration/workflows/RoyaltyIntegration.t.sol
@@ -310,26 +310,15 @@ contract RoyaltyIntegration is BaseIntegration {
         uint256 deadline = block.timestamp + 1000;
 
         // set permission for licensing module to attach license terms to ancestor IP
-        {
-            (bytes memory signature, , bytes memory data) = _getSetPermissionSigForPeriphery({
-                ipId: ancestorIpId,
-                to: licenseAttachmentWorkflowsAddr,
-                module: licensingModuleAddr,
-                selector: licensingModule.attachLicenseTerms.selector,
-                deadline: deadline,
-                state: IIPAccount(payable(ancestorIpId)).state(),
-                signerSk: testSenderSk
-            });
-
-            IIPAccount(payable(ancestorIpId)).executeWithSig({
-                to: accessControllerAddr,
-                value: 0,
-                data: data,
-                signer: testSender,
-                deadline: deadline,
-                signature: signature
-            });
-        }
+        (bytes memory signature, , ) = _getSetPermissionSigForPeriphery({
+            ipId: ancestorIpId,
+            to: licenseAttachmentWorkflowsAddr,
+            module: licensingModuleAddr,
+            selector: licensingModule.attachLicenseTerms.selector,
+            deadline: deadline,
+            state: IIPAccount(payable(ancestorIpId)).state(),
+            signerSk: testSenderSk
+        });
 
         // register and attach Terms A and C to ancestor IP
         commRemixTermsIdA = licenseAttachmentWorkflows.registerPILTermsAndAttach({
@@ -339,6 +328,11 @@ contract RoyaltyIntegration is BaseIntegration {
                 commercialRevShare: defaultCommRevShareA,
                 royaltyPolicy: royaltyPolicyLRPAddr,
                 currencyToken: address(StoryUSD)
+            }),
+            sigAttach: WorkflowStructs.SignatureData({
+                signer: testSender,
+                deadline: deadline,
+                signature: signature
             })
         });
 
@@ -349,6 +343,11 @@ contract RoyaltyIntegration is BaseIntegration {
                 commercialRevShare: defaultCommRevShareC,
                 royaltyPolicy: royaltyPolicyLAPAddr,
                 currencyToken: address(StoryUSD)
+            }),
+            sigAttach: WorkflowStructs.SignatureData({
+                signer: testSender,
+                deadline: deadline,
+                signature: signature
             })
         });
 

--- a/test/integration/workflows/RoyaltyIntegration.t.sol
+++ b/test/integration/workflows/RoyaltyIntegration.t.sol
@@ -329,11 +329,7 @@ contract RoyaltyIntegration is BaseIntegration {
                 royaltyPolicy: royaltyPolicyLRPAddr,
                 currencyToken: address(StoryUSD)
             }),
-            sigAttach: WorkflowStructs.SignatureData({
-                signer: testSender,
-                deadline: deadline,
-                signature: signature
-            })
+            sigAttach: WorkflowStructs.SignatureData({ signer: testSender, deadline: deadline, signature: signature })
         });
 
         commRemixTermsIdC = licenseAttachmentWorkflows.registerPILTermsAndAttach({
@@ -344,11 +340,7 @@ contract RoyaltyIntegration is BaseIntegration {
                 royaltyPolicy: royaltyPolicyLAPAddr,
                 currencyToken: address(StoryUSD)
             }),
-            sigAttach: WorkflowStructs.SignatureData({
-                signer: testSender,
-                deadline: deadline,
-                signature: signature
-            })
+            sigAttach: WorkflowStructs.SignatureData({ signer: testSender, deadline: deadline, signature: signature })
         });
 
         // register childIpA as derivative of ancestorIp under Terms A

--- a/test/story-nft/OrgNFT.t.sol
+++ b/test/story-nft/OrgNFT.t.sol
@@ -73,7 +73,7 @@ contract OrgNFTTest is BaseTest {
         );
     }
 
-    function test_OrgNFT_interfaceSupport() public {
+    function test_OrgNFT_interfaceSupport() public view {
         assertTrue(IOrgNFT(address(orgNft)).supportsInterface(type(IOrgNFT).interfaceId));
         assertTrue(orgNft.supportsInterface(type(IERC721).interfaceId));
         assertTrue(orgNft.supportsInterface(type(IERC721Metadata).interfaceId));

--- a/test/story-nft/StoryBadgeNFT.t.sol
+++ b/test/story-nft/StoryBadgeNFT.t.sol
@@ -116,7 +116,7 @@ contract StoryBadgeNFTTest is BaseTest {
         );
     }
 
-    function test_StoryBadgeNFT_interfaceSupport() public {
+    function test_StoryBadgeNFT_interfaceSupport() public view {
         assertTrue(BaseStoryNFT(rootStoryNft).supportsInterface(type(IStoryNFT).interfaceId));
         assertTrue(BaseStoryNFT(rootStoryNft).supportsInterface(type(IERC721).interfaceId));
         assertTrue(BaseStoryNFT(rootStoryNft).supportsInterface(type(IERC721Metadata).interfaceId));
@@ -210,7 +210,7 @@ contract StoryBadgeNFTTest is BaseTest {
         bytes memory signature = _signAddress(rootStoryNftSignerSk, u.carl);
 
         vm.startPrank(u.carl);
-        (uint256 tokenId, address ipId) = rootStoryNft.mint(u.carl, signature);
+        (uint256 tokenId, ) = rootStoryNft.mint(u.carl, signature);
 
         vm.expectRevert(IStoryBadgeNFT.StoryBadgeNFT__TransferLocked.selector);
         rootStoryNft.approve(u.bob, tokenId);

--- a/test/story-nft/StoryBadgeNFT.t.sol
+++ b/test/story-nft/StoryBadgeNFT.t.sol
@@ -116,7 +116,7 @@ contract StoryBadgeNFTTest is BaseTest {
         );
     }
 
-    function test_StoryBadgeNFT_interfaceSupport() public view {
+    function test_StoryBadgeNFT_interfaceSupport() public {
         assertTrue(BaseStoryNFT(rootStoryNft).supportsInterface(type(IStoryNFT).interfaceId));
         assertTrue(BaseStoryNFT(rootStoryNft).supportsInterface(type(IERC721).interfaceId));
         assertTrue(BaseStoryNFT(rootStoryNft).supportsInterface(type(IERC721Metadata).interfaceId));

--- a/test/story-nft/StoryNFTFactory.t.sol
+++ b/test/story-nft/StoryNFTFactory.t.sol
@@ -200,7 +200,7 @@ contract StoryNFTFactoryTest is BaseTest {
 
     function test_StoryNFTFactory_getStoryNftAddress() public {
         vm.startPrank(u.carl);
-        (address orgNft, uint256 orgTokenId, address orgIpId, address storyNft) = storyNftFactory.deployStoryNft({
+        (, uint256 orgTokenId, address orgIpId, address storyNft) = storyNftFactory.deployStoryNft({
             storyNftTemplate: defaultStoryNftTemplate,
             orgNftRecipient: u.carl,
             orgName: orgName,

--- a/test/utils/BaseTest.t.sol
+++ b/test/utils/BaseTest.t.sol
@@ -419,7 +419,7 @@ contract BaseTest is Test, DeployHelper {
     }
 
     /// @dev Uses `signerSk` to sign `addr` and return the signature.
-    function _signAddress(uint256 signerSk, address addr) internal view returns (bytes memory signature) {
+    function _signAddress(uint256 signerSk, address addr) internal pure returns (bytes memory signature) {
         bytes32 digest = keccak256(abi.encodePacked(addr)).toEthSignedMessageHash();
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerSk, digest);
         signature = abi.encodePacked(r, s, v);

--- a/test/workflows/LicenseAttachmentWorkflows.t.sol
+++ b/test/workflows/LicenseAttachmentWorkflows.t.sol
@@ -68,11 +68,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
                 currencyToken: address(mockToken),
                 royaltyPolicy: address(royaltyPolicyLAP)
             }),
-            sigAttach: WorkflowStructs.SignatureData({
-                signer: u.alice,
-                deadline: deadline,
-                signature: signature
-            })
+            sigAttach: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: signature })
         });
 
         assertEq(licenseTermsId, ltAmt + 1);
@@ -180,11 +176,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
                 currencyToken: address(mockToken),
                 royaltyPolicy: address(royaltyPolicyLAP)
             }),
-            sigAttach: WorkflowStructs.SignatureData({
-                signer: u.alice,
-                deadline: deadline,
-                signature: signature1
-            })
+            sigAttach: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: signature1 })
         });
 
         (bytes memory signature2, , ) = _getSetPermissionSigForPeriphery({
@@ -205,11 +197,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
                 currencyToken: address(mockToken),
                 royaltyPolicy: address(royaltyPolicyLAP)
             }),
-            sigAttach: WorkflowStructs.SignatureData({
-                signer: u.alice,
-                deadline: deadline,
-                signature: signature2
-            })
+            sigAttach: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: signature2 })
         });
 
         assertEq(licenseTermsId1, licenseTermsId2);
@@ -259,7 +247,6 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
             signerSk: sk.alice
         });
 
-
         // attach a different license terms to the child ip, should revert with the correct error
         vm.expectRevert(CoreErrors.LicensingModule__DerivativesCannotAddLicenseTerms.selector);
         licenseAttachmentWorkflows.registerPILTermsAndAttach({
@@ -269,11 +256,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
                 currencyToken: address(mockToken),
                 royaltyPolicy: address(royaltyPolicyLAP)
             }),
-            sigAttach: WorkflowStructs.SignatureData({
-                signer: u.alice,
-                deadline: deadline,
-                signature: signature
-            })
+            sigAttach: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: signature })
         });
     }
 }

--- a/test/workflows/RoyaltyWorkflows.t.sol
+++ b/test/workflows/RoyaltyWorkflows.t.sol
@@ -394,7 +394,35 @@ contract RoyaltyWorkflowsTest is BaseTest {
 
         // set permission for licensing module to attach license terms to ancestor IP
         {
-            (bytes memory signature, , bytes memory data) = _getSetPermissionSigForPeriphery({
+            (bytes memory signatureA, , ) = _getSetPermissionSigForPeriphery({
+                ipId: ancestorIpId,
+                to: address(licenseAttachmentWorkflows),
+                module: address(licensingModule),
+                selector: licensingModule.attachLicenseTerms.selector,
+                deadline: deadline,
+                state: IIPAccount(payable(ancestorIpId)).state(),
+            signerSk: sk.admin
+        });
+
+            // register and attach Terms A and C to ancestor IP
+            commRemixTermsIdA = licenseAttachmentWorkflows.registerPILTermsAndAttach({
+                ipId: ancestorIpId,
+                terms: PILFlavors.commercialRemix({
+                    mintingFee: defaultMintingFeeA,
+                    commercialRevShare: defaultCommRevShareA,
+                    royaltyPolicy: address(royaltyPolicyLRP),
+                    currencyToken: address(mockTokenA)
+                }),
+                sigAttach: WorkflowStructs.SignatureData({
+                    signer: u.admin,
+                    deadline: deadline,
+                    signature: signatureA
+                })
+            });
+        }
+
+        {
+            (bytes memory signatureC, , ) = _getSetPermissionSigForPeriphery({
                 ipId: ancestorIpId,
                 to: address(licenseAttachmentWorkflows),
                 module: address(licensingModule),
@@ -404,36 +432,21 @@ contract RoyaltyWorkflowsTest is BaseTest {
                 signerSk: sk.admin
             });
 
-            IIPAccount(payable(ancestorIpId)).executeWithSig({
-                to: address(accessController),
-                value: 0,
-                data: data,
-                signer: u.admin,
-                deadline: deadline,
-                signature: signature
+            commRemixTermsIdC = licenseAttachmentWorkflows.registerPILTermsAndAttach({
+                ipId: ancestorIpId,
+                terms: PILFlavors.commercialRemix({
+                    mintingFee: defaultMintingFeeC,
+                    commercialRevShare: defaultCommRevShareC,
+                    royaltyPolicy: address(royaltyPolicyLAP),
+                    currencyToken: address(mockTokenC)
+                }),
+                sigAttach: WorkflowStructs.SignatureData({
+                    signer: u.admin,
+                    deadline: deadline,
+                    signature: signatureC
+                })
             });
         }
-
-        // register and attach Terms A and C to ancestor IP
-        commRemixTermsIdA = licenseAttachmentWorkflows.registerPILTermsAndAttach({
-            ipId: ancestorIpId,
-            terms: PILFlavors.commercialRemix({
-                mintingFee: defaultMintingFeeA,
-                commercialRevShare: defaultCommRevShareA,
-                royaltyPolicy: address(royaltyPolicyLRP),
-                currencyToken: address(mockTokenA)
-            })
-        });
-
-        commRemixTermsIdC = licenseAttachmentWorkflows.registerPILTermsAndAttach({
-            ipId: ancestorIpId,
-            terms: PILFlavors.commercialRemix({
-                mintingFee: defaultMintingFeeC,
-                commercialRevShare: defaultCommRevShareC,
-                royaltyPolicy: address(royaltyPolicyLAP),
-                currencyToken: address(mockTokenC)
-            })
-        });
 
         // register childIpA as derivative of ancestorIp under Terms A
         {

--- a/test/workflows/RoyaltyWorkflows.t.sol
+++ b/test/workflows/RoyaltyWorkflows.t.sol
@@ -401,8 +401,8 @@ contract RoyaltyWorkflowsTest is BaseTest {
                 selector: licensingModule.attachLicenseTerms.selector,
                 deadline: deadline,
                 state: IIPAccount(payable(ancestorIpId)).state(),
-            signerSk: sk.admin
-        });
+                signerSk: sk.admin
+            });
 
             // register and attach Terms A and C to ancestor IP
             commRemixTermsIdA = licenseAttachmentWorkflows.registerPILTermsAndAttach({
@@ -413,11 +413,7 @@ contract RoyaltyWorkflowsTest is BaseTest {
                     royaltyPolicy: address(royaltyPolicyLRP),
                     currencyToken: address(mockTokenA)
                 }),
-                sigAttach: WorkflowStructs.SignatureData({
-                    signer: u.admin,
-                    deadline: deadline,
-                    signature: signatureA
-                })
+                sigAttach: WorkflowStructs.SignatureData({ signer: u.admin, deadline: deadline, signature: signatureA })
             });
         }
 
@@ -440,11 +436,7 @@ contract RoyaltyWorkflowsTest is BaseTest {
                     royaltyPolicy: address(royaltyPolicyLAP),
                     currencyToken: address(mockTokenC)
                 }),
-                sigAttach: WorkflowStructs.SignatureData({
-                    signer: u.admin,
-                    deadline: deadline,
-                    signature: signatureC
-                })
+                sigAttach: WorkflowStructs.SignatureData({ signer: u.admin, deadline: deadline, signature: signatureC })
             });
         }
 


### PR DESCRIPTION
## Description
This PR updates the `registerPILTermsAndAttach` function in `LicenseAttachmentWorkflows` to streamline permission handling. Previously, the caller needed to manually set permission for `LicenseAttachmentWorkflows` to invoke the `attachLicenseTerms` function in the `LicensingModule`. Now, this permission is automatically set within the function, using the provided signature.

#### Key Changes
- Added a call to `setPermissionForModule`, which grants the required permission to call `attachLicenseTerms` on behalf of the IP.
- Introduced a new parameter in `registerPILTermsAndAttach` to pass the signature required for setting the permission.
- Updated existing tests to reflect these changes.
- Minor test cleanup.

## Test Plan
All existing tests have been updated and are passing locally.

## Related Issue
- Closes #88 