### PR TITLE
fix: update periphery to align with PoC core changes

### DIFF
--- a/contracts/lib/WorkflowStructs.sol
+++ b/contracts/lib/WorkflowStructs.sol
@@ -32,10 +32,12 @@ library WorkflowStructs {
     /// @param licenseTemplate The address of the license template to be used for the linking.
     /// @param licenseTermsIds The IDs of the license terms to be used for the linking.
     /// @param royaltyContext The context for royalty module, should be empty for Royalty Policy LAP.
+    /// @param maxMintingFee The maximum minting fee that the caller is willing to pay. if set to 0 then no limit.
     struct MakeDerivative {
         address[] parentIpIds;
         address licenseTemplate;
         uint256[] licenseTermsIds;
         bytes royaltyContext;
+        uint256 maxMintingFee;
     }
 }

--- a/contracts/story-nft/BaseStoryNFT.sol
+++ b/contracts/story-nft/BaseStoryNFT.sol
@@ -116,19 +116,22 @@ abstract contract BaseStoryNFT is IStoryNFT, ERC721URIStorage, Ownable, Initiali
     /// @param licenseTemplate The address of the license template.
     /// @param licenseTermsIds The IDs of the license terms.
     /// @param royaltyContext The royalty context, should be empty for Royalty Policy LAP.
+    /// @param maxMintingFee The maximum minting fee that the caller is willing to pay. if set to 0 then no limit.
     function _makeDerivative(
         address ipId,
         address[] memory parentIpIds,
         address licenseTemplate,
         uint256[] memory licenseTermsIds,
-        bytes memory royaltyContext
+        bytes memory royaltyContext,
+        uint256 maxMintingFee
     ) internal virtual {
         LICENSING_MODULE.registerDerivative({
             childIpId: ipId,
             parentIpIds: parentIpIds,
             licenseTermsIds: licenseTermsIds,
             licenseTemplate: licenseTemplate,
-            royaltyContext: royaltyContext
+            royaltyContext: royaltyContext,
+            maxMintingFee: maxMintingFee
         });
     }
 

--- a/contracts/story-nft/OrgNFT.sol
+++ b/contracts/story-nft/OrgNFT.sol
@@ -135,7 +135,8 @@ contract OrgNFT is IOrgNFT, ERC721URIStorageUpgradeable, AccessManagedUpgradeabl
             parentIpIds: parentIpIds,
             licenseTermsIds: licenseTermsIds,
             licenseTemplate: LICENSE_TEMPLATE,
-            royaltyContext: ""
+            royaltyContext: "",
+            maxMintingFee: 0
         });
 
         _safeTransfer(address(this), recipient, orgTokenId);

--- a/contracts/story-nft/StoryBadgeNFT.sol
+++ b/contracts/story-nft/StoryBadgeNFT.sol
@@ -86,7 +86,7 @@ contract StoryBadgeNFT is IStoryBadgeNFT, BaseStoryNFT, ERC721Holder {
         licenseTermsIds[0] = DEFAULT_LICENSE_TERMS_ID;
 
         // Make the badge a derivative of the organization IP
-        _makeDerivative(ipId, parentIpIds, PIL_TEMPLATE, licenseTermsIds, "");
+        _makeDerivative(ipId, parentIpIds, PIL_TEMPLATE, licenseTermsIds, "", 0);
 
         // Transfer the badge to the recipient
         _safeTransfer(address(this), recipient, tokenId);

--- a/contracts/workflows/DerivativeWorkflows.sol
+++ b/contracts/workflows/DerivativeWorkflows.sol
@@ -145,7 +145,8 @@ contract DerivativeWorkflows is
             parentIpIds: derivData.parentIpIds,
             licenseTermsIds: derivData.licenseTermsIds,
             licenseTemplate: derivData.licenseTemplate,
-            royaltyContext: derivData.royaltyContext
+            royaltyContext: derivData.royaltyContext,
+            maxMintingFee: 0
         });
 
         ISPGNFT(spgNftContract).safeTransferFrom(address(this), recipient, tokenId, "");
