### PR TITLE
Introduce Licensing Hook for Limiting Total License Tokens

### DIFF
--- a/contracts/hooks/TotalLicenseTokenLimitHook.sol
+++ b/contracts/hooks/TotalLicenseTokenLimitHook.sol
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { IERC165 } from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import { BaseModule } from "@storyprotocol/core/modules/BaseModule.sol";
+import { AccessControlled } from "@storyprotocol/core/access/AccessControlled.sol";
+import { ILicensingHook } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingHook.sol";
+import { ILicenseRegistry } from "@storyprotocol/core/interfaces/registries/ILicenseRegistry.sol";
+import { ILicenseToken } from "@storyprotocol/core/interfaces/ILicenseToken.sol";
+import { ILicenseTemplate } from "@storyprotocol/core/interfaces/modules/licensing/ILicenseTemplate.sol";
+
+contract TotalLicenseTokenLimitHook is BaseModule, AccessControlled, ILicensingHook {
+    string public constant override name = "TotalLicenseTokenLimitHook";
+
+    ILicenseRegistry public immutable LICENSE_REGISTRY;
+    ILicenseToken public immutable LICENSE_TOKEN;
+    // keccak256(licensorIpId, licenseTemplate, licenseTermsId) => totalLicenseTokenLimit
+    mapping(bytes32 => uint256) public totalLicenseTokenLimit;
+
+    /// @notice Emitted when the total license token limit is set
+    /// @param licensorIpId The licensor IP id
+    /// @param licenseTemplate The license template address
+    /// @param licenseTermsId The license terms id
+    /// @param limit The total license token limit for the specific license of the licensor IP
+    event SetTotalLicenseTokenLimit(
+        address indexed licensorIpId,
+        address indexed licenseTemplate,
+        uint256 indexed licenseTermsId,
+        uint256 limit
+    );
+
+    /// @notice Emitted when the total license token limit is exceeded
+    /// @param totalSupply The total supply of the license tokens
+    /// @param amount The amount of license tokens to mint
+    /// @param limit The total license token limit
+    error TotalLicenseTokenLimitExceeded(uint256 totalSupply, uint256 amount, uint256 limit);
+
+    constructor(
+        address licenseRegistry,
+        address licenseToken,
+        address accessController,
+        address ipAssetRegistry
+    ) AccessControlled(accessController, ipAssetRegistry) {
+        require(licenseRegistry != address(0), "TotalLicenseTokenLimitHook: licenseRegistry is the zero address");
+        require(licenseToken != address(0), "TotalLicenseTokenLimitHook: licenseToken is the zero address");
+        LICENSE_REGISTRY = ILicenseRegistry(licenseRegistry);
+        LICENSE_TOKEN = ILicenseToken(licenseToken);
+    }
+
+    /// @notice Set the total license token limit for a specific license
+    /// @param licensorIpId The licensor IP id
+    /// @param licenseTemplate The license template address
+    /// @param licenseTermsId The license terms id
+    /// @param limit The total license token limit, 0 means no limit
+    function setTotalLicenseTokenLimit(
+        address licensorIpId,
+        address licenseTemplate,
+        uint256 licenseTermsId,
+        uint256 limit
+    ) external verifyPermission(licensorIpId) {
+        bytes32 key = keccak256(abi.encodePacked(licensorIpId, licenseTemplate, licenseTermsId));
+        totalLicenseTokenLimit[key] = limit;
+        emit SetTotalLicenseTokenLimit(licensorIpId, licenseTemplate, licenseTermsId, limit);
+    }
+
+    /// @notice This function is called when the LicensingModule mints license tokens.
+    /// @dev The hook can be used to implement various checks and determine the minting price.
+    /// The hook should revert if the minting is not allowed.
+    /// @param caller The address of the caller who calling the mintLicenseTokens() function.
+    /// @param licensorIpId The ID of licensor IP from which issue the license tokens.
+    /// @param licenseTemplate The address of the license template.
+    /// @param licenseTermsId The ID of the license terms within the license template,
+    /// which is used to mint license tokens.
+    /// @param amount The amount of license tokens to mint.
+    /// @param receiver The address of the receiver who receive the license tokens.
+    /// @param hookData The data to be used by the licensing hook.
+    /// @return totalMintingFee The total minting fee to be paid when minting amount of license tokens.
+    function beforeMintLicenseTokens(
+        address caller,
+        address licensorIpId,
+        address licenseTemplate,
+        uint256 licenseTermsId,
+        uint256 amount,
+        address receiver,
+        bytes calldata hookData
+    ) external returns (uint256 totalMintingFee) {
+        _checkTotalTokenLimit(licensorIpId, licenseTemplate, licenseTermsId, amount);
+        return _calculateFee(licenseTemplate, licenseTermsId, amount);
+    }
+
+    /// @notice This function is called before finalizing LicensingModule.registerDerivative(), after calling
+    /// LicenseRegistry.registerDerivative().
+    /// @dev The hook can be used to implement various checks and determine the minting price.
+    /// The hook should revert if the registering of derivative is not allowed.
+    /// @param childIpId The derivative IP ID.
+    /// @param parentIpId The parent IP ID.
+    /// @param licenseTemplate The address of the license template.
+    /// @param licenseTermsId The ID of the license terms within the license template.
+    /// @param hookData The data to be used by the licensing hook.
+    /// @return mintingFee The minting fee to be paid when register child IP to the parent IP as derivative.
+    function beforeRegisterDerivative(
+        address caller,
+        address childIpId,
+        address parentIpId,
+        address licenseTemplate,
+        uint256 licenseTermsId,
+        bytes calldata hookData
+    ) external returns (uint256 mintingFee) {
+        _checkTotalTokenLimit(parentIpId, licenseTemplate, licenseTermsId, 1);
+        return _calculateFee(licenseTemplate, licenseTermsId, 1);
+    }
+
+    /// @notice This function is called when the LicensingModule calculates/predict the minting fee for license tokens.
+    /// @dev The hook should guarantee the minting fee calculation is correct and return the minting fee which is
+    /// the exact same amount with returned by beforeMintLicenseTokens().
+    /// The hook should revert if the minting fee calculation is not allowed.
+    /// @param caller The address of the caller who calling the mintLicenseTokens() function.
+    /// @param licensorIpId The ID of licensor IP from which issue the license tokens.
+    /// @param licenseTemplate The address of the license template.
+    /// @param licenseTermsId The ID of the license terms within the license template,
+    /// which is used to mint license tokens.
+    /// @param amount The amount of license tokens to mint.
+    /// @param receiver The address of the receiver who receive the license tokens.
+    /// @param hookData The data to be used by the licensing hook.
+    /// @return totalMintingFee The total minting fee to be paid when minting amount of license tokens.
+    function calculateMintingFee(
+        address caller,
+        address licensorIpId,
+        address licenseTemplate,
+        uint256 licenseTermsId,
+        uint256 amount,
+        address receiver,
+        bytes calldata hookData
+    ) external view returns (uint256 totalMintingFee) {
+        return _calculateFee(licenseTemplate, licenseTermsId, amount);
+    }
+
+    function supportsInterface(bytes4 interfaceId) public view virtual override(BaseModule, IERC165) returns (bool) {
+        return interfaceId == type(ILicensingHook).interfaceId || super.supportsInterface(interfaceId);
+    }
+
+    /// @notice Get the total license token limit for a specific license
+    /// @param licensorIpId The licensor IP id
+    /// @param licenseTemplate The license template address
+    /// @param licenseTermsId The license terms id
+    /// @return limit The total license token limit
+    function getTotalLicenseTokenLimit(
+        address licensorIpId,
+        address licenseTemplate,
+        uint256 licenseTermsId
+    ) external view returns (uint256 limit) {
+        bytes32 key = keccak256(abi.encodePacked(licensorIpId, licenseTemplate, licenseTermsId));
+        limit = totalLicenseTokenLimit[key];
+    }
+
+    function _checkTotalTokenLimit(
+        address licensorIpId,
+        address licenseTemplate,
+        uint256 licenseTermsId,
+        uint256 amount
+    ) internal view {
+        bytes32 key = keccak256(abi.encodePacked(licensorIpId, licenseTemplate, licenseTermsId));
+        uint256 limit = totalLicenseTokenLimit[key];
+        if (limit != 0) {
+            // derivative IPs are also considered as minted license tokens
+            uint256 totalSupply = LICENSE_REGISTRY.getDerivativeIpCount(licensorIpId) +
+                LICENSE_TOKEN.getTotalTokensByLicensor(licensorIpId);
+            if (totalSupply + amount > limit) {
+                revert TotalLicenseTokenLimitExceeded(totalSupply, amount, limit);
+            }
+        }
+    }
+
+    function _calculateFee(
+        address licenseTemplate,
+        uint256 licenseTermsId,
+        uint256 amount
+    ) internal view returns (uint256 totalMintingFee) {
+        (, , uint256 mintingFee, ) = ILicenseTemplate(licenseTemplate).getRoyaltyPolicy(licenseTermsId);
+        return amount * mintingFee;
+    }
+}

