### PR TITLE
feat(story-nft): enable URI changes post deployment

### DIFF
--- a/contracts/interfaces/story-nft/IOrgNFT.sol
+++ b/contracts/interfaces/story-nft/IOrgNFT.sol
@@ -16,6 +16,12 @@ interface IOrgNFT is IERC721Metadata {
     /// @param storyNftFactory The address of the `StoryNFTFactory` contract.
     error OrgNFT__CallerNotStoryNFTFactory(address caller, address storyNftFactory);
 
+    /// @notice Caller is not the owner of `tokenId` organization token.
+    /// @param tokenId The ID of the organization token.
+    /// @param caller The address of the caller.
+    /// @param owner The address of the owner of `tokenId` organization token.
+    error OrgNFT__CallerNotOwner(uint256 tokenId, address caller, address owner);
+
     /// @notice Root organization NFT has already been minted.
     error OrgNFT__RootOrgNftAlreadyMinted();
 
@@ -58,6 +64,11 @@ interface IOrgNFT is IERC721Metadata {
         address recipient,
         string memory tokenURI
     ) external returns (uint256 orgTokenId, address orgIpId);
+
+    /// @notice Sets the tokenURI of `tokenId` organization token.
+    /// @param tokenId The ID of the organization token.
+    /// @param tokenURI The new tokenURI of the organization token.
+    function setTokenURI(uint256 tokenId, string memory tokenURI) external;
 
     /// @notice Returns the ID of the root organization IP.
     function getRootOrgIpId() external view returns (address);

--- a/contracts/interfaces/story-nft/IStoryNFT.sol
+++ b/contracts/interfaces/story-nft/IStoryNFT.sol
@@ -9,8 +9,15 @@ interface IStoryNFT is IERC721 {
     ////////////////////////////////////////////////////////////////////////////
     //                              Errors                                     //
     ////////////////////////////////////////////////////////////////////////////
-    /// @notice Zero address provided as a param to BaseStoryNFT constructor.
-    error BaseStoryNFT__ZeroAddressParam();
+    /// @notice Zero address provided as a param to StoryNFT constructor.
+    error StoryNFT__ZeroAddressParam();
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                              Events                                     //
+    ////////////////////////////////////////////////////////////////////////////
+    /// @notice Emitted when the contractURI is set.
+    /// @param contractURI The new contractURI of the collection.
+    event ContractMetadataUpdated(string contractURI);
 
     ////////////////////////////////////////////////////////////////////////////
     //                              Structs                                   //
@@ -39,6 +46,9 @@ interface IStoryNFT is IERC721 {
     /// @param orgIpId_ The ID of the organization IP.
     /// @param initParams The initialization parameters for StoryNFT {see {StoryNftInitParams}}.
     function initialize(uint256 orgTokenId_, address orgIpId_, StoryNftInitParams calldata initParams) external;
+
+    /// @notice Sets the contractURI of the collection (follows OpenSea contract-level metadata standard).
+    function setContractURI(string memory contractURI) external;
 
     /// @notice Returns the current total supply of the collection.
     function totalSupply() external view returns (uint256);

--- a/contracts/story-nft/BaseStoryNFT.sol
+++ b/contracts/story-nft/BaseStoryNFT.sol
@@ -50,7 +50,7 @@ abstract contract BaseStoryNFT is IStoryNFT, ERC721URIStorage, Ownable, Initiali
 
     constructor(address ipAssetRegistry, address licensingModule, address orgNft) ERC721("", "") Ownable(msg.sender) {
         if (ipAssetRegistry == address(0) || licensingModule == address(0) || orgNft == address(0))
-            revert BaseStoryNFT__ZeroAddressParam();
+            revert StoryNFT__ZeroAddressParam();
         IP_ASSET_REGISTRY = IIPAssetRegistry(ipAssetRegistry);
         LICENSING_MODULE = ILicensingModule(licensingModule);
         ORG_NFT = orgNft;
@@ -65,7 +65,7 @@ abstract contract BaseStoryNFT is IStoryNFT, ERC721URIStorage, Ownable, Initiali
         address orgIpId_,
         StoryNftInitParams calldata initParams
     ) public virtual initializer {
-        if (initParams.owner == address(0) || orgIpId_ == address(0)) revert BaseStoryNFT__ZeroAddressParam();
+        if (initParams.owner == address(0) || orgIpId_ == address(0)) revert StoryNFT__ZeroAddressParam();
 
         orgTokenId = orgTokenId_;
         orgIpId = orgIpId_;
@@ -77,6 +77,14 @@ abstract contract BaseStoryNFT is IStoryNFT, ERC721URIStorage, Ownable, Initiali
 
         _transferOwnership(initParams.owner);
         _customize(initParams.customInitData);
+    }
+
+    /// @notice Sets the contractURI of the collection (follows OpenSea contract-level metadata standard).
+    /// @param contractURI_ The new contractURI of the collection.
+    function setContractURI(string memory contractURI_) external onlyOwner {
+        _contractURI = contractURI_;
+
+        emit ContractMetadataUpdated(contractURI_);
     }
 
     /// @notice Mints a new token and registers as an IP asset without specifying a tokenURI.

--- a/contracts/story-nft/OrgNFT.sol
+++ b/contracts/story-nft/OrgNFT.sol
@@ -141,6 +141,14 @@ contract OrgNFT is IOrgNFT, ERC721URIStorageUpgradeable, AccessManagedUpgradeabl
         _safeTransfer(address(this), recipient, orgTokenId);
     }
 
+    /// @notice Sets the tokenURI of `tokenId` organization token.
+    /// @param tokenId The ID of the organization token.
+    /// @param tokenURI_ The new tokenURI of the organization token.
+    function setTokenURI(uint256 tokenId, string memory tokenURI_) external {
+        if (msg.sender != ownerOf(tokenId)) revert OrgNFT__CallerNotOwner(tokenId, msg.sender, ownerOf(tokenId));
+        _setTokenURI(tokenId, tokenURI_);
+    }
+
     /// @notice Mints a organization token and register it as an IP.
     /// @param recipient The address of the recipient of the minted organization token.
     /// @param tokenURI_ The URI of the minted organization token.

--- a/test/story-nft/OrgNFT.t.sol
+++ b/test/story-nft/OrgNFT.t.sol
@@ -47,6 +47,27 @@ contract OrgNFTTest is BaseTest {
         assertEq(testOrgNft.authority(), address(protocolAccessManager));
     }
 
+    function test_OrgNFT_setTokenURI() public {
+        string memory oldTokenURI = orgNft.tokenURI(0);
+        string memory newTokenURI = "test";
+
+        assertNotEq(oldTokenURI, newTokenURI);
+
+        vm.startPrank(rootStoryNftOwner);
+        orgNft.setTokenURI(0, newTokenURI);
+        assertEq(orgNft.tokenURI(0), newTokenURI);
+        orgNft.setTokenURI(0, oldTokenURI);
+        assertEq(orgNft.tokenURI(0), oldTokenURI);
+        vm.stopPrank();
+    }
+
+    function test_OrgNFT_revert_setTokenURI_CallerIsNotOwner() public {
+        vm.startPrank(u.bob);
+        vm.expectRevert(abi.encodeWithSelector(IOrgNFT.OrgNFT__CallerNotOwner.selector, 0, u.bob, rootStoryNftOwner));
+        orgNft.setTokenURI(0, "test");
+        vm.stopPrank();
+    }
+
     function test_OrgNFT_revert_initialize_ZeroAddress() public {
         vm.expectRevert(IOrgNFT.OrgNFT__ZeroAddressParam.selector);
         OrgNFT testOrgNft = new OrgNFT({

--- a/test/story-nft/StoryBadgeNFT.t.sol
+++ b/test/story-nft/StoryBadgeNFT.t.sol
@@ -70,7 +70,7 @@ contract StoryBadgeNFTTest is BaseTest {
     }
 
     function test_StoryBadgeNFT_revert_initialize_ZeroAddress() public {
-        vm.expectRevert(IStoryNFT.BaseStoryNFT__ZeroAddressParam.selector);
+        vm.expectRevert(IStoryNFT.StoryNFT__ZeroAddressParam.selector);
         StoryBadgeNFT testStoryBadgeNft = new StoryBadgeNFT(
             address(ipAssetRegistry),
             address(licensingModule),
@@ -149,6 +149,28 @@ contract StoryBadgeNFTTest is BaseTest {
             expectedParentCount: 1,
             expectedParentIndex: 0
         });
+    }
+
+    function test_StoryBadgeNFT_setContractURI() public {
+        string memory oldContractURI = rootStoryNft.contractURI();
+        string memory newContractURI = "New Contract URI";
+
+        assertNotEq(oldContractURI, newContractURI);
+
+        vm.startPrank(rootStoryNftOwner);
+        rootStoryNft.setContractURI(newContractURI);
+        assertEq(rootStoryNft.contractURI(), newContractURI);
+
+        rootStoryNft.setContractURI(oldContractURI);
+        assertEq(rootStoryNft.contractURI(), oldContractURI);
+        vm.stopPrank();
+    }
+
+    function test_StoryBadgeNFT_revert_setContractURI_CallerIsNotOwner() public {
+        vm.startPrank(u.carl);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, u.carl));
+        rootStoryNft.setContractURI("New Contract URI");
+        vm.stopPrank();
     }
 
     function test_StoryBadgeNFT_setSigner() public {


### PR DESCRIPTION
## Description

This PR enables two types of URI changes after deploying Story NFT:

1. **OrgNFT TokenURI Update**: Allows the owner of an OrgNFT to change its `tokenURI` after the token has been minted.

2. **Story NFT ContractURI Update**: Allows the owner of the Story NFT contract to change its `contractURI` after the contract has been deployed.

## Test Plan

Added new test cases for setting the URIs. All new and existing tests pass locally.

## Related Issue

- Closes #90