@@ -198,7 +199,8 @@ contract DerivativeWorkflows is
             parentIpIds: derivData.parentIpIds,
             licenseTermsIds: derivData.licenseTermsIds,
             licenseTemplate: derivData.licenseTemplate,
-            royaltyContext: derivData.royaltyContext
+            royaltyContext: derivData.royaltyContext,
+            maxMintingFee: derivData.maxMintingFee
         });
     }
 

--- a/script/deployment/Main.s.sol
+++ b/script/deployment/Main.s.sol
@@ -17,7 +17,7 @@ contract Main is DeployHelper {
     /// --verify --verifier=$VERIFIER_NAME --verifier-url=$VERIFIER_URL
     ///
     /// For detailed examples, see the documentation in `../../docs/DEPLOY_UPGRADE.md`.
-    function run() public virtual override {
+    function run() public virtual {
         _run(CREATE3_DEFAULT_SEED);
     }
 

--- a/script/deployment/StoryNFT.s.sol
+++ b/script/deployment/StoryNFT.s.sol
@@ -10,7 +10,7 @@ contract StoryNFT is DeployHelper {
     uint256 private constant CREATE3_DEFAULT_SEED = 1234567890;
     constructor() DeployHelper(CREATE3_DEPLOYER) {}
 
-    function run() public override {
+    function run() public {
         create3SaltSeed = CREATE3_DEFAULT_SEED;
         writeDeploys = true;
 

--- a/script/utils/DeployHelper.sol
+++ b/script/utils/DeployHelper.sol
@@ -141,7 +141,7 @@ contract DeployHelper is
         writeDeploys = writeDeploys_;
 
         // This will run OZ storage layout check for all contracts. Requires --ffi flag.
-        if (runStorageLayoutCheck) super.run();
+        if (runStorageLayoutCheck) _validate(); // StorageLayoutChecker.s.sol
 
         if (isTest) {
             // local test deployment
@@ -641,7 +641,7 @@ contract DeployHelper is
                 _getSalt(type(IpRoyaltyVault).name),
                 abi.encodePacked(
                     type(IpRoyaltyVault).creationCode,
-                    abi.encode(address(disputeModule), address(royaltyModule))
+                    abi.encode(address(disputeModule), address(royaltyModule), address(ipAssetRegistry), _getDeployedAddress(type(GroupingModule).name))
                 )
             )
         );
@@ -832,7 +832,7 @@ contract DeployHelper is
         ipRoyaltyVaultBeacon.transferOwnership(address(royaltyPolicyLAP));
 
         // add evenSplitGroupPool to whitelist of group pools
-        groupingModule.whitelistGroupRewardPool(address(evenSplitGroupPool));
+        groupingModule.whitelistGroupRewardPool(address(evenSplitGroupPool), true);
     }
 
     /// @dev get the salt for the contract deployment with CREATE3

--- a/test/hooks/TotalLicenseTokenLimitHook.t.sol
+++ b/test/hooks/TotalLicenseTokenLimitHook.t.sol
@@ -48,7 +48,8 @@ contract TotalLicenseTokenLimitHookTest is BaseTest {
             isSet: true,
             mintingFee: 100,
             licensingHook: address(totalLimitHook),
-            hookData: ""
+            hookData: "",
+            commercialRevShare: 0
         });
 
         vm.startPrank(ipOwner1);
@@ -68,9 +69,33 @@ contract TotalLicenseTokenLimitHookTest is BaseTest {
         assertEq(totalLimitHook.getTotalLicenseTokenLimit(ipId3, address(pilTemplate), socialRemixTermsId), 0);
         vm.stopPrank();
 
-        licensingModule.mintLicenseTokens(ipId1, address(pilTemplate), socialRemixTermsId, 10, u.alice, "");
-        licensingModule.mintLicenseTokens(ipId2, address(pilTemplate), socialRemixTermsId, 20, u.alice, "");
-        licensingModule.mintLicenseTokens(ipId3, address(pilTemplate), socialRemixTermsId, 10, u.alice, "");
+        licensingModule.mintLicenseTokens({
+            licensorIpId: ipId1,
+            licenseTemplate: address(pilTemplate),
+            licenseTermsId: socialRemixTermsId,
+            amount: 10,
+            receiver: u.alice,
+            royaltyContext: "",
+            maxMintingFee: 0
+        });
+        licensingModule.mintLicenseTokens({
+            licensorIpId: ipId2,
+            licenseTemplate: address(pilTemplate),
+            licenseTermsId: socialRemixTermsId,
+            amount: 20,
+            receiver: u.alice,
+            royaltyContext: "",
+            maxMintingFee: 0
+        });
+        licensingModule.mintLicenseTokens({
+            licensorIpId: ipId3,
+            licenseTemplate: address(pilTemplate),
+            licenseTermsId: socialRemixTermsId,
+            amount: 10,
+            receiver: u.alice,
+            royaltyContext: "",
+            maxMintingFee: 0
+        });
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -80,7 +105,15 @@ contract TotalLicenseTokenLimitHookTest is BaseTest {
                 10
             )
         );
-        licensingModule.mintLicenseTokens(ipId1, address(pilTemplate), socialRemixTermsId, 5, u.alice, "");
+        licensingModule.mintLicenseTokens({
+            licensorIpId: ipId1,
+            licenseTemplate: address(pilTemplate),
+            licenseTermsId: socialRemixTermsId,
+            amount: 5,
+            receiver: u.alice,
+            royaltyContext: "",
+            maxMintingFee: 0
+        });
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -90,7 +123,15 @@ contract TotalLicenseTokenLimitHookTest is BaseTest {
                 20
             )
         );
-        licensingModule.mintLicenseTokens(ipId2, address(pilTemplate), socialRemixTermsId, 5, u.alice, "");
+        licensingModule.mintLicenseTokens({
+            licensorIpId: ipId2,
+            licenseTemplate: address(pilTemplate),
+            licenseTermsId: socialRemixTermsId,
+            amount: 5,
+            receiver: u.alice,
+            royaltyContext: "",
+            maxMintingFee: 0
+        });
     }
 
     function test_TotalLicenseTokenLimitHook_revert_nonIpOwner_setLimit() public {
@@ -108,7 +149,8 @@ contract TotalLicenseTokenLimitHookTest is BaseTest {
             isSet: true,
             mintingFee: 100,
             licensingHook: address(totalLimitHook),
-            hookData: ""
+            hookData: "",
+            commercialRevShare: 0
         });
 
         vm.startPrank(ipOwner1);