--- a/test/hooks/TotalLicenseTokenLimitHook.t.sol
+++ b/test/hooks/TotalLicenseTokenLimitHook.t.sol
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
+import { Licensing } from "@storyprotocol/core/lib/Licensing.sol";
+import "@storyprotocol/core/lib/Errors.sol";
+
+import { TotalLicenseTokenLimitHook } from "contracts/hooks/TotalLicenseTokenLimitHook.sol";
+
+import { BaseTest } from "../utils/BaseTest.t.sol";
+
+contract TotalLicenseTokenLimitHookTest is BaseTest {
+    address public ipId1;
+    address public ipId2;
+    address public ipId3;
+    address public ipOwner1 = address(0x111);
+    address public ipOwner2 = address(0x222);
+    address public ipOwner3 = address(0x333);
+    uint256 public tokenId1;
+    uint256 public tokenId2;
+    uint256 public tokenId3;
+
+    function setUp() public override {
+        super.setUp();
+        tokenId1 = mockNft.mint(ipOwner1);
+        tokenId2 = mockNft.mint(ipOwner2);
+        tokenId3 = mockNft.mint(ipOwner3);
+        ipId1 = ipAssetRegistry.register(block.chainid, address(mockNft), tokenId1);
+        ipId2 = ipAssetRegistry.register(block.chainid, address(mockNft), tokenId2);
+        ipId3 = ipAssetRegistry.register(block.chainid, address(mockNft), tokenId3);
+        vm.label(ipId1, "IPAccount1");
+        vm.label(ipId2, "IPAccount2");
+        vm.label(ipId3, "IPAccount3");
+    }
+
+    function test_TotalLicenseTokenLimitHook_setLimit() public {
+        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        TotalLicenseTokenLimitHook totalLimitHook = new TotalLicenseTokenLimitHook(
+            address(licenseRegistry),
+            address(licenseToken),
+            address(accessController),
+            address(ipAssetRegistry)
+        );
+
+        vm.prank(u.admin);
+        moduleRegistry.registerModule("TotalLicenseTokenLimitHook", address(totalLimitHook));
+        Licensing.LicensingConfig memory licensingConfig = Licensing.LicensingConfig({
+            isSet: true,
+            mintingFee: 100,
+            licensingHook: address(totalLimitHook),
+            hookData: ""
+        });
+
+        vm.startPrank(ipOwner1);
+        licensingModule.setLicensingConfig(ipId1, address(pilTemplate), socialRemixTermsId, licensingConfig);
+        totalLimitHook.setTotalLicenseTokenLimit(ipId1, address(pilTemplate), socialRemixTermsId, 10);
+        assertEq(totalLimitHook.getTotalLicenseTokenLimit(ipId1, address(pilTemplate), socialRemixTermsId), 10);
+        vm.stopPrank();
+
+        vm.startPrank(ipOwner2);
+        licensingModule.setLicensingConfig(ipId2, address(0), 0, licensingConfig);
+        totalLimitHook.setTotalLicenseTokenLimit(ipId2, address(pilTemplate), socialRemixTermsId, 20);
+        assertEq(totalLimitHook.getTotalLicenseTokenLimit(ipId2, address(pilTemplate), socialRemixTermsId), 20);
+        vm.stopPrank();
+
+        vm.startPrank(ipOwner3);
+        licensingModule.setLicensingConfig(ipId3, address(pilTemplate), socialRemixTermsId, licensingConfig);
+        assertEq(totalLimitHook.getTotalLicenseTokenLimit(ipId3, address(pilTemplate), socialRemixTermsId), 0);
+        vm.stopPrank();
+
+        licensingModule.mintLicenseTokens(ipId1, address(pilTemplate), socialRemixTermsId, 10, u.alice, "");
+        licensingModule.mintLicenseTokens(ipId2, address(pilTemplate), socialRemixTermsId, 20, u.alice, "");
+        licensingModule.mintLicenseTokens(ipId3, address(pilTemplate), socialRemixTermsId, 10, u.alice, "");
+
+        vm.expectRevert(
+            abi.encodeWithSelector(TotalLicenseTokenLimitHook.TotalLicenseTokenLimitExceeded.selector, 10, 5, 10)
+        );
+        licensingModule.mintLicenseTokens(ipId1, address(pilTemplate), socialRemixTermsId, 5, u.alice, "");
+
+        vm.expectRevert(
+            abi.encodeWithSelector(TotalLicenseTokenLimitHook.TotalLicenseTokenLimitExceeded.selector, 20, 5, 20)
+        );
+        licensingModule.mintLicenseTokens(ipId2, address(pilTemplate), socialRemixTermsId, 5, u.alice, "");
+    }
+
+    function test_TotalLicenseTokenLimitHook_revert_nonIpOwner_setLimit() public {
+        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        TotalLicenseTokenLimitHook totalLimitHook = new TotalLicenseTokenLimitHook(
+            address(licenseRegistry),
+            address(licenseToken),
+            address(accessController),
+            address(ipAssetRegistry)
+        );
+
+        vm.prank(u.admin);
+        moduleRegistry.registerModule("TotalLicenseTokenLimitHook", address(totalLimitHook));
+        Licensing.LicensingConfig memory licensingConfig = Licensing.LicensingConfig({
+            isSet: true,
+            mintingFee: 100,
+            licensingHook: address(totalLimitHook),
+            hookData: ""
+        });
+
+        vm.startPrank(ipOwner1);
+        licensingModule.setLicensingConfig(ipId1, address(pilTemplate), socialRemixTermsId, licensingConfig);
+        totalLimitHook.setTotalLicenseTokenLimit(ipId1, address(pilTemplate), socialRemixTermsId, 10);
+        assertEq(totalLimitHook.getTotalLicenseTokenLimit(ipId1, address(pilTemplate), socialRemixTermsId), 10);
+        vm.stopPrank();
+
+        vm.startPrank(ipOwner2);
+        vm.expectRevert(abi.encodeWithSelector(Errors.AccessController__PermissionDenied.selector, ipId1, ipOwner2, address(totalLimitHook), totalLimitHook.setTotalLicenseTokenLimit.selector));
+        totalLimitHook.setTotalLicenseTokenLimit(ipId1, address(pilTemplate), socialRemixTermsId, 20);
+
+    }
+}


