### PR TITLE
feat(SPGNFT): add ERC-7572 contract-level metadata support

### DIFF
--- a/contracts/SPGNFT.sol
+++ b/contracts/SPGNFT.sol
@@ -32,6 +32,7 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
         bool _mintOpen;
         bool _publicMinting;
         string _baseURI;
+        string _contractURI;
     }
 
     // keccak256(abi.encode(uint256(keccak256("story-protocol-periphery.SPGNFT")) - 1)) & ~bytes32(uint256(0xff));
@@ -100,6 +101,7 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
         $._mintOpen = initParams.mintOpen;
         $._publicMinting = initParams.isPublicMinting;
         $._baseURI = initParams.baseURI;
+        $._contractURI = initParams.contractURI;
 
         __ERC721_init(initParams.name, initParams.symbol);
     }
@@ -141,24 +143,29 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
         return _baseURI();
     }
 
+    /// @notice Returns the contract URI for the collection.
+    function contractURI() external view returns (string memory) {
+        return _getSPGNFTStorage()._contractURI;
+    }
+
     /// @notice Sets the fee to mint an NFT from the collection. Payment is in the designated currency.
     /// @dev Only callable by the admin role.
     /// @param fee The new mint fee paid in the mint token.
-    function setMintFee(uint256 fee) public onlyRole(SPGNFTLib.ADMIN_ROLE) {
+    function setMintFee(uint256 fee) external onlyRole(SPGNFTLib.ADMIN_ROLE) {
         _getSPGNFTStorage()._mintFee = fee;
     }
 
     /// @notice Sets the mint token for the collection.
     /// @dev Only callable by the admin role.
     /// @param token The new mint token for mint payment.
-    function setMintFeeToken(address token) public onlyRole(SPGNFTLib.ADMIN_ROLE) {
+    function setMintFeeToken(address token) external onlyRole(SPGNFTLib.ADMIN_ROLE) {
         _getSPGNFTStorage()._mintFeeToken = token;
     }
 
     /// @notice Sets the recipient of mint fees.
     /// @dev Only callable by the fee recipient.
     /// @param newFeeRecipient The new fee recipient.
-    function setMintFeeRecipient(address newFeeRecipient) public {
+    function setMintFeeRecipient(address newFeeRecipient) external {
         if (msg.sender != _getSPGNFTStorage()._mintFeeRecipient) {
             revert Errors.SPGNFT__CallerNotFeeRecipient();
         }
@@ -168,14 +175,14 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
     /// @notice Sets the minting status.
     /// @dev Only callable by the admin role.
     /// @param mintOpen Whether minting is open or not.
-    function setMintOpen(bool mintOpen) public onlyRole(SPGNFTLib.ADMIN_ROLE) {
+    function setMintOpen(bool mintOpen) external onlyRole(SPGNFTLib.ADMIN_ROLE) {
         _getSPGNFTStorage()._mintOpen = mintOpen;
     }
 
     /// @notice Sets the public minting status.
     /// @dev Only callable by the admin role.
     /// @param isPublicMinting Whether the collection is open for public minting or not.
-    function setPublicMinting(bool isPublicMinting) public onlyRole(SPGNFTLib.ADMIN_ROLE) {
+    function setPublicMinting(bool isPublicMinting) external onlyRole(SPGNFTLib.ADMIN_ROLE) {
         _getSPGNFTStorage()._publicMinting = isPublicMinting;
     }
 
@@ -183,8 +190,18 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
     /// either baseURI + token ID (if nftMetadataURI is empty) or baseURI + nftMetadataURI.
     /// @dev Only callable by the admin role.
     /// @param baseURI The new base URI for the collection.
-    function setBaseURI(string memory baseURI) public onlyRole(SPGNFTLib.ADMIN_ROLE) {
+    function setBaseURI(string memory baseURI) external onlyRole(SPGNFTLib.ADMIN_ROLE) {
         _getSPGNFTStorage()._baseURI = baseURI;
+    }
+
+    /// @notice Sets the contract URI for the collection.
+    /// @dev Only callable by the admin role.
+    /// @param contractURI The new contract URI for the collection. Follows ERC-7572 standard.
+    ///        See https://eips.ethereum.org/EIPS/eip-7572
+    function setContractURI(string memory contractURI) external onlyRole(SPGNFTLib.ADMIN_ROLE) {
+        _getSPGNFTStorage()._contractURI = contractURI;
+
+        emit ContractURIUpdated();
     }
 
     /// @notice Mints an NFT from the collection. Only callable by the minter role.

--- a/contracts/interfaces/ISPGNFT.sol
+++ b/contracts/interfaces/ISPGNFT.sol
@@ -2,16 +2,19 @@
 pragma solidity 0.8.26;
 
 import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
-import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import { IERC721Metadata } from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
 
-interface ISPGNFT is IAccessControl, IERC721, IERC721Metadata {
+import { IERC7572 } from "./story-nft/IERC7572.sol";
+
+interface ISPGNFT is IAccessControl, IERC721Metadata, IERC7572 {
     /// @notice Struct for initializing the NFT collection.
     /// @dev If mint fee is non-zero, mint token must be set.
     /// @param name The name of the collection.
     /// @param symbol The symbol of the collection.
-    /// @param baseURI The base URI for the collection. If baseURI is not empty, tokenURI will be
-    /// either baseURI + token ID (if nftMetadataURI is empty) or baseURI + nftMetadataURI.
+    /// @param baseURI The base URI for the collection. If baseURI is not empty, tokenURI will be either
+    ///                baseURI + token ID (if nftMetadataURI is empty) or baseURI + nftMetadataURI.
+    /// @param contractURI The contract URI for the collection. Follows ERC-7572 standard.
+    ///                    See https://eips.ethereum.org/EIPS/eip-7572
     /// @param maxSupply The maximum supply of the collection.
     /// @param mintFee The fee to mint an NFT from the collection.
     /// @param mintFeeToken The token to pay for minting.
@@ -24,6 +27,7 @@ interface ISPGNFT is IAccessControl, IERC721, IERC721Metadata {
         string name;
         string symbol;
         string baseURI;
+        string contractURI;
         uint32 maxSupply;
         uint256 mintFee;
         address mintFeeToken;
@@ -91,6 +95,12 @@ interface ISPGNFT is IAccessControl, IERC721, IERC721Metadata {
     /// @dev Only callable by the admin role.
     /// @param baseURI The new base URI for the collection.
     function setBaseURI(string memory baseURI) external;
+
+    /// @notice Sets the contract URI for the collection.
+    /// @dev Only callable by the admin role.
+    /// @param contractURI The new contract URI for the collection. Follows ERC-7572 standard.
+    ///        See https://eips.ethereum.org/EIPS/eip-7572
+    function setContractURI(string memory contractURI) external;
 
     /// @notice Mints an NFT from the collection. Only callable by the minter role.
     /// @param to The address of the recipient of the minted NFT.

--- a/contracts/interfaces/story-nft/IERC7572.sol
+++ b/contracts/interfaces/story-nft/IERC7572.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+/// @title ERC7572 interface
+/// @notice Interface for supporting contract-level metadata
+interface IERC7572 {
+    /// @notice Emitted when the contract-level metadata is updated
+    event ContractURIUpdated();
+
+    /// @notice Returns the contract-level metadata
+    function contractURI() external view returns (string memory);
+}

--- a/contracts/interfaces/story-nft/IStoryBadgeNFT.sol
+++ b/contracts/interfaces/story-nft/IStoryBadgeNFT.sol
@@ -8,7 +8,7 @@ import { IStoryNFT } from "./IStoryNFT.sol";
 
 /// @title Story Badge NFT Interface
 /// @notice A Story Badge NFT is a soulbound NFT that has an unified token URI for all tokens.
-interface IStoryBadgeNFT is IStoryNFT, IERC5192, IERC721Metadata {
+interface IStoryBadgeNFT is IStoryNFT, IERC721Metadata, IERC5192 {
     ////////////////////////////////////////////////////////////////////////////
     //                              Errors                                    //
     ////////////////////////////////////////////////////////////////////////////

--- a/contracts/interfaces/story-nft/IStoryNFT.sol
+++ b/contracts/interfaces/story-nft/IStoryNFT.sol
@@ -3,21 +3,17 @@ pragma solidity 0.8.26;
 
 import { IERC721 } from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
+import { IERC7572 } from "./IERC7572.sol";
+
 /// @title IStoryNFT
 /// @notice Interface for StoryNFT contracts.
-interface IStoryNFT is IERC721 {
+interface IStoryNFT is IERC721, IERC7572 {
     ////////////////////////////////////////////////////////////////////////////
     //                              Errors                                     //
     ////////////////////////////////////////////////////////////////////////////
     /// @notice Zero address provided as a param to StoryNFT constructor.
     error StoryNFT__ZeroAddressParam();
 
-    ////////////////////////////////////////////////////////////////////////////
-    //                              Events                                     //
-    ////////////////////////////////////////////////////////////////////////////
-    /// @notice Emitted when the contractURI is set.
-    /// @param contractURI The new contractURI of the collection.
-    event ContractMetadataUpdated(string contractURI);
 
     ////////////////////////////////////////////////////////////////////////////
     //                              Structs                                   //
@@ -52,7 +48,4 @@ interface IStoryNFT is IERC721 {
 
     /// @notice Returns the current total supply of the collection.
     function totalSupply() external view returns (uint256);
-
-    /// @notice Returns the contract URI of the collection (follows OpenSea contract-level metadata standard).
-    function contractURI() external view returns (string memory);
 }

--- a/contracts/story-nft/BaseStoryNFT.sol
+++ b/contracts/story-nft/BaseStoryNFT.sol
@@ -84,7 +84,7 @@ abstract contract BaseStoryNFT is IStoryNFT, ERC721URIStorage, Ownable, Initiali
     function setContractURI(string memory contractURI_) external onlyOwner {
         _contractURI = contractURI_;
 
-        emit ContractMetadataUpdated(contractURI_);
+        emit ContractURIUpdated();
     }
 
     /// @notice Mints a new token and registers as an IP asset without specifying a tokenURI.

--- a/test/SPGNFT.t.sol
+++ b/test/SPGNFT.t.sol
@@ -28,6 +28,7 @@ contract SPGNFTTest is BaseTest {
                     name: "Test Collection",
                     symbol: "TEST",
                     baseURI: testBaseURI,
+                    contractURI: testContractURI,
                     maxSupply: 100,
                     mintFee: 100 * 10 ** mockToken.decimals(),
                     mintFeeToken: address(mockToken),
@@ -57,6 +58,7 @@ contract SPGNFTTest is BaseTest {
                 name: "Test Collection",
                 symbol: "TEST",
                 baseURI: testBaseURI,
+                contractURI: testContractURI,
                 maxSupply: 100,
                 mintFee: 100 * 10 ** mockToken.decimals(),
                 mintFeeToken: address(mockToken),
@@ -76,6 +78,8 @@ contract SPGNFTTest is BaseTest {
         assertEq(anotherNftContract.mintFeeRecipient(), feeRecipient);
         assertTrue(anotherNftContract.mintOpen());
         assertFalse(anotherNftContract.publicMinting());
+        assertEq(anotherNftContract.contractURI(), testContractURI);
+        assertEq(anotherNftContract.baseURI(), testBaseURI);
     }
 
     function test_SPGNFT_initialize_revert_zeroParams() public {
@@ -96,6 +100,7 @@ contract SPGNFTTest is BaseTest {
                 name: "Test Collection",
                 symbol: "TEST",
                 baseURI: testBaseURI,
+                contractURI: testContractURI,
                 maxSupply: 100,
                 mintFee: 1,
                 mintFeeToken: address(0),
@@ -112,6 +117,7 @@ contract SPGNFTTest is BaseTest {
                 name: "Test Collection",
                 symbol: "TEST",
                 baseURI: testBaseURI,
+                contractURI: testContractURI,
                 maxSupply: 0,
                 mintFee: 0,
                 mintFeeToken: address(mockToken),
@@ -193,6 +199,18 @@ contract SPGNFTTest is BaseTest {
         assertEq(nftContract.tokenURI(tokenId2), ipMetadataEmpty.nftMetadataURI);
         assertEq(nftContract.tokenURI(tokenId3), ipMetadataDefault.nftMetadataURI);
 
+        vm.stopPrank();
+    }
+
+    function test_SPGNFT_setContractURI() public {
+        assertEq(nftContract.contractURI(), testContractURI);
+
+        vm.startPrank(u.alice); // owner (admin) of the collection
+        nftContract.setContractURI("test");
+        assertEq(nftContract.contractURI(), "test");
+
+        nftContract.setContractURI(testContractURI);
+        assertEq(nftContract.contractURI(), testContractURI);
         vm.stopPrank();
     }
 

--- a/test/integration/BaseIntegration.t.sol
+++ b/test/integration/BaseIntegration.t.sol
@@ -66,6 +66,7 @@ contract BaseIntegration is Test, Script, StoryProtocolCoreAddressManager, Story
     string internal testCollectionName;
     string internal testCollectionSymbol;
     string internal testBaseURI;
+    string internal testContractURI;
     uint32 internal testMaxSupply;
     uint256 internal testMintFee;
     address internal testMintFeeToken;
@@ -110,6 +111,7 @@ contract BaseIntegration is Test, Script, StoryProtocolCoreAddressManager, Story
         testCollectionName = "Test Collection";
         testCollectionSymbol = "TEST";
         testBaseURI = "https://test.com/";
+        testContractURI = "https://test-contract-uri.com/";
         testMaxSupply = 100_000;
         testMintFee = 10 * 10 ** StoryUSD.decimals(); // 10 SUSD
         testMintFeeToken = address(StoryUSD);

--- a/test/integration/workflows/DerivativeIntegration.t.sol
+++ b/test/integration/workflows/DerivativeIntegration.t.sol
@@ -341,6 +341,7 @@ contract DerivativeIntegration is BaseIntegration {
                     name: testCollectionName,
                     symbol: testCollectionSymbol,
                     baseURI: testBaseURI,
+                    contractURI: testContractURI,
                     maxSupply: testMaxSupply,
                     mintFee: testMintFee,
                     mintFeeToken: testMintFeeToken,

--- a/test/integration/workflows/GroupingIntegration.t.sol
+++ b/test/integration/workflows/GroupingIntegration.t.sol
@@ -366,6 +366,7 @@ contract GroupingIntegration is BaseIntegration {
                         name: testCollectionName,
                         symbol: testCollectionSymbol,
                         baseURI: testBaseURI,
+                        contractURI: testContractURI,
                         maxSupply: testMaxSupply,
                         mintFee: testMintFee,
                         mintFeeToken: testMintFeeToken,

--- a/test/integration/workflows/LicenseAttachmentIntegration.t.sol
+++ b/test/integration/workflows/LicenseAttachmentIntegration.t.sol
@@ -180,6 +180,7 @@ contract LicenseAttachmentIntegration is BaseIntegration {
                     name: testCollectionName,
                     symbol: testCollectionSymbol,
                     baseURI: testBaseURI,
+                    contractURI: testContractURI,
                     maxSupply: testMaxSupply,
                     mintFee: testMintFee,
                     mintFeeToken: testMintFeeToken,

--- a/test/integration/workflows/RegistrationIntegration.t.sol
+++ b/test/integration/workflows/RegistrationIntegration.t.sol
@@ -44,6 +44,7 @@ contract RegistrationIntegration is BaseIntegration {
                     name: testCollectionName,
                     symbol: testCollectionSymbol,
                     baseURI: testBaseURI,
+                    contractURI: testContractURI,
                     maxSupply: testMaxSupply,
                     mintFee: testMintFee,
                     mintFeeToken: testMintFeeToken,
@@ -58,6 +59,7 @@ contract RegistrationIntegration is BaseIntegration {
         assertEq(spgNftContract.name(), testCollectionName);
         assertEq(spgNftContract.symbol(), testCollectionSymbol);
         assertEq(spgNftContract.baseURI(), testBaseURI);
+        assertEq(spgNftContract.contractURI(), testContractURI);
         assertEq(spgNftContract.totalSupply(), 0);
         assertEq(spgNftContract.mintFee(), testMintFee);
         assertEq(spgNftContract.mintFeeToken(), testMintFeeToken);
@@ -137,6 +139,7 @@ contract RegistrationIntegration is BaseIntegration {
                     name: testCollectionName,
                     symbol: testCollectionSymbol,
                     baseURI: testBaseURI,
+                    contractURI: testContractURI,
                     maxSupply: testMaxSupply,
                     mintFee: testMintFee,
                     mintFeeToken: testMintFeeToken,
@@ -163,6 +166,7 @@ contract RegistrationIntegration is BaseIntegration {
             assertEq(nftContracts[i].mintFeeRecipient(), testSender);
             assertTrue(nftContracts[i].mintOpen());
             assertFalse(nftContracts[i].publicMinting());
+            assertEq(nftContracts[i].contractURI(), testContractURI);
         }
     }
 

--- a/test/integration/workflows/RoyaltyIntegration.t.sol
+++ b/test/integration/workflows/RoyaltyIntegration.t.sol
@@ -590,6 +590,7 @@ contract RoyaltyIntegration is BaseIntegration {
                     name: testCollectionName,
                     symbol: testCollectionSymbol,
                     baseURI: testBaseURI,
+                    contractURI: testContractURI,
                     maxSupply: testMaxSupply,
                     mintFee: 0,
                     mintFeeToken: testMintFeeToken,

--- a/test/utils/BaseTest.t.sol
+++ b/test/utils/BaseTest.t.sol
@@ -72,6 +72,7 @@ contract BaseTest is Test, DeployHelper {
 
     /// @dev test baseURI
     string internal testBaseURI = "https://test-base-uri.com/";
+    string internal testContractURI = "https://test-contract-uri.com/";
 
     constructor() DeployHelper(CREATE3_DEPLOYER) {}
 
@@ -143,6 +144,7 @@ contract BaseTest is Test, DeployHelper {
                     name: "Test SPG NFT Public",
                     symbol: "TSPGNFTPUB",
                     baseURI: testBaseURI,
+                    contractURI: testContractURI,
                     maxSupply: 100_000_000,
                     mintFee: 1 * 10 ** mockToken.decimals(), // 1 token
                     mintFeeToken: address(mockToken),
@@ -160,6 +162,7 @@ contract BaseTest is Test, DeployHelper {
                     name: "Test SPG NFT Private",
                     symbol: "TSPGNFTPRI",
                     baseURI: testBaseURI,
+                    contractURI: testContractURI,
                     maxSupply: 100_000_000,
                     mintFee: 1 * 10 ** mockToken.decimals(), // 1 token
                     mintFeeToken: address(mockToken),
@@ -247,6 +250,7 @@ contract BaseTest is Test, DeployHelper {
                     name: "Test Collection",
                     symbol: "TEST",
                     baseURI: testBaseURI,
+                    contractURI: testContractURI,
                     maxSupply: 100,
                     mintFee: 100 * 10 ** mockToken.decimals(),
                     mintFeeToken: address(mockToken),

--- a/test/workflows/RegistrationWorkflows.t.sol
+++ b/test/workflows/RegistrationWorkflows.t.sol
@@ -26,6 +26,8 @@ contract RegistrationWorkflowsTest is BaseTest {
     function test_RegistrationWorkflows_createCollection() public withCollection {
         assertEq(nftContract.name(), "Test Collection");
         assertEq(nftContract.symbol(), "TEST");
+        assertEq(nftContract.baseURI(), testBaseURI);
+        assertEq(nftContract.contractURI(), testContractURI);
         assertEq(nftContract.totalSupply(), 0);
         assertTrue(nftContract.hasRole(SPGNFTLib.MINTER_ROLE, u.alice));
         assertEq(nftContract.mintFee(), 100 * 10 ** mockToken.decimals());
@@ -43,6 +45,7 @@ contract RegistrationWorkflowsTest is BaseTest {
                     name: "Test Private Collection",
                     symbol: "TESTPRIV",
                     baseURI: testBaseURI,
+                    contractURI: testContractURI,
                     maxSupply: 100,
                     mintFee: 100 * 10 ** mockToken.decimals(),
                     mintFeeToken: address(mockToken),
@@ -71,6 +74,7 @@ contract RegistrationWorkflowsTest is BaseTest {
                     name: "Test Public Collection",
                     symbol: "TESTPUB",
                     baseURI: testBaseURI,
+                    contractURI: testContractURI,
                     maxSupply: 100,
                     mintFee: 1 * 10 ** mockToken.decimals(),
                     mintFeeToken: address(mockToken),
@@ -163,6 +167,7 @@ contract RegistrationWorkflowsTest is BaseTest {
                 ISPGNFT.InitParams({
                     name: "Test Collection",
                     symbol: "TEST",
+                    contractURI: testContractURI,
                     baseURI: testBaseURI,
                     maxSupply: 100,
                     mintFee: 100 * 10 ** mockToken.decimals(),
@@ -190,6 +195,7 @@ contract RegistrationWorkflowsTest is BaseTest {
             assertEq(nftContracts[i].mintFeeRecipient(), u.carl);
             assertTrue(nftContracts[i].mintOpen());
             assertFalse(nftContracts[i].publicMinting());
+            assertEq(nftContracts[i].contractURI(), testContractURI);
         }
     }
 


### PR DESCRIPTION
## Description
<!-- Add a description of the changes that this PR introduces -->
This PR introduces ERC-7572 contract-level metadata support to `SPGNFT` and updates the existing contract-level metadata in `IStoryNFT` and `BaseStoryNFT` to comply with the ERC-7572 standard.

#### Key Changes
- Added `IERC7572`; both `IStoryNFT` and `SPGNFT` now inherit from `IERC7572`.
- Introduced a new `_contractURI` field in `SPGNFTStorage`, along with corresponding getter (`contractURI`) and setter (`setContractURI`) functions in SPGNFT.
- `setContractURI` in `BaseStoryNFT` now emits `ContractURIUpdated` event defined in `IERC7572`
- Minor cleanups:
	- Removed redundant inheritance in `ISPGNFT`.
	- Updated setter functions in `SPGNFT` to be external rather than public.


## Test Plan 
<!-- The test plan section indicates detailed steps on how to verify and test code changes. 
You can list the test cases or test steps that need to be performed.-->
- Added tests for the `setContractURI` function in `SPGNFT`.
- Added assertions for `contractURI` in `SPGNFT` initialization and `RegistrationWorkflows` tests for `CreateCollection`.
All new and existing tests pass locally.

## Related Issue
<!-- The related Issue section can indicate which issue or task the Pull Request is related with -->
- Closes #83 

## Notes
<!-- The Important Matters section can alert others to special requirements or matters that need extra attention -->
This PR include interface changes to `SPGNFT` and `createCollection` function in `RegistrationWorkflows`