@@ -145,7 +187,8 @@ contract TotalLicenseTokenLimitHookTest is BaseTest {
             isSet: true,
             mintingFee: 100,
             licensingHook: address(totalLimitHook),
-            hookData: ""
+            hookData: "",
+            commercialRevShare: 0
         });
 
         vm.startPrank(ipOwner1);
@@ -153,7 +196,15 @@ contract TotalLicenseTokenLimitHookTest is BaseTest {
         totalLimitHook.setTotalLicenseTokenLimit(ipId1, address(pilTemplate), socialRemixTermsId, 10);
         assertEq(totalLimitHook.getTotalLicenseTokenLimit(ipId1, address(pilTemplate), socialRemixTermsId), 10);
 
-        licensingModule.mintLicenseTokens(ipId1, address(pilTemplate), socialRemixTermsId, 10, u.alice, "");
+        licensingModule.mintLicenseTokens({
+            licensorIpId: ipId1,
+            licenseTemplate: address(pilTemplate),
+            licenseTermsId: socialRemixTermsId,
+            amount: 10,
+            receiver: u.alice,
+            royaltyContext: "",
+            maxMintingFee: 0
+        });
 
         vm.expectRevert(
             abi.encodeWithSelector(

--- a/test/integration/workflows/DerivativeIntegration.t.sol
+++ b/test/integration/workflows/DerivativeIntegration.t.sol
@@ -51,7 +51,8 @@ contract DerivativeIntegration is BaseIntegration {
                 parentIpIds: parentIpIds,
                 licenseTemplate: parentLicenseTemplate,
                 licenseTermsIds: parentLicenseTermIds,
-                royaltyContext: ""
+                royaltyContext: "",
+                maxMintingFee: 0
             }),
             ipMetadata: testIpMetadata,
             recipient: testSender
@@ -117,7 +118,8 @@ contract DerivativeIntegration is BaseIntegration {
                 parentIpIds: parentIpIds,
                 licenseTemplate: parentLicenseTemplate,
                 licenseTermsIds: parentLicenseTermIds,
-                royaltyContext: ""
+                royaltyContext: "",
+                maxMintingFee: 0
             }),
             ipMetadata: testIpMetadata,
             sigMetadata: WorkflowStructs.SignatureData({
@@ -163,7 +165,8 @@ contract DerivativeIntegration is BaseIntegration {
             licenseTermsId: parentLicenseTermIds[0],
             amount: 1,
             receiver: testSender,
-            royaltyContext: ""
+            royaltyContext: "",
+            maxMintingFee: 0
         });
 
         // Need so that derivative workflows can transfer the license tokens
@@ -222,7 +225,8 @@ contract DerivativeIntegration is BaseIntegration {
             licenseTermsId: parentLicenseTermIds[0],
             amount: 1,
             receiver: testSender,
-            royaltyContext: ""
+            royaltyContext: "",
+            maxMintingFee: 0
         });
 
         uint256[] memory licenseTokenIds = new uint256[](1);
@@ -299,7 +303,8 @@ contract DerivativeIntegration is BaseIntegration {
                     parentIpIds: parentIpIds,
                     licenseTemplate: parentLicenseTemplate,
                     licenseTermsIds: parentLicenseTermIds,
-                    royaltyContext: ""
+                    royaltyContext: "",
+                    maxMintingFee: 0
                 }),
                 testIpMetadata,
                 testSender

