### PR TITLE
fix(integ-test): fix integration test & release v1.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # CHANGELOG
 
+## v1.2.4
+
+* Introduced Story NFT with various enhancements:
+  * Added permission handling in `registerPILTermsAndAttach`
+  * Enabled URI changes post deployment
+  * Added upgrade scripts
+  * Implemented ERC-7572 contract-level metadata support
+  * Resolved reentrancy vulnerability
+* Added royalty claiming for group IPs
+* Updated tests and added new deployment
+
+**Full Changelog**: [v1.2.3...v1.2.4](https://github.com/storyprotocol/protocol-periphery-v1/compare/v1.2.3...v1.2.4)
+
 ## v1.2.3
 
 * Refactored SPG into "workflow" contracts and introduced `RoyaltyWorkflows` for IP Revenue Claiming

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,12 @@
 ## v1.2.4
 
 * Introduced Story NFT with various enhancements:
-  * Added permission handling in `registerPILTermsAndAttach`
   * Enabled URI changes post deployment
   * Added upgrade scripts
-  * Implemented ERC-7572 contract-level metadata support
   * Resolved reentrancy vulnerability
+* Implemented ERC-7572 contract-level metadata support
+* Added permission handling in `registerPILTermsAndAttach`
 * Added royalty claiming for group IPs
-* Updated tests and added new deployment
 
 **Full Changelog**: [v1.2.3...v1.2.4](https://github.com/storyprotocol/protocol-periphery-v1/compare/v1.2.3...v1.2.4)
 

--- a/README.md
+++ b/README.md
@@ -36,17 +36,17 @@ Batch calling functions is supported both natively and through the `Multicall3` 
 
 ### Deployed Contracts
 
-[![Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fstoryprotocol%2Fprotocol-periphery-v1%2Fmain%2Fpackage.json&query=%24.version&label=PoC%20Periphery)](https://github.com/storyprotocol/protocol-periphery-v1/releases) contracts are deployed on Story's Iliad Testnet at the following addresses:
+[![Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fstoryprotocol%2Fprotocol-periphery-v1%2Fmain%2Fpackage.json&query=%24.version&label=PoC%20Periphery)](https://github.com/storyprotocol/protocol-periphery-v1/releases) contracts are deployed on Story Testnet at the following addresses:
 
 ```json
 {
-  "DerivativeWorkflows": "0xC022C70DA8c23Ae8e36B3de9039Ed24E4E42a127",
-  "GroupingWorkflows": "0x426fF4F7E9Debe565F5Fe6F53334Ad3982295E20",
-  "LicenseAttachmentWorkflows": "0x1B95144b62B4566501482e928aa435Dd205fE71B",
-  "RegistrationWorkflows": "0xF403fcCAAE6C503D0CC1D25904A0B2cCd5B96C6F",
-  "RoyaltyWorkflows": "0xc757921ee0f7c8E935d44BFBDc2602786e0eda6C",
-  "SPGNFTBeacon": "0x02324ca8f369abB445F50c4cE79e956e49AC75d8",
-  "SPGNFTImpl": "0xC8E4376Da033cE244027B03f9b94dc0d7005D67E"
+  "DerivativeWorkflows": "0xE0e1d222E024bF14B1e0A4b48fC6e6B6F8ebaEB3",
+  "GroupingWorkflows": "0xfAa9CCd49DCDfB9a950CBF036cD6082e623a6bcC",
+  "LicenseAttachmentWorkflows": "0xC7A40c41Cbe44C6B326447081877d69F98127C59",
+  "RegistrationWorkflows": "0x8D8E0d24E7B6420d3209EfA185Fa451c95D8316A",
+  "RoyaltyWorkflows": "0x19E435b1C0857375F9423C8ba508203054CE1d9F",
+  "SPGNFTBeacon": "0xD753c698aE69194C851d60BF759d537DE7477696",
+  "SPGNFTImpl": "0xA12e66a4429c9B7f38893c9b00E80646e0e76446"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ forge compile --build-info
 3. Run the script to generate boilerplate code for storage handling and the namespace hash:
 
 ```sh
-forge script script/utils/upgrades/ERC7201Helper.s.sol 
+forge script script/utils/upgrades/ERC7201Helper.s.sol
 ```
 
 4. The log output is the boilerplate code, copy and paste in your contract

--- a/deploy-out/deployment-1516.json
+++ b/deploy-out/deployment-1516.json
@@ -1,0 +1,11 @@
+{
+    "main": {
+        "DerivativeWorkflows": "0xE0e1d222E024bF14B1e0A4b48fC6e6B6F8ebaEB3",
+        "GroupingWorkflows": "0xfAa9CCd49DCDfB9a950CBF036cD6082e623a6bcC",
+        "LicenseAttachmentWorkflows": "0xC7A40c41Cbe44C6B326447081877d69F98127C59",
+        "RegistrationWorkflows": "0x8D8E0d24E7B6420d3209EfA185Fa451c95D8316A",
+        "RoyaltyWorkflows": "0x19E435b1C0857375F9423C8ba508203054CE1d9F",
+        "SPGNFTBeacon": "0xD753c698aE69194C851d60BF759d537DE7477696",
+        "SPGNFTImpl": "0xA12e66a4429c9B7f38893c9b00E80646e0e76446"
+    }
+}

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -41,6 +41,8 @@
   - Registers a group IP → Attaches the given license terms to the group IP
 - `registerGroupAndAttachLicenseAndAddIps`:
   - Registers a group IP → Attaches the given license terms to the group IP → Adds existing IPs to the group IP
+- `collectRoyaltiesAndClaimReward`:
+  - Collects revenue tokens to the group's reward pool → Distributes the rewards to each given member IP's royalty vault
 
 ### [Royalty Workflows](../contracts/interfaces/workflows/IRoyaltyWorkflows.sol)
 

--- a/package.json
+++ b/package.json
@@ -1,47 +1,47 @@
 {
-  "name": "@story-protocol/protocol-periphery",
-  "version": "v1.2.3",
-  "description": "Story Proof-of-Creativity protocol periphery smart contracts",
-  "main": "",
-  "directories": {
-    "lib": "lib",
-    "test": "test"
-  },
-  "scripts": {
-    "lint": "npm run lint:js && npm run lint:sol",
-    "lint:fix": "npm run lint:js:fix && npm run lint:sol:fix",
-    "lint:js": "prettier --log-level warn --ignore-path .gitignore '**/*.{js,ts}' --check && eslint --ignore-path .gitignore .",
-    "lint:js:fix": "prettier --log-level warn --ignore-path .gitignore '**/*.{js,ts}' --write && eslint --ignore-path .gitignore . --fix",
-    "lint:sol": "prettier --log-level warn --ignore-path .gitignore '{contracts,test}/**/*.sol' --check && solhint '{contracts,test}/**/*.sol'",
-    "lint:sol:fix": "prettier --log-level warn --ignore-path .gitignore '{contracts,test}/**/*.sol' --write",
-    "solhint": "solhint '{contracts,test}/**/*.sol'",
-    "test": "npx hardhat test",
-    "prepare": "husky install"
-  },
-  "author": "StoryProtocol",
-  "license": "MIT",
-  "devDependencies": {
-    "chai": "^5.0.3",
-    "dotenv": "^16.4.1",
-    "eslint": "^8.56.0",
-    "eslint-plugin-prettier": "^5.1.3",
-    "ethers": "^6.10.0",
-    "husky": "^9.0.11",
-    "mocha": "^10.2.0",
-    "prettier": "^3.0.0",
-    "prettier-plugin-solidity": "^1.1.3",
-    "solhint": "^4.1.1",
-    "solhint-plugin-prettier": "^0.1.0",
-    "solidity-coverage": "^0.8.6",
-    "ts-node": "^10.9.2",
-    "typechain": "^8.3.2"
-  },
-  "dependencies": {
-    "@openzeppelin/contracts": "5.0.1",
-    "@openzeppelin/contracts-upgradeable": "5.0.1",
-    "@story-protocol/create3-deployer": "github:storyprotocol/create3-deployer#main",
-    "@story-protocol/protocol-core": "github:storyprotocol/protocol-core-v1#main",
-    "erc6551": "^0.3.1",
-    "solady": "^0.0.192"
-  }
+    "name": "@story-protocol/protocol-periphery",
+    "version": "v1.2.4",
+    "description": "Story Proof-of-Creativity protocol periphery smart contracts",
+    "main": "",
+    "directories": {
+        "lib": "lib",
+        "test": "test"
+    },
+    "scripts": {
+        "lint": "npm run lint:js && npm run lint:sol",
+        "lint:fix": "npm run lint:js:fix && npm run lint:sol:fix",
+        "lint:js": "prettier --log-level warn --ignore-path .gitignore '**/*.{js,ts}' --check && eslint --ignore-path .gitignore .",
+        "lint:js:fix": "prettier --log-level warn --ignore-path .gitignore '**/*.{js,ts}' --write && eslint --ignore-path .gitignore . --fix",
+        "lint:sol": "prettier --log-level warn --ignore-path .gitignore '{contracts,test}/**/*.sol' --check && solhint '{contracts,test}/**/*.sol'",
+        "lint:sol:fix": "prettier --log-level warn --ignore-path .gitignore '{contracts,test}/**/*.sol' --write",
+        "solhint": "solhint '{contracts,test}/**/*.sol'",
+        "test": "npx hardhat test",
+        "prepare": "husky install"
+    },
+    "author": "StoryProtocol",
+    "license": "MIT",
+    "devDependencies": {
+        "chai": "^5.0.3",
+        "dotenv": "^16.4.1",
+        "eslint": "^8.56.0",
+        "eslint-plugin-prettier": "^5.1.3",
+        "ethers": "^6.10.0",
+        "husky": "^9.0.11",
+        "mocha": "^10.2.0",
+        "prettier": "^3.0.0",
+        "prettier-plugin-solidity": "^1.1.3",
+        "solhint": "^4.1.1",
+        "solhint-plugin-prettier": "^0.1.0",
+        "solidity-coverage": "^0.8.6",
+        "ts-node": "^10.9.2",
+        "typechain": "^8.3.2"
+    },
+    "dependencies": {
+        "@openzeppelin/contracts": "5.0.1",
+        "@openzeppelin/contracts-upgradeable": "5.0.1",
+        "@story-protocol/create3-deployer": "github:storyprotocol/create3-deployer#main",
+        "@story-protocol/protocol-core": "github:storyprotocol/protocol-core-v1#main",
+        "erc6551": "^0.3.1",
+        "solady": "^0.0.192"
+    }
 }

--- a/script/utils/BroadcastManager.s.sol
+++ b/script/utils/BroadcastManager.s.sol
@@ -14,7 +14,7 @@ contract BroadcastManager is Script {
             deployer = vm.envAddress("MAINNET_DEPLOYER_ADDRESS");
             multisig = vm.envAddress("MAINNET_MULTISIG_ADDRESS");
             vm.startBroadcast(deployerPrivateKey);
-        } else if (block.chainid == 1513 || block.chainid == 11155111) {
+        } else if (block.chainid == 1513 || block.chainid == 1516 || block.chainid == 11155111) {
             deployerPrivateKey = vm.envUint("TESTNET_PRIVATEKEY");
             deployer = vm.envAddress("TESTNET_DEPLOYER_ADDRESS");
             multisig = vm.envAddress("TESTNET_MULTISIG_ADDRESS");

--- a/script/utils/StoryProtocolCoreAddressManager.sol
+++ b/script/utils/StoryProtocolCoreAddressManager.sol
@@ -21,6 +21,7 @@ contract StoryProtocolCoreAddressManager is Script {
     address internal groupNFTAddr;
     address internal royaltyPolicyLAPAddr;
     address internal royaltyPolicyLRPAddr;
+    address internal evenSplitGroupPoolAddr;
 
     function _readStoryProtocolCoreAddresses() internal {
         string memory root = vm.projectRoot();
@@ -49,5 +50,6 @@ contract StoryProtocolCoreAddressManager is Script {
         groupNFTAddr = json.readAddress(".main.GroupNFT");
         royaltyPolicyLAPAddr = json.readAddress(".main.RoyaltyPolicyLAP");
         royaltyPolicyLRPAddr = json.readAddress(".main.RoyaltyPolicyLRP");
+        evenSplitGroupPoolAddr = json.readAddress(".main.EvenSplitGroupPool");
     }
 }

--- a/test/integration/BaseIntegration.t.sol
+++ b/test/integration/BaseIntegration.t.sol
@@ -21,6 +21,7 @@ import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensi
 import { IPILicenseTemplate } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
 import { IRoyaltyModule } from "@storyprotocol/core/interfaces/modules/royalty/IRoyaltyModule.sol";
 import { MetaTx } from "@storyprotocol/core/lib/MetaTx.sol";
+import { MockIPGraph } from "@storyprotocol/test/mocks/MockIPGraph.sol";
 
 // contracts
 import { DerivativeWorkflows } from "../../contracts/workflows/DerivativeWorkflows.sol";
@@ -57,10 +58,7 @@ contract BaseIntegration is Test, Script, StoryProtocolCoreAddressManager, Story
     RoyaltyWorkflows internal royaltyWorkflows;
 
     /// @dev Story USD
-    SUSD internal StoryUSD = SUSD(0x91f6F05B08c16769d3c85867548615d270C42fC7);
-
-    /// @dev Even split group reward pool
-    address internal groupRewardPool = 0xA1dB7AB14900Cd9eF9A7eBA931A206250F403a14;
+    SUSD internal StoryUSD = SUSD(0x6058bB8A2a51a8e63Bd18cE897D08616331C25a7);
 
     /// @dev Test data
     string internal testCollectionName;
@@ -79,6 +77,8 @@ contract BaseIntegration is Test, Script, StoryProtocolCoreAddressManager, Story
     }
 
     function run() public virtual {
+        // mock IPGraph precompile
+        vm.etch(address(0x0101), address(new MockIPGraph()).code);
         _setUp();
     }
 

--- a/test/integration/workflows/DerivativeIntegration.t.sol
+++ b/test/integration/workflows/DerivativeIntegration.t.sol
@@ -365,10 +365,11 @@ contract DerivativeIntegration is BaseIntegration {
                 spgNftContract: address(spgNftContract),
                 recipient: testSender,
                 ipMetadata: testIpMetadata,
-                terms: PILFlavors.commercialUse({
+                terms: PILFlavors.commercialRemix({
                     mintingFee: testMintFee,
-                    currencyToken: testMintFeeToken,
-                    royaltyPolicy: royaltyPolicyLRPAddr
+                    commercialRevShare: 10 * 10 ** 6, // 10%
+                    royaltyPolicy: royaltyPolicyLRPAddr,
+                    currencyToken: testMintFeeToken
                 })
             });
 

--- a/test/integration/workflows/GroupingIntegration.t.sol
+++ b/test/integration/workflows/GroupingIntegration.t.sol
@@ -153,7 +153,7 @@ contract GroupingIntegration is BaseIntegration {
         logTest("test_GroupingIntegration_registerGroupAndAttachLicense")
     {
         address newGroupId = groupingWorkflows.registerGroupAndAttachLicense({
-            groupPool: groupRewardPool,
+            groupPool: evenSplitGroupPoolAddr,
             licenseTemplate: testLicenseTemplate,
             licenseTermsId: testLicenseTermsId
         });
@@ -172,7 +172,7 @@ contract GroupingIntegration is BaseIntegration {
         logTest("test_GroupingIntegration_registerGroupAndAttachLicenseAndAddIps")
     {
         address newGroupId = groupingWorkflows.registerGroupAndAttachLicenseAndAddIps({
-            groupPool: groupRewardPool,
+            groupPool: evenSplitGroupPoolAddr,
             ipIds: ipIds,
             licenseTemplate: testLicenseTemplate,
             licenseTermsId: testLicenseTermsId
@@ -348,7 +348,7 @@ contract GroupingIntegration is BaseIntegration {
 
         // setup a group
         {
-            groupId = groupingModule.registerGroup(groupRewardPool);
+            groupId = groupingModule.registerGroup(evenSplitGroupPoolAddr);
             LicensingHelper.attachLicenseTerms(
                 groupId,
                 licensingModuleAddr,

--- a/test/workflows/DerivativeWorkflows.t.sol
+++ b/test/workflows/DerivativeWorkflows.t.sol
@@ -41,7 +41,7 @@ contract DerivativeWorkflowsTest is BaseTest {
             ipMetadata: ipMetadataDefault,
             terms: PILFlavors.commercialRemix({
                 mintingFee: 100 * 10 ** mockToken.decimals(),
-                commercialRevShare: 10, // 1%
+                commercialRevShare: 10 * 10 ** 6, // 10%
                 royaltyPolicy: address(royaltyPolicyLAP),
                 currencyToken: address(mockToken)
             })

--- a/yarn.lock
+++ b/yarn.lock
@@ -441,7 +441,7 @@
 
 "@story-protocol/protocol-core@github:storyprotocol/protocol-core-v1#main":
   version "1.1.0"
-  resolved "https://codeload.github.com/storyprotocol/protocol-core-v1/tar.gz/55114b5475b80bac0accf268d29e9f7583fd4ece"
+  resolved "https://codeload.github.com/storyprotocol/protocol-core-v1/tar.gz/3ef2a99a99192587d24b4805d5848e3a799dcf5e"
   dependencies:
     "@openzeppelin/contracts" "5.0.2"
     "@openzeppelin/contracts-upgradeable" "5.0.2"
@@ -495,9 +495,9 @@
   integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
 "@types/node@*":
-  version "22.7.6"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.7.6.tgz#3ec3e2b071e136cd11093c19128405e1d1f92f33"
-  integrity sha512-/d7Rnj0/ExXDMcioS78/kf1lMzYk4BZV8MZGTBKzTGZ6/406ukkbYlIsZmMPhcR5KlkunDHQLrtAVmSq7r+mSw==
+  version "22.7.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.7.7.tgz#6cd9541c3dccb4f7e8b141b491443f4a1570e307"
+  integrity sha512-SRxCrrg9CL/y54aiMCG3edPKdprgMVGDXjA3gB8UmmBW5TcXzRUYAh8EWzTnSJFAd1rgImPELza+A3bJ+qxz8Q==
   dependencies:
     undici-types "~6.19.2"
 


### PR DESCRIPTION
## Key Changes
- Integration Test Updates:
    - Modified `GroupingWorkflows` integration test to use `EvenSplitGroupPool` from the protocol core deployment info.
    - Updated `BroadcastManager` to include the new chain ID.
    - Adjusted `DerivativeWorkflows` integration test to use the `CommercialRemix` license, replacing the previous `CommercialUse` license.
    - Updated `BaseIntegration` to include mock IPGraph precompile.
- Added changelog for version v1.2.4.
- Updated docs to incelude `collectRoyaltiesAndClaimReward` function in `GroupingWorkflows`.
- Updated contract deployment addresses.
- Bumped the package version to v1.2.4.