### PR TITLE
feat(hooks): add `LockLicenseHook` to locking/disabling licensing operations

### DIFF
--- a/contracts/hooks/LockLicenseHook.sol
+++ b/contracts/hooks/LockLicenseHook.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { IERC165 } from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import { BaseModule } from "@storyprotocol/core/modules/BaseModule.sol";
+import { ILicensingHook } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingHook.sol";
+
+contract LockLicenseHook is BaseModule, ILicensingHook {
+    string public constant override name = "LockLicenseHook";
+
+    /// @notice Emitted when attempting to perform an action on a locked license
+    /// @param licensorIpId The licensor IP id that is locked
+    /// @param licenseTemplate The license template address that is locked
+    /// @param licenseTermsId The license terms id that is locked
+    error LockLicenseHook_LicenseLocked(address licensorIpId, address licenseTemplate, uint256 licenseTermsId);
+
+    /// @notice This function is called when the LicensingModule mints license tokens.
+    /// @dev This function will always revert to prevent any license token minting.
+    /// @param caller The address of the caller who calling the mintLicenseTokens() function.
+    /// @param licensorIpId The ID of licensor IP from which issue the license tokens.
+    /// @param licenseTemplate The address of the license template.
+    /// @param licenseTermsId The ID of the license terms within the license template,
+    /// which is used to mint license tokens.
+    /// @param amount The amount of license tokens to mint.
+    /// @param receiver The address of the receiver who receive the license tokens.
+    /// @param hookData The data to be used by the licensing hook.
+    /// @return totalMintingFee The total minting fee to be paid when minting amount of license tokens.
+    function beforeMintLicenseTokens(
+        address caller,
+        address licensorIpId,
+        address licenseTemplate,
+        uint256 licenseTermsId,
+        uint256 amount,
+        address receiver,
+        bytes calldata hookData
+    ) external returns (uint256 totalMintingFee) {
+        revert LockLicenseHook_LicenseLocked(licensorIpId, licenseTemplate, licenseTermsId);
+    }
+
+    /// @notice This function is called before finalizing LicensingModule.registerDerivative(), after calling
+    /// LicenseRegistry.registerDerivative().
+    /// @dev This function will always revert to prevent any derivative registration.
+    /// @param childIpId The derivative IP ID.
+    /// @param parentIpId The parent IP ID.
+    /// @param licenseTemplate The address of the license template.
+    /// @param licenseTermsId The ID of the license terms within the license template.
+    /// @param hookData The data to be used by the licensing hook.
+    /// @return mintingFee The minting fee to be paid when register child IP to the parent IP as derivative.
+    function beforeRegisterDerivative(
+        address caller,
+        address childIpId,
+        address parentIpId,
+        address licenseTemplate,
+        uint256 licenseTermsId,
+        bytes calldata hookData
+    ) external returns (uint256 mintingFee) {
+        revert LockLicenseHook_LicenseLocked(parentIpId, licenseTemplate, licenseTermsId);
+    }
+
+    /// @notice This function is called when the LicensingModule calculates/predict the minting fee for license tokens.
+    /// @dev This function will always revert to prevent any license minting fee calculation/prediction.
+    /// @param caller The address of the caller who calling the mintLicenseTokens() function.
+    /// @param licensorIpId The ID of licensor IP from which issue the license tokens.
+    /// @param licenseTemplate The address of the license template.
+    /// @param licenseTermsId The ID of the license terms within the license template,
+    /// which is used to mint license tokens.
+    /// @param amount The amount of license tokens to mint.
+    /// @param receiver The address of the receiver who receive the license tokens.
+    /// @param hookData The data to be used by the licensing hook.
+    /// @return totalMintingFee The minting fee to be paid when minting amount of license tokens.
+    function calculateMintingFee(
+        address caller,
+        address licensorIpId,
+        address licenseTemplate,
+        uint256 licenseTermsId,
+        uint256 amount,
+        address receiver,
+        bytes calldata hookData
+    ) external view returns (uint256 totalMintingFee) {
+        revert LockLicenseHook_LicenseLocked(licensorIpId, licenseTemplate, licenseTermsId);
+    }
+
+    function supportsInterface(bytes4 interfaceId) public view virtual override(BaseModule, IERC165) returns (bool) {
+        return interfaceId == type(ILicensingHook).interfaceId || super.supportsInterface(interfaceId);
+    }
+}

--- a/contracts/hooks/LockLicenseHook.sol
+++ b/contracts/hooks/LockLicenseHook.sol
@@ -58,7 +58,7 @@ contract LockLicenseHook is BaseModule, ILicensingHook {
     }
 
     /// @notice This function is called when the LicensingModule calculates/predict the minting fee for license tokens.