--- a/test/integration/workflows/RoyaltyIntegration.t.sol
+++ b/test/integration/workflows/RoyaltyIntegration.t.sol
@@ -382,7 +382,8 @@ contract RoyaltyIntegration is BaseIntegration {
                     parentIpIds: parentIpIds,
                     licenseTemplate: pilTemplateAddr,
                     licenseTermsIds: licenseTermsIds,
-                    royaltyContext: ""
+                    royaltyContext: "",
+                    maxMintingFee: 0
                 }),
                 ipMetadata: emptyIpMetadata,
                 sigMetadata: emptySigData,
@@ -444,7 +445,8 @@ contract RoyaltyIntegration is BaseIntegration {
                     parentIpIds: parentIpIds,
                     licenseTemplate: address(pilTemplate),
                     licenseTermsIds: licenseTermsIds,
-                    royaltyContext: ""
+                    royaltyContext: "",
+                    maxMintingFee: 0
                 }),
                 ipMetadata: emptyIpMetadata,
                 sigMetadata: emptySigData,
@@ -493,7 +495,8 @@ contract RoyaltyIntegration is BaseIntegration {
                     parentIpIds: parentIpIds,
                     licenseTemplate: address(pilTemplate),
                     licenseTermsIds: licenseTermsIds,
-                    royaltyContext: ""
+                    royaltyContext: "",
+                    maxMintingFee: 0
                 }),
                 ipMetadata: emptyIpMetadata,
                 sigMetadata: emptySigData,
@@ -545,7 +548,8 @@ contract RoyaltyIntegration is BaseIntegration {
                     parentIpIds: parentIpIds,
                     licenseTemplate: address(pilTemplate),
                     licenseTermsIds: licenseTermsIds,
-                    royaltyContext: ""
+                    royaltyContext: "",
+                    maxMintingFee: 0
                 }),
                 ipMetadata: emptyIpMetadata,
                 sigMetadata: emptySigData,
@@ -570,7 +574,8 @@ contract RoyaltyIntegration is BaseIntegration {
                 licenseTermsId: commRemixTermsIdA,
                 amount: amountLicenseTokensToMint,
                 receiver: testSender,
-                royaltyContext: ""
+                royaltyContext: "",
+                maxMintingFee: 0
             });
 
             // mint `amountLicenseTokensToMint` childIpC's license tokens