### PR DESCRIPTION
#### Summary
This PR introduces a new Licensing Hook, `TotalLicenseTokenLimitHook`, which allows IP owners to set a limit on the total number of license tokens that can be minted from specific license terms of an IP. This feature ensures that the minting of license tokens is controlled and adheres to the predefined limits set by the IP owner.

#### Key Features
- **Set Total License Token Limit**: IP owners can specify the maximum number of license tokens that can be minted for a given license template and terms.
- **Minting Fee Calculation**: The hook calculates the minting fee based on the license template and terms.
- **Validation**: The hook validates the total supply of license tokens before allowing new tokens to be minted, ensuring the limit is not exceeded.
- **Revert on Exceeding Limit**: If the minting request exceeds the set limit, the transaction is reverted with a `TotalLicenseTokenLimitExceeded` error.

#### Changes
- Added `TotalLicenseTokenLimitHook` contract with the following key functions:
  - `beforeRegisterDerivative`: Checks the total token limit before registering a derivative.
  - `calculateMintingFee`: Calculates the minting fee for license tokens.
  - `getTotalLicenseTokenLimit`: Retrieves the total license token limit for a specific license.
  - `_checkTotalTokenLimit`: Internal function to check if the total token limit is exceeded.
  - `_calculateFee`: Internal function to calculate the minting fee.
- Added tests in `TotalLicenseTokenLimitHookTest` to ensure the functionality works as expected:
  - `test_TotalLicenseTokenLimitHook_setLimit`: Tests setting and enforcing the total license token limit.
  - `test_TotalLicenseTokenLimitHook_revert_nonIpOwner_setLimit`: Tests that only the IP owner can set the limit.

#### Usage
1. **Set Licensing Config**: IP owners set the licensing configuration using the `LicensingModule`.
2. **Set Token Limit**: IP owners set the total license token limit using the `setTotalLicenseTokenLimit` function.
3. **Mint License Tokens**: The system checks the limit before minting new license tokens to ensure compliance.