-    /// @dev This function will always revert to prevent any license minting fee calculation/prediction.
+    /// @dev This function will always return 0 to signal that license is locked/disabled.
     /// @param caller The address of the caller who calling the mintLicenseTokens() function.
     /// @param licensorIpId The ID of licensor IP from which issue the license tokens.
     /// @param licenseTemplate The address of the license template.
@@ -77,7 +77,7 @@ contract LockLicenseHook is BaseModule, ILicensingHook {
         address receiver,
         bytes calldata hookData
     ) external view returns (uint256 totalMintingFee) {
-        revert LockLicenseHook_LicenseLocked(licensorIpId, licenseTemplate, licenseTermsId);
+        totalMintingFee = 0;
     }
 
     function supportsInterface(bytes4 interfaceId) public view virtual override(BaseModule, IERC165) returns (bool) {

--- a/test/hooks/LockLicenseHook.t.sol
+++ b/test/hooks/LockLicenseHook.t.sol
@@ -98,7 +98,7 @@ contract LockLicenseHookTest is BaseTest {
         });
     }
 
-    function test_LockLicenseHook_revert_calculateMintingFee() public {
+    function test_LockLicenseHook_calculateMintingFee() public {
         uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
         LockLicenseHook lockLicenseHook = new LockLicenseHook();
         vm.prank(u.admin);
@@ -107,7 +107,7 @@ contract LockLicenseHookTest is BaseTest {
         vm.startPrank(ipOwner);
         Licensing.LicensingConfig memory licensingConfig = Licensing.LicensingConfig({
             isSet: true,
-            mintingFee: 0,
+            mintingFee: 1000,
             licensingHook: address(lockLicenseHook),
             hookData: "",
             commercialRevShare: 0
@@ -116,15 +116,7 @@ contract LockLicenseHookTest is BaseTest {
         vm.stopPrank();
 
         vm.startPrank(u.bob);
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                LockLicenseHook.LockLicenseHook_LicenseLocked.selector,
-                ipId,
-                address(pilTemplate),
-                socialRemixTermsId
-            )
-        );
-        licensingModule.predictMintingLicenseFee({
+        (, uint256 mintingFee) = licensingModule.predictMintingLicenseFee({
             licensorIpId: ipId,
             licenseTemplate: address(pilTemplate),
             licenseTermsId: socialRemixTermsId,
@@ -132,5 +124,6 @@ contract LockLicenseHookTest is BaseTest {
             receiver: u.bob,
             royaltyContext: ""
         });
+        assertEq(mintingFee, 0);
     }
 }

--- a/test/hooks/LockLicenseHook.t.sol
+++ b/test/hooks/LockLicenseHook.t.sol
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { Licensing } from "@storyprotocol/core/lib/Licensing.sol";
+import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
+
+import { BaseTest } from "../utils/BaseTest.t.sol";
+import { LockLicenseHook } from "../../contracts/hooks/LockLicenseHook.sol";
+
+contract LockLicenseHookTest is BaseTest {
+    address public ipId;
+    address public ipOwner;
+
+    function setUp() public override {
+        super.setUp();
+        ipOwner = u.alice;
+        uint256 tokenId = mockNft.mint(ipOwner);
+        ipId = ipAssetRegistry.register(block.chainid, address(mockNft), tokenId);
+        vm.label(ipId, "IPAccount");
+    }
+
+    function test_LockLicenseHook_revert_beforeMintLicenseTokens() public {
+        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        LockLicenseHook lockLicenseHook = new LockLicenseHook();
+        vm.prank(u.admin);
+        moduleRegistry.registerModule("LockLicenseHook", address(lockLicenseHook));
+
+        vm.startPrank(ipOwner);
+        Licensing.LicensingConfig memory licensingConfig = Licensing.LicensingConfig({
+            isSet: true,
+            mintingFee: 0,
+            licensingHook: address(lockLicenseHook),
+            hookData: "",
+            commercialRevShare: 0
+        });
+        licensingModule.setLicensingConfig(ipId, address(pilTemplate), socialRemixTermsId, licensingConfig);
+        vm.stopPrank();
+
+        vm.startPrank(u.bob);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LockLicenseHook.LockLicenseHook_LicenseLocked.selector,
+                ipId,
+                address(pilTemplate),
+                socialRemixTermsId
+            )
+        );
+        licensingModule.mintLicenseTokens({
+            licensorIpId: ipId,
+            licenseTemplate: address(pilTemplate),
+            licenseTermsId: socialRemixTermsId,
+            amount: 1,
+            receiver: u.bob,
+            royaltyContext: "",
+            maxMintingFee: 0
+        });
+    }
+
+    function test_LockLicenseHook_revert_beforeRegisterDerivative() public {
+        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        LockLicenseHook lockLicenseHook = new LockLicenseHook();
+        vm.prank(u.admin);
+        moduleRegistry.registerModule("LockLicenseHook", address(lockLicenseHook));
+
+        vm.startPrank(ipOwner);
+        Licensing.LicensingConfig memory licensingConfig = Licensing.LicensingConfig({
+            isSet: true,
+            mintingFee: 0,
+            licensingHook: address(lockLicenseHook),
+            hookData: "",
+            commercialRevShare: 0
+        });
+        licensingModule.setLicensingConfig(ipId, address(pilTemplate), socialRemixTermsId, licensingConfig);
+        vm.stopPrank();
+
+        address[] memory parentIpIds = new address[](1);
+        parentIpIds[0] = ipId;
+        uint256[] memory licenseTermsIds = new uint256[](1);
+        licenseTermsIds[0] = socialRemixTermsId;
+
+        vm.startPrank(u.bob);
+        address ipIdChild = ipAssetRegistry.register(block.chainid, address(mockNft), mockNft.mint(u.bob));
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LockLicenseHook.LockLicenseHook_LicenseLocked.selector,
+                ipId,
+                address(pilTemplate),
+                socialRemixTermsId
+            )
+        );
+        licensingModule.registerDerivative({
+            childIpId: ipIdChild,
+            parentIpIds: parentIpIds,
+            licenseTermsIds: licenseTermsIds,
+            licenseTemplate: address(pilTemplate),
+            royaltyContext: "",
+            maxMintingFee: 0
+        });
+    }
+
+    function test_LockLicenseHook_revert_calculateMintingFee() public {
+        uint256 socialRemixTermsId = pilTemplate.registerLicenseTerms(PILFlavors.nonCommercialSocialRemixing());
+        LockLicenseHook lockLicenseHook = new LockLicenseHook();
+        vm.prank(u.admin);
+        moduleRegistry.registerModule("LockLicenseHook", address(lockLicenseHook));
+
+        vm.startPrank(ipOwner);
+        Licensing.LicensingConfig memory licensingConfig = Licensing.LicensingConfig({
+            isSet: true,
+            mintingFee: 0,
+            licensingHook: address(lockLicenseHook),
+            hookData: "",
+            commercialRevShare: 0
+        });
+        licensingModule.setLicensingConfig(ipId, address(pilTemplate), socialRemixTermsId, licensingConfig);
+        vm.stopPrank();
+
+        vm.startPrank(u.bob);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                LockLicenseHook.LockLicenseHook_LicenseLocked.selector,
+                ipId,
+                address(pilTemplate),
+                socialRemixTermsId
+            )
+        );
+        licensingModule.predictMintingLicenseFee({
+            licensorIpId: ipId,
+            licenseTemplate: address(pilTemplate),
+            licenseTermsId: socialRemixTermsId,
+            amount: 1,
+            receiver: u.bob,
+            royaltyContext: ""
+        });
+    }
+}