@@ -580,7 +585,8 @@ contract RoyaltyIntegration is BaseIntegration {
                 licenseTermsId: commRemixTermsIdC,
                 amount: amountLicenseTokensToMint,
                 receiver: testSender,
-                royaltyContext: ""
+                royaltyContext: "",
+                maxMintingFee: 0
             });
         }
     }

--- a/test/workflows/DerivativeWorkflows.t.sol
+++ b/test/workflows/DerivativeWorkflows.t.sol
@@ -39,10 +39,11 @@ contract DerivativeWorkflowsTest is BaseTest {
             spgNftContract: address(nftContract),
             recipient: caller,
             ipMetadata: ipMetadataDefault,
-            terms: PILFlavors.commercialUse({
+            terms: PILFlavors.commercialRemix({
                 mintingFee: 100 * 10 ** mockToken.decimals(),
-                currencyToken: address(mockToken),
-                royaltyPolicy: address(royaltyPolicyLAP)
+                commercialRevShare: 10, // 1%
+                royaltyPolicy: address(royaltyPolicyLAP),
+                currencyToken: address(mockToken)
             })
         });
         _;
@@ -106,7 +107,8 @@ contract DerivativeWorkflowsTest is BaseTest {
             licenseTermsId: licenseTermsIdParent,
             amount: 1,
             receiver: caller,
-            royaltyContext: ""
+            royaltyContext: "",
+            maxMintingFee: 0
         });
 
         // Need so that derivative workflows can transfer the license tokens
@@ -166,7 +168,8 @@ contract DerivativeWorkflowsTest is BaseTest {
             licenseTermsId: licenseTermsIdParent,
             amount: 1,
             receiver: caller,
-            royaltyContext: ""
+            royaltyContext: "",
+            maxMintingFee: 0
         });
 
         uint256[] memory licenseTokenIds = new uint256[](1);
@@ -245,7 +248,8 @@ contract DerivativeWorkflowsTest is BaseTest {
                     parentIpIds: parentIpIds,
                     licenseTemplate: address(pilTemplate),
                     licenseTermsIds: licenseTermsIds,
-                    royaltyContext: ""
+                    royaltyContext: "",
+                    maxMintingFee: 0
                 }),
                 ipMetadataDefault,
                 caller
@@ -294,7 +298,8 @@ contract DerivativeWorkflowsTest is BaseTest {
                 parentIpIds: parentIpIds,
                 licenseTemplate: address(pilTemplate),
                 licenseTermsIds: licenseTermsIds,
-                royaltyContext: ""
+                royaltyContext: "",
+                maxMintingFee: 0
             }),
             ipMetadata: ipMetadataDefault,
             recipient: caller
@@ -362,7 +367,8 @@ contract DerivativeWorkflowsTest is BaseTest {
                 parentIpIds: parentIpIds,
                 licenseTemplate: address(pilTemplate),
                 licenseTermsIds: licenseTermsIds,
-                royaltyContext: ""
+                royaltyContext: "",
+                maxMintingFee: 0
             }),
             ipMetadata: ipMetadataDefault,
             sigMetadata: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: sigMetadata }),

--- a/test/workflows/GroupingWorkflows.t.sol
+++ b/test/workflows/GroupingWorkflows.t.sol
@@ -273,7 +273,8 @@ contract GroupingWorkflowsTest is BaseTest {
                 parentIpIds: parentIpIds,
                 licenseTermsIds: licenseTermsIds,
                 licenseTemplate: address(pilTemplate),
-                royaltyContext: ""
+                royaltyContext: "",
+                maxMintingFee: 0
             }),
             ipMetadata: ipMetadataDefault,
             recipient: ipOwner1
@@ -291,7 +292,8 @@ contract GroupingWorkflowsTest is BaseTest {
                 parentIpIds: parentIpIds,
                 licenseTermsIds: licenseTermsIds,
                 licenseTemplate: address(pilTemplate),
-                royaltyContext: ""
+                royaltyContext: "",
+                maxMintingFee: 0
             }),
             ipMetadata: ipMetadataDefault,
             recipient: ipOwner2
