### PR TITLE
fix(story-nft): resolve reentrancy vulnerability

### DIFF
--- a/contracts/story-nft/StoryBadgeNFT.sol
+++ b/contracts/story-nft/StoryBadgeNFT.sol
@@ -70,6 +70,9 @@ contract StoryBadgeNFT is IStoryBadgeNFT, BaseStoryNFT, ERC721Holder {
         // The given signature must not have been used
         if (_usedSignatures[signature]) revert StoryBadgeNFT__SignatureAlreadyUsed();
 
+        // Mark the signature as used
+        _usedSignatures[signature] = true;
+
         // The given signature must be valid
         bytes32 digest = keccak256(abi.encodePacked(msg.sender)).toEthSignedMessageHash();
         if (!SignatureChecker.isValidSignatureNow(_signer, digest, signature)) revert StoryBadgeNFT__InvalidSignature();
@@ -87,9 +90,6 @@ contract StoryBadgeNFT is IStoryBadgeNFT, BaseStoryNFT, ERC721Holder {
 
         // Transfer the badge to the recipient
         _safeTransfer(address(this), recipient, tokenId);
-
-        // Mark the signature as used
-        _usedSignatures[signature] = true;
 
         emit StoryBadgeNFTMinted(recipient, tokenId, ipId);
     }

--- a/contracts/story-nft/StoryNFTFactory.sol
+++ b/contracts/story-nft/StoryNFTFactory.sol
@@ -129,6 +129,9 @@ contract StoryNFTFactory is IStoryNFTFactory, AccessManagedUpgradeable, UUPSUpgr
         // The given signature must not have been used
         if ($.usedSignatures[signature]) revert StoryNFTFactory__SignatureAlreadyUsed(signature);
 
+        // Mark the signature as used
+        $.usedSignatures[signature] = true;
+
         // The given organization name must not have been used
         if ($.deployedStoryNftsByOrgName[orgName] != address(0))
             revert StoryNFTFactory__OrgAlreadyDeployed(orgName, $.deployedStoryNftsByOrgName[orgName]);
@@ -151,9 +154,6 @@ contract StoryNFTFactory is IStoryNFTFactory, AccessManagedUpgradeable, UUPSUpgr
         $.deployedStoryNftsByOrgName[orgName] = storyNft;
         $.deployedStoryNftsByOrgTokenId[orgTokenId] = storyNft;
         $.deployedStoryNftsByOrgIpId[orgIpId] = storyNft;
-
-        // Mark the signature as used
-        $.usedSignatures[signature] = true;
 
         emit StoryNftDeployed(orgName, orgNft, orgTokenId, orgIpId, storyNft);
     }


### PR DESCRIPTION
## Description
<!-- Add a description of the changes that this PR introduces -->

This PR addresses a reentrancy vulnerability in the `mint` function of the `StoryBadgeNFT` contract. The issue arises because `_safeTransfer` invokes the `onERC721Received` hook, which could potentially re-enter the `mint` function and bypass the used signature check.

This issue is resolved by moving the `_usedSignature[signature] = true` update before the `_safeTransfer` function so that the signature is marked as used before any external calls are made. 