--- a/test/hooks/TotalLicenseTokenLimitHook.t.sol
+++ b/test/hooks/TotalLicenseTokenLimitHook.t.sol
@@ -5,7 +5,7 @@ import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
 import { Licensing } from "@storyprotocol/core/lib/Licensing.sol";
 import { Errors } from "@storyprotocol/core/lib/Errors.sol";
 
-import { TotalLicenseTokenLimitHook } from "contracts/hooks/TotalLicenseTokenLimitHook.sol";
+import { TotalLicenseTokenLimitHook } from "../../contracts/hooks/TotalLicenseTokenLimitHook.sol";
 
 import { BaseTest } from "../utils/BaseTest.t.sol";
 


### PR DESCRIPTION
## Description
<!-- Add a description of the changes that this PR introduces -->
This PR introduces the `LockLicenseHook` contract, which is designed to prevent any license token minting, derivative registration, and minting fee calculations. This hook can be used to effectively lock a license, preventing any further operations on it.

## Changes
- Added `LockLicenseHook` contract in `contracts/hooks/LockLicenseHook.sol`
- Implemented `ILicensingHook` interface
- Added custom error `LockLicenseHook_LicenseLocked`
- Implemented `beforeMintLicenseTokens`, `beforeRegisterDerivative`, and `calculateMintingFee` functions to always revert
- Added `supportsInterface` function for ERC165 compliance

## Test Plan 
<!-- The test plan section indicates detailed steps on how to verify and test code changes. 
You can list the test cases or test steps that need to be performed.-->
Tested integration with the `LicensingModule` to verify that the hook prevents minting and derivative registration.


## Usage
1. To lock or disable a license:
     - IP owners should set the license configuration using the  `LicensingModule`.
     - Set the `LockLicenseHook` as the license hook in the license configuration to enforce the lock.
2. To unlock or re-enable a license:
     - Change the `isSet` flag to `false` in license configuration to deactivate the lock.
     - Alternatively, remove the lock by setting license hook to address(0) in license configuration.