@@ -343,7 +345,8 @@ contract GroupingWorkflowsTest is BaseTest {
                     licenseTermsId: testLicenseTermsId,
                     amount: 1,
                     receiver: u.admin,
-                    royaltyContext: ""
+                    royaltyContext: "",
+                    maxMintingFee: 0
                 });
             }
         }

--- a/test/workflows/LicenseAttachmentWorkflows.t.sol
+++ b/test/workflows/LicenseAttachmentWorkflows.t.sol
@@ -229,7 +229,8 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
                 parentIpIds: parentIpIds,
                 licenseTemplate: address(pilTemplate),
                 licenseTermsIds: licenseTermsIds,
-                royaltyContext: ""
+                royaltyContext: "",
+                maxMintingFee: 0
             }),
             ipMetadata: ipMetadataDefault,
             recipient: caller

--- a/test/workflows/RoyaltyWorkflows.t.sol
+++ b/test/workflows/RoyaltyWorkflows.t.sol
@@ -466,7 +466,8 @@ contract RoyaltyWorkflowsTest is BaseTest {
                     parentIpIds: parentIpIds,
                     licenseTemplate: address(pilTemplate),
                     licenseTermsIds: licenseTermsIds,
-                    royaltyContext: ""
+                    royaltyContext: "",
+                    maxMintingFee: 0
                 }),
                 ipMetadata: emptyIpMetadata,
                 sigMetadata: emptySigData,
@@ -525,7 +526,8 @@ contract RoyaltyWorkflowsTest is BaseTest {
                     parentIpIds: parentIpIds,
                     licenseTemplate: address(pilTemplate),
                     licenseTermsIds: licenseTermsIds,
-                    royaltyContext: ""
+                    royaltyContext: "",
+                    maxMintingFee: 0
                 }),
                 ipMetadata: emptyIpMetadata,
                 sigMetadata: emptySigData,
@@ -575,7 +577,8 @@ contract RoyaltyWorkflowsTest is BaseTest {
                     parentIpIds: parentIpIds,
                     licenseTemplate: address(pilTemplate),
                     licenseTermsIds: licenseTermsIds,
-                    royaltyContext: ""
+                    royaltyContext: "",
+                    maxMintingFee: 0
                 }),
                 ipMetadata: emptyIpMetadata,
                 sigMetadata: emptySigData,
@@ -628,7 +631,8 @@ contract RoyaltyWorkflowsTest is BaseTest {
                     parentIpIds: parentIpIds,
                     licenseTemplate: address(pilTemplate),
                     licenseTermsIds: licenseTermsIds,
-                    royaltyContext: ""
+                    royaltyContext: "",
+                    maxMintingFee: 0
                 }),
                 ipMetadata: emptyIpMetadata,
                 sigMetadata: emptySigData,
@@ -655,7 +659,8 @@ contract RoyaltyWorkflowsTest is BaseTest {
                 licenseTermsId: commRemixTermsIdA,
                 amount: amountLicenseTokensToMint,
                 receiver: address(0xbeef),
-                royaltyContext: ""
+                royaltyContext: "",
+                maxMintingFee: 0
             });
 
             mockTokenC.mint(address(0xbeef), defaultMintingFeeC * amountLicenseTokensToMint);
@@ -668,7 +673,8 @@ contract RoyaltyWorkflowsTest is BaseTest {
                 licenseTermsId: commRemixTermsIdC,
                 amount: amountLicenseTokensToMint,
                 receiver: address(0xbeef),
-                royaltyContext: ""
+                royaltyContext: "",
+                maxMintingFee: 0
             });
             vm.stopPrank();
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -441,7 +441,7 @@
 
 "@story-protocol/protocol-core@github:storyprotocol/protocol-core-v1#main":
   version "1.1.0"
-  resolved "https://codeload.github.com/storyprotocol/protocol-core-v1/tar.gz/71d9dd0b3df59f6cf19cb18244946dec52bc6502"
+  resolved "https://codeload.github.com/storyprotocol/protocol-core-v1/tar.gz/55114b5475b80bac0accf268d29e9f7583fd4ece"
   dependencies:
     "@openzeppelin/contracts" "5.0.2"
     "@openzeppelin/contracts-upgradeable" "5.0.2"
@@ -494,7 +494,14 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
   integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
-"@types/node@*", "@types/node@22.7.5":
+"@types/node@*":
+  version "22.7.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.7.6.tgz#3ec3e2b071e136cd11093c19128405e1d1f92f33"
+  integrity sha512-/d7Rnj0/ExXDMcioS78/kf1lMzYk4BZV8MZGTBKzTGZ6/406ukkbYlIsZmMPhcR5KlkunDHQLrtAVmSq7r+mSw==
+  dependencies:
+    undici-types "~6.19.2"
+
+"@types/node@22.7.5":
   version "22.7.5"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-22.7.5.tgz#cfde981727a7ab3611a481510b473ae54442b92b"
   integrity sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==
@@ -534,9 +541,9 @@ acorn-walk@^8.1.1:
     acorn "^8.11.0"
 
 acorn@^8.11.0, acorn@^8.4.1, acorn@^8.9.0:
-  version "8.12.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.12.1.tgz#71616bdccbe25e27a54439e0046e89ca76df2248"
-  integrity sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==
+  version "8.13.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.13.0.tgz#2a30d670818ad16ddd6a35d3842dacec9e5d7ca3"
+  integrity sha512-8zSiw54Oxrdym50NlZ9sUusyO1Z1ZchgRLWRaK6c86XJFClyCgFKetdowBg5bKxyp/u+CDBJG4Mpp0m3HLZl9w==
 
 aes-js@4.0.0-beta.5:
   version "4.0.0-beta.5"
@@ -1205,9 +1212,9 @@ fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fast-uri@^3.0.1:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.0.2.tgz#d78b298cf70fd3b752fd951175a3da6a7b48f024"
-  integrity sha512-GR6f0hD7XXyNJa25Tb9BuIdN0tdr+0BMi6/CJPH3wJO1JjNG3n/VsSw38AwRdKZABm8lGbPfakLRkYzx2V9row==
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.0.3.tgz#892a1c91802d5d7860de728f18608a0573142241"
+  integrity sha512-aLrHthzCjH5He4Z2H9YZ+v6Ujb9ocRuW6ZzkJQOrTxleEijANq4v1TsaPaVG1PZcuurEzrLcWRyYBYXD5cEiaw==
 
 fastq@^1.6.0:
   version "1.17.1"
@@ -2037,9 +2044,9 @@ pathval@^2.0.0:
   integrity sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==
 
 picocolors@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.0.tgz#5358b76a78cde483ba5cef6a9dc9671440b27d59"
-  integrity sha512-TQ92mBOW0l3LeMeyLV6mzy/kWr8lkd/hp3mTg7wYK7zJhuBStmGMBG0BdeDZS/dZx1IukaX6Bk11zcln25o1Aw==
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
+  integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   version "2.3.1"
@@ -2527,10 +2534,15 @@ ts-node@^10.9.2:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-tslib@2.7.0, tslib@^2.6.2:
+tslib@2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.7.0.tgz#d9b40c5c40ab59e8738f297df3087bf1a2690c01"
   integrity sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==
+
+tslib@^2.6.2:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.0.tgz#d124c86c3c05a40a91e6fdea4021bd31d377971b"
+  integrity sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"


### PR DESCRIPTION
## Description

This PR updates the periphery’s dependency on the PoC core to include changes from [PR#204](https://github.com/storyprotocol/protocol-core-v1/pull/204) up to [PR#280](https://github.com/storyprotocol/protocol-core-v1/pull/280). It modifies the periphery contracts, tests, and scripts to adapt to these PoC core updates.

#### Key Modifications:

- Added an extra `maxMintingFee` parameter when calling `registerDerivative` and `mintLicenseTokens` in `LicensingModule`.
- Introduced a new `commercialRevShare` field to `LicensingConfig`.
- Replaced the `commercialUse` license with `commercialRemix` in derivative tests.
- Made minor changes to deployment scripts.

## Test Plan
All existing tests pass locally.