### PR TITLE
feat(spg-nft): add deduplication option to mint functions

### DIFF
--- a/contracts/BaseWorkflow.sol
+++ b/contracts/BaseWorkflow.sol
@@ -60,4 +60,12 @@ abstract contract BaseWorkflow {
         ) revert Errors.Workflow__CallerNotAuthorizedToMint();
         _;
     }
+
+    /// @notice Gets the IP ID associated with an NFT.
+    /// @param nftContract The address of the NFT.
+    /// @param tokenId The token identifier of the NFT.
+    /// @return The IP's canonical address identifier (IP ID).
+    function _getIpId(address nftContract, uint256 tokenId) internal view returns (address) {
+        return IP_ASSET_REGISTRY.ipId(block.chainid, nftContract, tokenId);
+    }
 }

--- a/contracts/BaseWorkflow.sol
+++ b/contracts/BaseWorkflow.sol
@@ -60,12 +60,4 @@ abstract contract BaseWorkflow {
         ) revert Errors.Workflow__CallerNotAuthorizedToMint();
         _;
     }
-
-    /// @notice Gets the IP ID associated with an NFT.
-    /// @param nftContract The address of the NFT.
-    /// @param tokenId The token identifier of the NFT.
-    /// @return The IP's canonical address identifier (IP ID).
-    function _getIpId(address nftContract, uint256 tokenId) internal view returns (address) {
-        return IP_ASSET_REGISTRY.ipId(block.chainid, nftContract, tokenId);
-    }
 }

--- a/contracts/SPGNFT.sol
+++ b/contracts/SPGNFT.sol
@@ -22,6 +22,7 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
     /// @param _publicMinting True if the collection is open for everyone to mint.
     /// @param _baseURI The base URI for the collection. If baseURI is not empty, tokenURI will be
     /// either baseURI + token ID (if nftMetadataURI is empty) or baseURI + nftMetadataURI.
+    /// @param _nftMetadataHashToTokenId The mapping of nftMetadataHash to token ID.
     /// @custom:storage-location erc7201:story-protocol-periphery.SPGNFT
     struct SPGNFTStorage {
         uint32 _maxSupply;
@@ -33,6 +34,7 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
         bool _publicMinting;
         string _baseURI;
         string _contractURI;
+        mapping (bytes32 nftMetadataHash => uint256 tokenId) _nftMetadataHashToTokenId;
     }
 
     // keccak256(abi.encode(uint256(keccak256("story-protocol-periphery.SPGNFT")) - 1)) & ~bytes32(uint256(0xff));
@@ -148,6 +150,14 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
         return _getSPGNFTStorage()._contractURI;
     }
 
+    /// @notice Returns the token ID by the metadata hash.
+    /// @dev Returns 0 if the metadata hash has not been used in this collection.
+    /// @param nftMetadataHash A bytes32 hash of the NFT's metadata.
+    /// @return tokenId The token ID of the NFT with the given metadata hash.
+    function getTokenIdByMetadataHash(bytes32 nftMetadataHash) external view returns (uint256) {
+        return _getSPGNFTStorage()._nftMetadataHashToTokenId[nftMetadataHash];
+    }
+
     /// @notice Sets the fee to mint an NFT from the collection. Payment is in the designated currency.
     /// @dev Only callable by the admin role.
     /// @param fee The new mint fee paid in the mint token.
@@ -207,25 +217,54 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
     /// @notice Mints an NFT from the collection. Only callable by the minter role.
     /// @param to The address of the recipient of the minted NFT.
     /// @param nftMetadataURI OPTIONAL. The URI of the desired metadata for the newly minted NFT.
-    /// @return tokenId The ID of the minted NFT.
-    function mint(address to, string calldata nftMetadataURI) public virtual returns (uint256 tokenId) {
+    /// @param nftMetadataHash OPTIONAL. A bytes32 hash of the NFT's metadata.
+    /// This metadata is accessible via the NFT's tokenURI.
+    /// @param dedup Set to true to enable checking for duplicate metadata hashes.
+    /// If a duplicate is found, the function will return the existing token ID instead of minting a new one.
+    /// @return tokenId The token ID of the minted NFT with the given metadata hash.
+    /// @return deduped true if dedup is enabled and the metadata hash is already used, false otherwise.
+    function mint(
+        address to,
+        string calldata nftMetadataURI,
+        bytes32 nftMetadataHash,
+        bool dedup
+    ) public virtual returns (uint256 tokenId, bool deduped) {
         if (!_getSPGNFTStorage()._publicMinting && !hasRole(SPGNFTLib.MINTER_ROLE, msg.sender)) {
             revert Errors.SPGNFT__MintingDenied();
         }
-        tokenId = _mintToken({ to: to, payer: msg.sender, nftMetadataURI: nftMetadataURI });
+        (tokenId, deduped) = _mintToken({
+            to: to,
+            payer: msg.sender,
+            nftMetadataURI: nftMetadataURI,
+            nftMetadataHash: nftMetadataHash,
+            dedup: dedup
+        });
     }
 
     /// @notice Mints an NFT from the collection. Only callable by the Periphery contracts.
     /// @param to The address of the recipient of the minted NFT.
     /// @param payer The address of the payer for the mint fee.
     /// @param nftMetadataURI OPTIONAL. The URI of the desired metadata for the newly minted NFT.
-    /// @return tokenId The ID of the minted NFT.
+    /// @param nftMetadataHash OPTIONAL. A bytes32 hash of the NFT's metadata.
+    /// This metadata is accessible via the NFT's tokenURI.
+    /// @param dedup Set to true to enable checking for duplicate metadata hashes.
+    /// If a duplicate is found, the function will return the existing token ID instead of minting a new one.
+    /// @return tokenId The token ID of the minted NFT with the given metadata hash.
+    /// @return deduped true if dedup is enabled and the metadata hash is already used, false otherwise.
     function mintByPeriphery(
         address to,
         address payer,
-        string calldata nftMetadataURI
-    ) public virtual onlyPeriphery returns (uint256 tokenId) {
-        tokenId = _mintToken({ to: to, payer: payer, nftMetadataURI: nftMetadataURI });
+        string calldata nftMetadataURI,
+        bytes32 nftMetadataHash,
+        bool dedup
+    ) public virtual onlyPeriphery returns (uint256 tokenId, bool deduped) {
+        (tokenId, deduped) = _mintToken({
+            to: to,
+            payer: payer,
+            nftMetadataURI: nftMetadataURI,
+            nftMetadataHash: nftMetadataHash,
+            dedup: dedup
+        });
     }
 
     /// @dev Withdraws the contract's token balance to the fee recipient.
@@ -246,20 +285,43 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
     /// @param to The address of the recipient of the minted NFT.
     /// @param payer The address of the payer for the mint fee.
     /// @param nftMetadataURI OPTIONAL. The URI of the desired metadata for the newly minted NFT.
-    /// @return tokenId The ID of the minted NFT.
-    function _mintToken(address to, address payer, string calldata nftMetadataURI) internal returns (uint256 tokenId) {
+    /// @param nftMetadataHash OPTIONAL. A bytes32 hash of the NFT's metadata.
+    /// This metadata is accessible via the NFT's tokenURI.
+    /// @param dedup Set to true to enable checking for duplicate metadata hashes.
+    /// If a duplicate is found, the function will return the existing token ID instead of minting a new one.
+    /// @return tokenId The token ID of the minted NFT with the given metadata hash.
+    /// @return deduped true if dedup is enabled and the metadata hash is already used, false otherwise.
+    function _mintToken(
+        address to,
+        address payer,
+        string calldata nftMetadataURI,
+        bytes32 nftMetadataHash,
+        bool dedup
+    ) internal returns (uint256 tokenId, bool deduped) {
         SPGNFTStorage storage $ = _getSPGNFTStorage();
         if (!$._mintOpen) revert Errors.SPGNFT__MintingClosed();
         if ($._totalSupply + 1 > $._maxSupply) revert Errors.SPGNFT__MaxSupplyReached();
+
+        tokenId = $._nftMetadataHashToTokenId[nftMetadataHash];
+        if (dedup && tokenId != 0) {
+            return (tokenId, true);
+        }
 
         if ($._mintFeeToken != address(0) && $._mintFee > 0) {
             IERC20($._mintFeeToken).transferFrom(payer, address(this), $._mintFee);
         }
 
         tokenId = ++$._totalSupply;
+        if ($._nftMetadataHashToTokenId[nftMetadataHash] == 0) {
+            // only store the token ID if the metadata hash is not used
+            $._nftMetadataHashToTokenId[nftMetadataHash] = tokenId;
+        }
+
         _mint(to, tokenId);
 
         if (bytes(nftMetadataURI).length > 0) _setTokenURI(tokenId, nftMetadataURI);
+
+        return (tokenId, false);
     }
 
     /// @dev Base URI for computing tokenURI.

--- a/contracts/SPGNFT.sol
+++ b/contracts/SPGNFT.sol
@@ -34,7 +34,7 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
         bool _publicMinting;
         string _baseURI;
         string _contractURI;
-        mapping (bytes32 nftMetadataHash => uint256 tokenId) _nftMetadataHashToTokenId;
+        mapping(bytes32 nftMetadataHash => uint256 tokenId) _nftMetadataHashToTokenId;
     }
 
     // keccak256(abi.encode(uint256(keccak256("story-protocol-periphery.SPGNFT")) - 1)) & ~bytes32(uint256(0xff));

--- a/contracts/interfaces/ISPGNFT.sol
+++ b/contracts/interfaces/ISPGNFT.sol
@@ -114,16 +114,14 @@ interface ISPGNFT is IAccessControl, IERC721Metadata, IERC7572 {
     /// @param nftMetadataURI OPTIONAL. The desired metadata for the newly minted NFT.
     /// @param nftMetadataHash OPTIONAL. A bytes32 hash of the NFT's metadata.
     /// This metadata is accessible via the NFT's tokenURI.
-    /// @param dedup Set to true to enable checking for duplicate metadata hashes.
-    /// If a duplicate is found, the function will return the existing token ID instead of minting a new one.
+    /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
     /// @return tokenId The token ID of the minted NFT with the given metadata hash.
-    /// @return deduped true if dedup is enabled and the metadata hash is already used, false otherwise.
     function mint(
         address to,
         string calldata nftMetadataURI,
         bytes32 nftMetadataHash,
-        bool dedup
-    ) external returns (uint256 tokenId, bool deduped);
+        bool allowDuplicates
+    ) external returns (uint256 tokenId);
 
     /// @notice Mints an NFT from the collection. Only callable by Periphery contracts.
     /// @param to The address of the recipient of the minted NFT.
@@ -131,17 +129,15 @@ interface ISPGNFT is IAccessControl, IERC721Metadata, IERC7572 {
     /// @param nftMetadataURI OPTIONAL. The desired metadata for the newly minted NFT.
     /// @param nftMetadataHash OPTIONAL. A bytes32 hash of the NFT's metadata.
     /// This metadata is accessible via the NFT's tokenURI.
-    /// @param dedup Set to true to enable checking for duplicate metadata hashes.
-    /// If a duplicate is found, the function will return the existing token ID instead of minting a new one.
+    /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
     /// @return tokenId The token ID of the minted NFT with the given metadata hash.
-    /// @return deduped true if dedup is enabled and the metadata hash is already used, false otherwise.
     function mintByPeriphery(
         address to,
         address payer,
         string calldata nftMetadataURI,
         bytes32 nftMetadataHash,
-        bool dedup
-    ) external returns (uint256 tokenId, bool deduped);
+        bool allowDuplicates
+    ) external returns (uint256 tokenId);
 
     /// @dev Withdraws the contract's token balance to the fee recipient.
     /// @param token The token to withdraw.

--- a/contracts/interfaces/ISPGNFT.sol
+++ b/contracts/interfaces/ISPGNFT.sol
@@ -65,6 +65,13 @@ interface ISPGNFT is IAccessControl, IERC721Metadata, IERC7572 {
     /// or baseURI + token ID (if nftMetadataURI is empty).
     function baseURI() external view returns (string memory);
 
+    /// @notice Returns the token ID by the metadata hash.
+    /// @dev Returns 0 if the metadata hash has not been used in this collection.
+    /// @param nftMetadataHash A bytes32 hash of the NFT's metadata.
+    /// This metadata is accessible via the NFT's tokenURI.
+    /// @return tokenId The token ID of the NFT with the given metadata hash.
+    function getTokenIdByMetadataHash(bytes32 nftMetadataHash) external view returns (uint256);
+
     /// @notice Sets the fee to mint an NFT from the collection. Payment is in the designated currency.
     /// @dev Only callable by the admin role.
     /// @param fee The new mint fee paid in the mint token.
@@ -105,19 +112,36 @@ interface ISPGNFT is IAccessControl, IERC721Metadata, IERC7572 {
     /// @notice Mints an NFT from the collection. Only callable by the minter role.
     /// @param to The address of the recipient of the minted NFT.
     /// @param nftMetadataURI OPTIONAL. The desired metadata for the newly minted NFT.
-    /// @return tokenId The ID of the minted NFT.
-    function mint(address to, string calldata nftMetadataURI) external returns (uint256 tokenId);
+    /// @param nftMetadataHash OPTIONAL. A bytes32 hash of the NFT's metadata.
+    /// This metadata is accessible via the NFT's tokenURI.
+    /// @param dedup Set to true to enable checking for duplicate metadata hashes.
+    /// If a duplicate is found, the function will return the existing token ID instead of minting a new one.
+    /// @return tokenId The token ID of the minted NFT with the given metadata hash.
+    /// @return deduped true if dedup is enabled and the metadata hash is already used, false otherwise.
+    function mint(
+        address to,
+        string calldata nftMetadataURI,
+        bytes32 nftMetadataHash,
+        bool dedup
+    ) external returns (uint256 tokenId, bool deduped);
 
     /// @notice Mints an NFT from the collection. Only callable by Periphery contracts.
     /// @param to The address of the recipient of the minted NFT.
     /// @param payer The address of the payer for the mint fee.
     /// @param nftMetadataURI OPTIONAL. The desired metadata for the newly minted NFT.
-    /// @return tokenId The ID of the minted NFT.
+    /// @param nftMetadataHash OPTIONAL. A bytes32 hash of the NFT's metadata.
+    /// This metadata is accessible via the NFT's tokenURI.
+    /// @param dedup Set to true to enable checking for duplicate metadata hashes.
+    /// If a duplicate is found, the function will return the existing token ID instead of minting a new one.
+    /// @return tokenId The token ID of the minted NFT with the given metadata hash.
+    /// @return deduped true if dedup is enabled and the metadata hash is already used, false otherwise.
     function mintByPeriphery(
         address to,
         address payer,
-        string calldata nftMetadataURI
-    ) external returns (uint256 tokenId);
+        string calldata nftMetadataURI,
+        bytes32 nftMetadataHash,
+        bool dedup
+    ) external returns (uint256 tokenId, bool deduped);
 
     /// @dev Withdraws the contract's token balance to the fee recipient.
     /// @param token The token to withdraw.

--- a/contracts/interfaces/workflows/IDerivativeWorkflows.sol
+++ b/contracts/interfaces/workflows/IDerivativeWorkflows.sol
@@ -12,13 +12,15 @@ interface IDerivativeWorkflows {
     /// @param derivData The derivative data to be used for registerDerivative.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
     /// @param recipient The address to receive the minted NFT.
+    /// @param dedup Set to true to enable checking for duplicate metadata hashes in the SPGNFT collection.
     /// @return ipId The ID of the newly registered IP.
     /// @return tokenId The ID of the newly minted NFT.
     function mintAndRegisterIpAndMakeDerivative(
         address spgNftContract,
         WorkflowStructs.MakeDerivative calldata derivData,
         WorkflowStructs.IPMetadata calldata ipMetadata,
-        address recipient
+        address recipient,
+        bool dedup
     ) external returns (address ipId, uint256 tokenId);
 
     /// @notice Register the given NFT as a derivative IP with metadata without license tokens.
@@ -46,6 +48,7 @@ interface IDerivativeWorkflows {
     /// @param royaltyContext The context for royalty module, should be empty for Royalty Policy LAP.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
     /// @param recipient The address to receive the minted NFT.
+    /// @param dedup Set to true to enable checking for duplicate metadata hashes in the SPGNFT collection.
     /// @return ipId The ID of the newly registered IP.
     /// @return tokenId The ID of the newly minted NFT.
     function mintAndRegisterIpAndMakeDerivativeWithLicenseTokens(
@@ -53,7 +56,8 @@ interface IDerivativeWorkflows {
         uint256[] calldata licenseTokenIds,
         bytes calldata royaltyContext,
         WorkflowStructs.IPMetadata calldata ipMetadata,
-        address recipient
+        address recipient,
+        bool dedup
     ) external returns (address ipId, uint256 tokenId);
 
     /// @notice Register the given NFT as a derivative IP using license tokens.

--- a/contracts/interfaces/workflows/IDerivativeWorkflows.sol
+++ b/contracts/interfaces/workflows/IDerivativeWorkflows.sol
@@ -12,7 +12,7 @@ interface IDerivativeWorkflows {
     /// @param derivData The derivative data to be used for registerDerivative.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
     /// @param recipient The address to receive the minted NFT.
-    /// @param dedup Set to true to enable checking for duplicate metadata hashes in the SPGNFT collection.
+    /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
     /// @return ipId The ID of the newly registered IP.
     /// @return tokenId The ID of the newly minted NFT.
     function mintAndRegisterIpAndMakeDerivative(
@@ -20,7 +20,7 @@ interface IDerivativeWorkflows {
         WorkflowStructs.MakeDerivative calldata derivData,
         WorkflowStructs.IPMetadata calldata ipMetadata,
         address recipient,
-        bool dedup
+        bool allowDuplicates
     ) external returns (address ipId, uint256 tokenId);
 
     /// @notice Register the given NFT as a derivative IP with metadata without license tokens.
@@ -48,7 +48,7 @@ interface IDerivativeWorkflows {
     /// @param royaltyContext The context for royalty module, should be empty for Royalty Policy LAP.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
     /// @param recipient The address to receive the minted NFT.
-    /// @param dedup Set to true to enable checking for duplicate metadata hashes in the SPGNFT collection.
+    /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
     /// @return ipId The ID of the newly registered IP.
     /// @return tokenId The ID of the newly minted NFT.
     function mintAndRegisterIpAndMakeDerivativeWithLicenseTokens(
@@ -57,7 +57,7 @@ interface IDerivativeWorkflows {
         bytes calldata royaltyContext,
         WorkflowStructs.IPMetadata calldata ipMetadata,
         address recipient,
-        bool dedup
+        bool allowDuplicates
     ) external returns (address ipId, uint256 tokenId);
 
     /// @notice Register the given NFT as a derivative IP using license tokens.

--- a/contracts/interfaces/workflows/IGroupingWorkflows.sol
+++ b/contracts/interfaces/workflows/IGroupingWorkflows.sol
@@ -16,6 +16,7 @@ interface IGroupingWorkflows {
     /// @param licenseTermsId The ID of the registered license terms that will be attached to the new IP.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
     /// @param sigAddToGroup Signature data for addIp to the group IP via the Grouping Module.
+    /// @param dedup Set to true to enable checking for duplicate metadata hashes in the SPGNFT collection.
     /// @return ipId The ID of the newly registered IP.
     /// @return tokenId The ID of the newly minted NFT.
     function mintAndRegisterIpAndAttachLicenseAndAddToGroup(
@@ -25,7 +26,8 @@ interface IGroupingWorkflows {
         address licenseTemplate,
         uint256 licenseTermsId,
         WorkflowStructs.IPMetadata calldata ipMetadata,
-        WorkflowStructs.SignatureData calldata sigAddToGroup
+        WorkflowStructs.SignatureData calldata sigAddToGroup,
+        bool dedup
     ) external returns (address ipId, uint256 tokenId);
 
     /// @notice Register an NFT as IP with metadata, attach license terms to the registered IP,

--- a/contracts/interfaces/workflows/IGroupingWorkflows.sol
+++ b/contracts/interfaces/workflows/IGroupingWorkflows.sol
@@ -16,7 +16,7 @@ interface IGroupingWorkflows {
     /// @param licenseTermsId The ID of the registered license terms that will be attached to the new IP.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
     /// @param sigAddToGroup Signature data for addIp to the group IP via the Grouping Module.
-    /// @param dedup Set to true to enable checking for duplicate metadata hashes in the SPGNFT collection.
+    /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
     /// @return ipId The ID of the newly registered IP.
     /// @return tokenId The ID of the newly minted NFT.
     function mintAndRegisterIpAndAttachLicenseAndAddToGroup(
@@ -27,7 +27,7 @@ interface IGroupingWorkflows {
         uint256 licenseTermsId,
         WorkflowStructs.IPMetadata calldata ipMetadata,
         WorkflowStructs.SignatureData calldata sigAddToGroup,
-        bool dedup
+        bool allowDuplicates
     ) external returns (address ipId, uint256 tokenId);
 
     /// @notice Register an NFT as IP with metadata, attach license terms to the registered IP,

--- a/contracts/interfaces/workflows/ILicenseAttachmentWorkflows.sol
+++ b/contracts/interfaces/workflows/ILicenseAttachmentWorkflows.sol
@@ -27,6 +27,7 @@ interface ILicenseAttachmentWorkflows {
     /// @param recipient The address of the recipient of the minted NFT.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
     /// @param terms The PIL terms to be registered.
+    /// @param dedup Set to true to enable checking for duplicate metadata hashes in the SPGNFT collection.
     /// @return ipId The ID of the newly registered IP.
     /// @return tokenId The ID of the newly minted NFT.
     /// @return licenseTermsId The ID of the newly registered PIL terms.
@@ -34,7 +35,8 @@ interface ILicenseAttachmentWorkflows {
         address spgNftContract,
         address recipient,
         WorkflowStructs.IPMetadata calldata ipMetadata,
-        PILTerms calldata terms
+        PILTerms calldata terms,
+        bool dedup
     ) external returns (address ipId, uint256 tokenId, uint256 licenseTermsId);
 
     /// @notice Register a given NFT as an IP and attach Programmable IP License Terms.

--- a/contracts/interfaces/workflows/ILicenseAttachmentWorkflows.sol
+++ b/contracts/interfaces/workflows/ILicenseAttachmentWorkflows.sol
@@ -27,7 +27,7 @@ interface ILicenseAttachmentWorkflows {
     /// @param recipient The address of the recipient of the minted NFT.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
     /// @param terms The PIL terms to be registered.
-    /// @param dedup Set to true to enable checking for duplicate metadata hashes in the SPGNFT collection.
+    /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
     /// @return ipId The ID of the newly registered IP.
     /// @return tokenId The ID of the newly minted NFT.
     /// @return licenseTermsId The ID of the newly registered PIL terms.
@@ -36,7 +36,7 @@ interface ILicenseAttachmentWorkflows {
         address recipient,
         WorkflowStructs.IPMetadata calldata ipMetadata,
         PILTerms calldata terms,
-        bool dedup
+        bool allowDuplicates
     ) external returns (address ipId, uint256 tokenId, uint256 licenseTermsId);
 
     /// @notice Register a given NFT as an IP and attach Programmable IP License Terms.

--- a/contracts/interfaces/workflows/IRegistrationWorkflows.sol
+++ b/contracts/interfaces/workflows/IRegistrationWorkflows.sol
@@ -21,7 +21,7 @@ interface IRegistrationWorkflows {
     /// @param spgNftContract The address of the SPGNFT collection.
     /// @param recipient The address of the recipient of the minted NFT.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
-    /// @param dedup Set to true to enable checking for duplicate metadata hashes in the SPGNFT collection.
+    /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
     /// If a duplicate is found, returns existing token Id and IP Id instead of minting/registering a new one.
     /// @return ipId The ID of the registered IP.
     /// @return tokenId The ID of the newly minted NFT.
@@ -29,7 +29,7 @@ interface IRegistrationWorkflows {
         address spgNftContract,
         address recipient,
         WorkflowStructs.IPMetadata calldata ipMetadata,
-        bool dedup
+        bool allowDuplicates
     ) external returns (address ipId, uint256 tokenId);
 
     /// @notice Registers an NFT as IP with metadata.

--- a/contracts/interfaces/workflows/IRegistrationWorkflows.sol
+++ b/contracts/interfaces/workflows/IRegistrationWorkflows.sol
@@ -21,12 +21,15 @@ interface IRegistrationWorkflows {
     /// @param spgNftContract The address of the SPGNFT collection.
     /// @param recipient The address of the recipient of the minted NFT.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
+    /// @param dedup Set to true to enable checking for duplicate metadata hashes in the SPGNFT collection.
+    /// If a duplicate is found, returns existing token Id and IP Id instead of minting/registering a new one.
     /// @return ipId The ID of the registered IP.
     /// @return tokenId The ID of the newly minted NFT.
     function mintAndRegisterIp(
         address spgNftContract,
         address recipient,
-        WorkflowStructs.IPMetadata calldata ipMetadata
+        WorkflowStructs.IPMetadata calldata ipMetadata,
+        bool dedup
     ) external returns (address ipId, uint256 tokenId);
 
     /// @notice Registers an NFT as IP with metadata.

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -14,6 +14,18 @@ library Errors {
     /// @notice Zero address provided as a param to the RegistrationWorkflows.
     error RegistrationWorkflows__ZeroAddressParam();
 
+    /// @notice Error thrown when attempting to mint an NFT with a metadata hash that already exists.
+    /// @param spgNftContract The address of the SPGNFT collection contract where the duplicate was detected.
+    /// @param tokenId The ID of the original NFT that was first minted with this metadata hash.
+    /// @param ipId The identifier of the registered IP associated with this NFT.
+    /// @param nftMetadataHash The hash of the NFT metadata that caused the duplication error.
+    error RegistrationWorkflows__DuplicatedNFTMetadataHash(
+        address spgNftContract,
+        uint256 tokenId,
+        address ipId,
+        bytes32 nftMetadataHash
+    );
+
     ////////////////////////////////////////////////////////////////////////////
     //                         LicenseAttachmentWorkflows                     //
     ////////////////////////////////////////////////////////////////////////////

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -21,6 +21,18 @@ library Errors {
     /// @notice Zero address provided as a param to the LicenseAttachmentWorkflows.
     error LicenseAttachmentWorkflows__ZeroAddressParam();
 
+    /// @notice Duplicated NFT metadata hash.
+    /// @param spgNftContract The address of the SPGNFT collection.
+    /// @param tokenId The ID of the NFT.
+    /// @param ipId The ID of the registered IP.
+    /// @param nftMetadataHash The duplicated NFT metadata hash.
+    error LicenseAttachmentWorkflows__DuplicatedNFTMetadataHash(
+        address spgNftContract,
+        uint256 tokenId,
+        address ipId,
+        bytes32 nftMetadataHash
+    );
+
     ////////////////////////////////////////////////////////////////////////////
     //                         DerivativeWorkflows                            //
     ////////////////////////////////////////////////////////////////////////////
@@ -34,12 +46,36 @@ library Errors {
     /// @notice Caller is not the owner of the license token.
     error DerivativeWorkflows__CallerAndNotTokenOwner(uint256 tokenId, address caller, address actualTokenOwner);
 
+    /// @notice Duplicated NFT metadata hash.
+    /// @param spgNftContract The address of the SPGNFT collection.
+    /// @param tokenId The ID of the NFT.
+    /// @param ipId The ID of the registered IP.
+    /// @param nftMetadataHash The duplicated NFT metadata hash.
+    error DerivativeWorkflows__DuplicatedNFTMetadataHash(
+        address spgNftContract,
+        uint256 tokenId,
+        address ipId,
+        bytes32 nftMetadataHash
+    );
+
     ////////////////////////////////////////////////////////////////////////////
     //                             Grouping Workflows                         //
     ////////////////////////////////////////////////////////////////////////////
 
     /// @notice Zero address provided as a param to the GroupingWorkflows.
     error GroupingWorkflows__ZeroAddressParam();
+
+    /// @notice Duplicated NFT metadata hash.
+    /// @param spgNftContract The address of the SPGNFT collection.
+    /// @param tokenId The ID of the NFT.
+    /// @param ipId The ID of the registered IP.
+    /// @param nftMetadataHash The duplicated NFT metadata hash.
+    error GroupingWorkflows__DuplicatedNFTMetadataHash(
+        address spgNftContract,
+        uint256 tokenId,
+        address ipId,
+        bytes32 nftMetadataHash
+    );
 
     ////////////////////////////////////////////////////////////////////////////
     //                              Royalty Workflows                         //

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -21,11 +21,11 @@ library Errors {
     /// @notice Zero address provided as a param to the LicenseAttachmentWorkflows.
     error LicenseAttachmentWorkflows__ZeroAddressParam();
 
-    /// @notice Duplicated NFT metadata hash.
-    /// @param spgNftContract The address of the SPGNFT collection.
-    /// @param tokenId The ID of the NFT.
-    /// @param ipId The ID of the registered IP.
-    /// @param nftMetadataHash The duplicated NFT metadata hash.
+    /// @notice Error thrown when attempting to mint an NFT with a metadata hash that already exists.
+    /// @param spgNftContract The address of the SPGNFT collection contract where the duplicate was detected.
+    /// @param tokenId The ID of the original NFT that was first minted with this metadata hash.
+    /// @param ipId The identifier of the registered IP associated with this NFT.
+    /// @param nftMetadataHash The hash of the NFT metadata that caused the duplication error.
     error LicenseAttachmentWorkflows__DuplicatedNFTMetadataHash(
         address spgNftContract,
         uint256 tokenId,
@@ -46,11 +46,11 @@ library Errors {
     /// @notice Caller is not the owner of the license token.
     error DerivativeWorkflows__CallerAndNotTokenOwner(uint256 tokenId, address caller, address actualTokenOwner);
 
-    /// @notice Duplicated NFT metadata hash.
-    /// @param spgNftContract The address of the SPGNFT collection.
-    /// @param tokenId The ID of the NFT.
-    /// @param ipId The ID of the registered IP.
-    /// @param nftMetadataHash The duplicated NFT metadata hash.
+    /// @notice Error thrown when attempting to mint an NFT with a metadata hash that already exists.
+    /// @param spgNftContract The address of the SPGNFT collection contract where the duplicate was detected.
+    /// @param tokenId The ID of the original NFT that was first minted with this metadata hash.
+    /// @param ipId The identifier of the registered IP associated with this NFT.
+    /// @param nftMetadataHash The hash of the NFT metadata that caused the duplication error.
     error DerivativeWorkflows__DuplicatedNFTMetadataHash(
         address spgNftContract,
         uint256 tokenId,
@@ -65,11 +65,11 @@ library Errors {
     /// @notice Zero address provided as a param to the GroupingWorkflows.
     error GroupingWorkflows__ZeroAddressParam();
 
-    /// @notice Duplicated NFT metadata hash.
-    /// @param spgNftContract The address of the SPGNFT collection.
-    /// @param tokenId The ID of the NFT.
-    /// @param ipId The ID of the registered IP.
-    /// @param nftMetadataHash The duplicated NFT metadata hash.
+    /// @notice Error thrown when attempting to mint an NFT with a metadata hash that already exists.
+    /// @param spgNftContract The address of the SPGNFT collection contract where the duplicate was detected.
+    /// @param tokenId The ID of the original NFT that was first minted with this metadata hash.
+    /// @param ipId The identifier of the registered IP associated with this NFT.
+    /// @param nftMetadataHash The hash of the NFT metadata that caused the duplication error.
     error GroupingWorkflows__DuplicatedNFTMetadataHash(
         address spgNftContract,
         uint256 tokenId,

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -14,36 +14,12 @@ library Errors {
     /// @notice Zero address provided as a param to the RegistrationWorkflows.
     error RegistrationWorkflows__ZeroAddressParam();
 
-    /// @notice Error thrown when attempting to mint an NFT with a metadata hash that already exists.
-    /// @param spgNftContract The address of the SPGNFT collection contract where the duplicate was detected.
-    /// @param tokenId The ID of the original NFT that was first minted with this metadata hash.
-    /// @param ipId The identifier of the registered IP associated with this NFT.
-    /// @param nftMetadataHash The hash of the NFT metadata that caused the duplication error.
-    error RegistrationWorkflows__DuplicatedNFTMetadataHash(
-        address spgNftContract,
-        uint256 tokenId,
-        address ipId,
-        bytes32 nftMetadataHash
-    );
-
     ////////////////////////////////////////////////////////////////////////////
     //                         LicenseAttachmentWorkflows                     //
     ////////////////////////////////////////////////////////////////////////////
 
     /// @notice Zero address provided as a param to the LicenseAttachmentWorkflows.
     error LicenseAttachmentWorkflows__ZeroAddressParam();
-
-    /// @notice Error thrown when attempting to mint an NFT with a metadata hash that already exists.
-    /// @param spgNftContract The address of the SPGNFT collection contract where the duplicate was detected.
-    /// @param tokenId The ID of the original NFT that was first minted with this metadata hash.
-    /// @param ipId The identifier of the registered IP associated with this NFT.
-    /// @param nftMetadataHash The hash of the NFT metadata that caused the duplication error.
-    error LicenseAttachmentWorkflows__DuplicatedNFTMetadataHash(
-        address spgNftContract,
-        uint256 tokenId,
-        address ipId,
-        bytes32 nftMetadataHash
-    );
 
     ////////////////////////////////////////////////////////////////////////////
     //                         DerivativeWorkflows                            //
@@ -58,36 +34,12 @@ library Errors {
     /// @notice Caller is not the owner of the license token.
     error DerivativeWorkflows__CallerAndNotTokenOwner(uint256 tokenId, address caller, address actualTokenOwner);
 
-    /// @notice Error thrown when attempting to mint an NFT with a metadata hash that already exists.
-    /// @param spgNftContract The address of the SPGNFT collection contract where the duplicate was detected.
-    /// @param tokenId The ID of the original NFT that was first minted with this metadata hash.
-    /// @param ipId The identifier of the registered IP associated with this NFT.
-    /// @param nftMetadataHash The hash of the NFT metadata that caused the duplication error.
-    error DerivativeWorkflows__DuplicatedNFTMetadataHash(
-        address spgNftContract,
-        uint256 tokenId,
-        address ipId,
-        bytes32 nftMetadataHash
-    );
-
     ////////////////////////////////////////////////////////////////////////////
     //                             Grouping Workflows                         //
     ////////////////////////////////////////////////////////////////////////////
 
     /// @notice Zero address provided as a param to the GroupingWorkflows.
     error GroupingWorkflows__ZeroAddressParam();
-
-    /// @notice Error thrown when attempting to mint an NFT with a metadata hash that already exists.
-    /// @param spgNftContract The address of the SPGNFT collection contract where the duplicate was detected.
-    /// @param tokenId The ID of the original NFT that was first minted with this metadata hash.
-    /// @param ipId The identifier of the registered IP associated with this NFT.
-    /// @param nftMetadataHash The hash of the NFT metadata that caused the duplication error.
-    error GroupingWorkflows__DuplicatedNFTMetadataHash(
-        address spgNftContract,
-        uint256 tokenId,
-        address ipId,
-        bytes32 nftMetadataHash
-    );
 
     ////////////////////////////////////////////////////////////////////////////
     //                              Royalty Workflows                         //
@@ -119,4 +71,10 @@ library Errors {
 
     /// @notice Caller is not one of the periphery contracts.
     error SPGNFT__CallerNotPeripheryContract();
+
+    /// @notice Error thrown when attempting to mint an NFT with a metadata hash that already exists.
+    /// @param spgNftContract The address of the SPGNFT collection contract where the duplicate was detected.
+    /// @param tokenId The ID of the original NFT that was first minted with this metadata hash.
+    /// @param nftMetadataHash The hash of the NFT metadata that caused the duplication error.
+    error SPGNFT__DuplicatedNFTMetadataHash(address spgNftContract, uint256 tokenId, bytes32 nftMetadataHash);
 }

--- a/contracts/workflows/GroupingWorkflows.sol
+++ b/contracts/workflows/GroupingWorkflows.sol
@@ -120,6 +120,7 @@ contract GroupingWorkflows is
     /// @param licenseTermsId The ID of the registered license terms that will be attached to the new IP.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
     /// @param sigAddToGroup Signature data for addIp to the group IP via the Grouping Module.
+    /// @param dedup Set to true to enable checking for duplicate metadata hashes in the SPGNFT collection.
     /// @return ipId The ID of the newly registered IP.
     /// @return tokenId The ID of the newly minted NFT.
     function mintAndRegisterIpAndAttachLicenseAndAddToGroup(
@@ -129,13 +130,26 @@ contract GroupingWorkflows is
         address licenseTemplate,
         uint256 licenseTermsId,
         WorkflowStructs.IPMetadata calldata ipMetadata,
-        WorkflowStructs.SignatureData calldata sigAddToGroup
+        WorkflowStructs.SignatureData calldata sigAddToGroup,
+        bool dedup
     ) external onlyMintAuthorized(spgNftContract) returns (address ipId, uint256 tokenId) {
-        tokenId = ISPGNFT(spgNftContract).mintByPeriphery({
+        bool deduped;
+        (tokenId, deduped) = ISPGNFT(spgNftContract).mintByPeriphery({
             to: address(this),
             payer: msg.sender,
-            nftMetadataURI: ipMetadata.nftMetadataURI
+            nftMetadataURI: ipMetadata.nftMetadataURI,
+            nftMetadataHash: ipMetadata.nftMetadataHash,
+            dedup: dedup
         });
+
+        if (deduped)
+            revert Errors.GroupingWorkflows__DuplicatedNFTMetadataHash(
+                spgNftContract,
+                tokenId,
+                _getIpId(spgNftContract, tokenId),
+                ipMetadata.nftMetadataHash
+            );
+
         ipId = IP_ASSET_REGISTRY.register(block.chainid, spgNftContract, tokenId);
         MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);
 

--- a/contracts/workflows/RegistrationWorkflows.sol
+++ b/contracts/workflows/RegistrationWorkflows.sol
@@ -125,8 +125,7 @@ contract RegistrationWorkflows is
             dedup: dedup
         });
 
-        if (deduped)
-            return (_getIpId(spgNftContract, tokenId), tokenId);
+        if (deduped) return (_getIpId(spgNftContract, tokenId), tokenId);
 
         ipId = IP_ASSET_REGISTRY.register(block.chainid, spgNftContract, tokenId);
         MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);

--- a/contracts/workflows/RegistrationWorkflows.sol
+++ b/contracts/workflows/RegistrationWorkflows.sol
@@ -107,31 +107,22 @@ contract RegistrationWorkflows is
     /// @param spgNftContract The address of the SPGNFT collection.
     /// @param recipient The address of the recipient of the minted NFT.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
-    /// @param dedup Set to true to enable checking for duplicate metadata hashes in the SPGNFT collection.
+    /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
     /// @return ipId The ID of the registered IP.
     /// @return tokenId The ID of the newly minted NFT.
     function mintAndRegisterIp(
         address spgNftContract,
         address recipient,
         WorkflowStructs.IPMetadata calldata ipMetadata,
-        bool dedup
+        bool allowDuplicates
     ) external onlyMintAuthorized(spgNftContract) returns (address ipId, uint256 tokenId) {
-        bool deduped;
-        (tokenId, deduped) = ISPGNFT(spgNftContract).mintByPeriphery({
+        tokenId = ISPGNFT(spgNftContract).mintByPeriphery({
             to: address(this),
             payer: msg.sender,
             nftMetadataURI: ipMetadata.nftMetadataURI,
             nftMetadataHash: ipMetadata.nftMetadataHash,
-            dedup: dedup
+            allowDuplicates: allowDuplicates
         });
-
-        if (deduped)
-            revert Errors.RegistrationWorkflows__DuplicatedNFTMetadataHash({
-                spgNftContract: spgNftContract,
-                tokenId: tokenId,
-                ipId: _getIpId(spgNftContract, tokenId),
-                nftMetadataHash: ipMetadata.nftMetadataHash
-            });
 
         ipId = IP_ASSET_REGISTRY.register(block.chainid, spgNftContract, tokenId);
         MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);

--- a/contracts/workflows/RegistrationWorkflows.sol
+++ b/contracts/workflows/RegistrationWorkflows.sol
@@ -125,7 +125,13 @@ contract RegistrationWorkflows is
             dedup: dedup
         });
 
-        if (deduped) return (_getIpId(spgNftContract, tokenId), tokenId);
+        if (deduped)
+            revert Errors.RegistrationWorkflows__DuplicatedNFTMetadataHash({
+                spgNftContract: spgNftContract,
+                tokenId: tokenId,
+                ipId: _getIpId(spgNftContract, tokenId),
+                nftMetadataHash: ipMetadata.nftMetadataHash
+            });
 
         ipId = IP_ASSET_REGISTRY.register(block.chainid, spgNftContract, tokenId);
         MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);

--- a/test/SPGNFT.t.sol
+++ b/test/SPGNFT.t.sol
@@ -138,8 +138,14 @@ contract SPGNFTTest is BaseTest {
         uint256 mintFee = nftContract.mintFee();
         uint256 balanceBeforeAlice = mockToken.balanceOf(u.alice);
         uint256 balanceBeforeContract = mockToken.balanceOf(address(nftContract));
-        uint256 tokenId = nftContract.mint(u.bob, ipMetadataEmpty.nftMetadataURI);
+        (uint256 tokenId, bool deduped) = nftContract.mint(
+            u.bob,
+            ipMetadataEmpty.nftMetadataURI,
+            ipMetadataEmpty.nftMetadataHash,
+            false
+        );
 
+        assertTrue(!deduped);
         assertEq(nftContract.totalSupply(), 1);
         assertEq(nftContract.balanceOf(u.bob), 1);
         assertEq(nftContract.ownerOf(tokenId), u.bob);
@@ -149,7 +155,14 @@ contract SPGNFTTest is BaseTest {
         balanceBeforeAlice = mockToken.balanceOf(u.alice);
         balanceBeforeContract = mockToken.balanceOf(address(nftContract));
 
-        tokenId = nftContract.mint(u.bob, ipMetadataDefault.nftMetadataURI);
+        (tokenId, deduped) = nftContract.mint(
+            u.bob,
+            ipMetadataDefault.nftMetadataURI,
+            ipMetadataDefault.nftMetadataHash,
+            true
+        );
+        assertTrue(!deduped);
+        assertEq(nftContract.getTokenIdByMetadataHash(ipMetadataDefault.nftMetadataHash), tokenId);
         assertEq(nftContract.totalSupply(), 2);
         assertEq(nftContract.balanceOf(u.bob), 2);
         assertEq(nftContract.ownerOf(tokenId), u.bob);
@@ -163,13 +176,44 @@ contract SPGNFTTest is BaseTest {
         nftContract.setMintFee(200 * 10 ** mockToken.decimals());
         mintFee = nftContract.mintFee();
 
-        tokenId = nftContract.mint(u.carl, ipMetadataDefault.nftMetadataURI);
+        (tokenId, deduped) = nftContract.mint(
+            u.carl,
+            ipMetadataDefault.nftMetadataURI,
+            ipMetadataDefault.nftMetadataHash,
+            false
+        );
+        assertTrue(!deduped);
+        assertEq(tokenId, 3);
+        assertEq(nftContract.getTokenIdByMetadataHash(ipMetadataDefault.nftMetadataHash), 2);
         assertEq(mockToken.balanceOf(address(nftContract)), 400 * 10 ** mockToken.decimals());
         assertEq(nftContract.totalSupply(), 3);
         assertEq(nftContract.balanceOf(u.carl), 1);
         assertEq(nftContract.ownerOf(tokenId), u.carl);
         assertEq(mockToken.balanceOf(u.alice), balanceBeforeAlice - mintFee);
         assertEq(mockToken.balanceOf(address(nftContract)), balanceBeforeContract + mintFee);
+        assertEq(nftContract.tokenURI(tokenId), string.concat(testBaseURI, ipMetadataDefault.nftMetadataURI));
+
+
+        balanceBeforeAlice = mockToken.balanceOf(u.alice);
+        balanceBeforeContract = mockToken.balanceOf(address(nftContract));
+
+        // turn on dedup
+        (tokenId, deduped) = nftContract.mint(
+            u.carl,
+            ipMetadataDefault.nftMetadataURI,
+            ipMetadataDefault.nftMetadataHash,
+            true
+        );
+        assertTrue(deduped);
+        // deduped, so no state change happened
+        assertEq(tokenId, 2);
+        assertEq(nftContract.getTokenIdByMetadataHash(ipMetadataDefault.nftMetadataHash), tokenId);
+        assertEq(mockToken.balanceOf(address(nftContract)), 400 * 10 ** mockToken.decimals());
+        assertEq(nftContract.totalSupply(), 3);
+        assertEq(nftContract.balanceOf(u.carl), 1);
+        assertEq(nftContract.ownerOf(tokenId), u.bob);
+        assertEq(mockToken.balanceOf(u.alice), balanceBeforeAlice);
+        assertEq(mockToken.balanceOf(address(nftContract)), balanceBeforeContract);
         assertEq(nftContract.tokenURI(tokenId), string.concat(testBaseURI, ipMetadataDefault.nftMetadataURI));
 
         vm.stopPrank();
@@ -182,19 +226,34 @@ contract SPGNFTTest is BaseTest {
 
         // non empty baseURI
         assertEq(nftContract.baseURI(), testBaseURI);
-        uint256 tokenId1 = nftContract.mint(u.alice, ipMetadataDefault.nftMetadataURI);
+        (uint256 tokenId1,) = nftContract.mint(
+            u.alice,
+            ipMetadataDefault.nftMetadataURI,
+            ipMetadataDefault.nftMetadataHash,
+            false
+        );
         assertEq(nftContract.tokenURI(tokenId1), string.concat(testBaseURI, ipMetadataDefault.nftMetadataURI));
 
         nftContract.setBaseURI("test");
         assertEq(nftContract.baseURI(), "test");
-        uint256 tokenId2 = nftContract.mint(u.alice, ipMetadataEmpty.nftMetadataURI);
+        (uint256 tokenId2,) = nftContract.mint(
+            u.alice,
+            ipMetadataEmpty.nftMetadataURI,
+            ipMetadataEmpty.nftMetadataHash,
+            false
+        );
         assertEq(nftContract.tokenURI(tokenId1), string.concat("test", ipMetadataDefault.nftMetadataURI));
         assertEq(nftContract.tokenURI(tokenId2), string.concat("test", tokenId2.toString()));
 
         // empty baseURI
         nftContract.setBaseURI("");
         assertEq(nftContract.baseURI(), "");
-        uint256 tokenId3 = nftContract.mint(u.alice, ipMetadataDefault.nftMetadataURI);
+        (uint256 tokenId3,) = nftContract.mint(
+            u.alice,
+            ipMetadataDefault.nftMetadataURI,
+            ipMetadataDefault.nftMetadataHash,
+            false
+        );
         assertEq(nftContract.tokenURI(tokenId1), ipMetadataDefault.nftMetadataURI);
         assertEq(nftContract.tokenURI(tokenId2), ipMetadataEmpty.nftMetadataURI);
         assertEq(nftContract.tokenURI(tokenId3), ipMetadataDefault.nftMetadataURI);
@@ -222,7 +281,7 @@ contract SPGNFTTest is BaseTest {
             abi.encodeWithSelector(IERC20Errors.ERC20InsufficientAllowance.selector, address(nftContract), 0, mintFee)
         );
         vm.prank(u.alice);
-        nftContract.mint(u.bob, ipMetadataDefault.nftMetadataURI);
+        nftContract.mint(u.bob, ipMetadataDefault.nftMetadataURI, ipMetadataDefault.nftMetadataHash, false);
     }
 
     function test_SPGNFT_revert_mint_erc20InsufficientBalance() public {
@@ -237,7 +296,7 @@ contract SPGNFTTest is BaseTest {
                 nftContract.mintFee()
             )
         );
-        nftContract.mint(u.bob, ipMetadataDefault.nftMetadataURI);
+        nftContract.mint(u.bob, ipMetadataDefault.nftMetadataURI, ipMetadataDefault.nftMetadataHash, false);
         vm.stopPrank();
     }
 
@@ -291,7 +350,7 @@ contract SPGNFTTest is BaseTest {
 
         uint256 mintFee = nftContract.mintFee();
 
-        nftContract.mint(feeRecipient, ipMetadataDefault.nftMetadataURI);
+        nftContract.mint(feeRecipient, ipMetadataDefault.nftMetadataURI, ipMetadataDefault.nftMetadataHash, false);
 
         assertEq(mockToken.balanceOf(address(nftContract)), mintFee);
 

--- a/test/SPGNFT.t.sol
+++ b/test/SPGNFT.t.sol
@@ -193,7 +193,6 @@ contract SPGNFTTest is BaseTest {
         assertEq(mockToken.balanceOf(address(nftContract)), balanceBeforeContract + mintFee);
         assertEq(nftContract.tokenURI(tokenId), string.concat(testBaseURI, ipMetadataDefault.nftMetadataURI));
 
-
         balanceBeforeAlice = mockToken.balanceOf(u.alice);
         balanceBeforeContract = mockToken.balanceOf(address(nftContract));
 
@@ -226,7 +225,7 @@ contract SPGNFTTest is BaseTest {
 
         // non empty baseURI
         assertEq(nftContract.baseURI(), testBaseURI);
-        (uint256 tokenId1,) = nftContract.mint(
+        (uint256 tokenId1, ) = nftContract.mint(
             u.alice,
             ipMetadataDefault.nftMetadataURI,
             ipMetadataDefault.nftMetadataHash,
@@ -236,7 +235,7 @@ contract SPGNFTTest is BaseTest {
 
         nftContract.setBaseURI("test");
         assertEq(nftContract.baseURI(), "test");
-        (uint256 tokenId2,) = nftContract.mint(
+        (uint256 tokenId2, ) = nftContract.mint(
             u.alice,
             ipMetadataEmpty.nftMetadataURI,
             ipMetadataEmpty.nftMetadataHash,
@@ -248,7 +247,7 @@ contract SPGNFTTest is BaseTest {
         // empty baseURI
         nftContract.setBaseURI("");
         assertEq(nftContract.baseURI(), "");
-        (uint256 tokenId3,) = nftContract.mint(
+        (uint256 tokenId3, ) = nftContract.mint(
             u.alice,
             ipMetadataDefault.nftMetadataURI,
             ipMetadataDefault.nftMetadataHash,

--- a/test/integration/workflows/DerivativeIntegration.t.sol
+++ b/test/integration/workflows/DerivativeIntegration.t.sol
@@ -56,7 +56,7 @@ contract DerivativeIntegration is BaseIntegration {
             }),
             ipMetadata: testIpMetadata,
             recipient: testSender,
-            dedup: false
+            allowDuplicates: true
         });
 
         assertTrue(ipAssetRegistry.isRegistered(childIpId));
@@ -85,12 +85,12 @@ contract DerivativeIntegration is BaseIntegration {
         StoryUSD.mint(testSender, testMintFee);
         StoryUSD.approve(address(spgNftContract), testMintFee); // for nft minting fee
 
-        (uint256 childTokenId, ) = spgNftContract.mint(
-            testSender,
-            testIpMetadata.nftMetadataURI,
-            testIpMetadata.nftMetadataHash,
-            false
-        );
+        uint256 childTokenId = spgNftContract.mint({
+            to: testSender,
+            nftMetadataURI: testIpMetadata.nftMetadataURI,
+            nftMetadataHash: testIpMetadata.nftMetadataHash,
+            allowDuplicates: true
+        });
         address childIpId = ipAssetRegistry.ipId(block.chainid, address(spgNftContract), childTokenId);
 
         uint256 deadline = block.timestamp + 1000;
@@ -190,7 +190,7 @@ contract DerivativeIntegration is BaseIntegration {
                 royaltyContext: "",
                 ipMetadata: testIpMetadata,
                 recipient: testSender,
-                dedup: false
+                allowDuplicates: true
             });
 
         assertTrue(ipAssetRegistry.isRegistered(childIpId));
@@ -219,12 +219,12 @@ contract DerivativeIntegration is BaseIntegration {
     {
         StoryUSD.mint(testSender, testMintFee);
         StoryUSD.approve(address(spgNftContract), testMintFee); // for nft minting fee
-        (uint256 childTokenId, ) = spgNftContract.mint(
-            testSender,
-            testIpMetadata.nftMetadataURI,
-            testIpMetadata.nftMetadataHash,
-            false
-        );
+        uint256 childTokenId = spgNftContract.mint({
+            to: testSender,
+            nftMetadataURI: testIpMetadata.nftMetadataURI,
+            nftMetadataHash: testIpMetadata.nftMetadataHash,
+            allowDuplicates: true
+        });
         address childIpId = ipAssetRegistry.ipId(block.chainid, address(spgNftContract), childTokenId);
 
         uint256 deadline = block.timestamp + 1000;
@@ -383,7 +383,7 @@ contract DerivativeIntegration is BaseIntegration {
                     royaltyPolicy: royaltyPolicyLRPAddr,
                     currencyToken: testMintFeeToken
                 }),
-                dedup: false
+                allowDuplicates: true
             });
 
         parentIpIds = new address[](1);

--- a/test/integration/workflows/DerivativeIntegration.t.sol
+++ b/test/integration/workflows/DerivativeIntegration.t.sol
@@ -85,7 +85,7 @@ contract DerivativeIntegration is BaseIntegration {
         StoryUSD.mint(testSender, testMintFee);
         StoryUSD.approve(address(spgNftContract), testMintFee); // for nft minting fee
 
-        (uint256 childTokenId,) = spgNftContract.mint(
+        (uint256 childTokenId, ) = spgNftContract.mint(
             testSender,
             testIpMetadata.nftMetadataURI,
             testIpMetadata.nftMetadataHash,
@@ -219,7 +219,7 @@ contract DerivativeIntegration is BaseIntegration {
     {
         StoryUSD.mint(testSender, testMintFee);
         StoryUSD.approve(address(spgNftContract), testMintFee); // for nft minting fee
-        (uint256 childTokenId,) = spgNftContract.mint(
+        (uint256 childTokenId, ) = spgNftContract.mint(
             testSender,
             testIpMetadata.nftMetadataURI,
             testIpMetadata.nftMetadataHash,

--- a/test/integration/workflows/DerivativeIntegration.t.sol
+++ b/test/integration/workflows/DerivativeIntegration.t.sol
@@ -55,7 +55,8 @@ contract DerivativeIntegration is BaseIntegration {
                 maxMintingFee: 0
             }),
             ipMetadata: testIpMetadata,
-            recipient: testSender
+            recipient: testSender,
+            dedup: false
         });
 
         assertTrue(ipAssetRegistry.isRegistered(childIpId));
@@ -84,7 +85,12 @@ contract DerivativeIntegration is BaseIntegration {
         StoryUSD.mint(testSender, testMintFee);
         StoryUSD.approve(address(spgNftContract), testMintFee); // for nft minting fee
 
-        uint256 childTokenId = spgNftContract.mint(testSender, testIpMetadata.nftMetadataURI);
+        (uint256 childTokenId,) = spgNftContract.mint(
+            testSender,
+            testIpMetadata.nftMetadataURI,
+            testIpMetadata.nftMetadataHash,
+            false
+        );
         address childIpId = ipAssetRegistry.ipId(block.chainid, address(spgNftContract), childTokenId);
 
         uint256 deadline = block.timestamp + 1000;
@@ -183,7 +189,8 @@ contract DerivativeIntegration is BaseIntegration {
                 licenseTokenIds: licenseTokenIds,
                 royaltyContext: "",
                 ipMetadata: testIpMetadata,
-                recipient: testSender
+                recipient: testSender,
+                dedup: false
             });
 
         assertTrue(ipAssetRegistry.isRegistered(childIpId));
@@ -212,7 +219,12 @@ contract DerivativeIntegration is BaseIntegration {
     {
         StoryUSD.mint(testSender, testMintFee);
         StoryUSD.approve(address(spgNftContract), testMintFee); // for nft minting fee
-        uint256 childTokenId = spgNftContract.mint(testSender, testIpMetadata.nftMetadataURI);
+        (uint256 childTokenId,) = spgNftContract.mint(
+            testSender,
+            testIpMetadata.nftMetadataURI,
+            testIpMetadata.nftMetadataHash,
+            false
+        );
         address childIpId = ipAssetRegistry.ipId(block.chainid, address(spgNftContract), childTokenId);
 
         uint256 deadline = block.timestamp + 1000;
@@ -370,7 +382,8 @@ contract DerivativeIntegration is BaseIntegration {
                     commercialRevShare: 10 * 10 ** 6, // 10%
                     royaltyPolicy: royaltyPolicyLRPAddr,
                     currencyToken: testMintFeeToken
-                })
+                }),
+                dedup: false
             });
 
         parentIpIds = new address[](1);

--- a/test/integration/workflows/GroupingIntegration.t.sol
+++ b/test/integration/workflows/GroupingIntegration.t.sol
@@ -99,7 +99,9 @@ contract GroupingIntegration is BaseIntegration {
     {
         StoryUSD.mint(testSender, testMintFee);
         StoryUSD.approve(address(spgNftContract), testMintFee);
-        (uint256 tokenId,) = spgNftContract.mint(testSender, testIpMetadata.nftMetadataURI,
+        (uint256 tokenId, ) = spgNftContract.mint(
+            testSender,
+            testIpMetadata.nftMetadataURI,
             testIpMetadata.nftMetadataHash,
             false
         );
@@ -373,7 +375,9 @@ contract GroupingIntegration is BaseIntegration {
         // mint a NFT from the spgNftContract
         uint256[] memory tokenIds = new uint256[](numCalls);
         for (uint256 i = 0; i < numCalls; i++) {
-            (tokenIds[i], ) = spgNftContract.mint(testSender, testIpMetadata.nftMetadataURI,
+            (tokenIds[i], ) = spgNftContract.mint(
+                testSender,
+                testIpMetadata.nftMetadataURI,
                 testIpMetadata.nftMetadataHash,
                 false
             );

--- a/test/integration/workflows/GroupingIntegration.t.sol
+++ b/test/integration/workflows/GroupingIntegration.t.sol
@@ -79,7 +79,8 @@ contract GroupingIntegration is BaseIntegration {
                 signer: testSender,
                 deadline: deadline,
                 signature: sigAddToGroup
-            })
+            }),
+            dedup: false
         });
 
         assertEq(IIPAccount(payable(groupId)).state(), expectedState);
@@ -98,7 +99,10 @@ contract GroupingIntegration is BaseIntegration {
     {
         StoryUSD.mint(testSender, testMintFee);
         StoryUSD.approve(address(spgNftContract), testMintFee);
-        uint256 tokenId = spgNftContract.mint(testSender, testIpMetadata.nftMetadataURI);
+        (uint256 tokenId,) = spgNftContract.mint(testSender, testIpMetadata.nftMetadataURI,
+            testIpMetadata.nftMetadataHash,
+            false
+        );
 
         // get the expected IP ID
         address expectedIpId = ipAssetRegistry.ipId(block.chainid, address(spgNftContract), tokenId);
@@ -231,7 +235,8 @@ contract GroupingIntegration is BaseIntegration {
                 maxMintingFee: 0
             }),
             ipMetadata: testIpMetadata,
-            recipient: testSender
+            recipient: testSender,
+            dedup: false
         });
 
         StoryUSD.mint(testSender, testMintFee);
@@ -246,7 +251,8 @@ contract GroupingIntegration is BaseIntegration {
                 maxMintingFee: 0
             }),
             ipMetadata: testIpMetadata,
-            recipient: testSender
+            recipient: testSender,
+            dedup: false
         });
 
         uint256 amount1 = 1_000 * 10 ** StoryUSD.decimals(); // 1,000 tokens
@@ -367,7 +373,10 @@ contract GroupingIntegration is BaseIntegration {
         // mint a NFT from the spgNftContract
         uint256[] memory tokenIds = new uint256[](numCalls);
         for (uint256 i = 0; i < numCalls; i++) {
-            tokenIds[i] = spgNftContract.mint(testSender, testIpMetadata.nftMetadataURI);
+            (tokenIds[i], ) = spgNftContract.mint(testSender, testIpMetadata.nftMetadataURI,
+                testIpMetadata.nftMetadataHash,
+                false
+            );
         }
 
         // get the expected IP ID

--- a/test/integration/workflows/GroupingIntegration.t.sol
+++ b/test/integration/workflows/GroupingIntegration.t.sol
@@ -80,7 +80,7 @@ contract GroupingIntegration is BaseIntegration {
                 deadline: deadline,
                 signature: sigAddToGroup
             }),
-            dedup: false
+            allowDuplicates: true
         });
 
         assertEq(IIPAccount(payable(groupId)).state(), expectedState);
@@ -99,12 +99,12 @@ contract GroupingIntegration is BaseIntegration {
     {
         StoryUSD.mint(testSender, testMintFee);
         StoryUSD.approve(address(spgNftContract), testMintFee);
-        (uint256 tokenId, ) = spgNftContract.mint(
-            testSender,
-            testIpMetadata.nftMetadataURI,
-            testIpMetadata.nftMetadataHash,
-            false
-        );
+        uint256 tokenId = spgNftContract.mint({
+            to: testSender,
+            nftMetadataURI: testIpMetadata.nftMetadataURI,
+            nftMetadataHash: testIpMetadata.nftMetadataHash,
+            allowDuplicates: true
+        });
 
         // get the expected IP ID
         address expectedIpId = ipAssetRegistry.ipId(block.chainid, address(spgNftContract), tokenId);
@@ -238,7 +238,7 @@ contract GroupingIntegration is BaseIntegration {
             }),
             ipMetadata: testIpMetadata,
             recipient: testSender,
-            dedup: false
+            allowDuplicates: true
         });
 
         StoryUSD.mint(testSender, testMintFee);
@@ -254,7 +254,7 @@ contract GroupingIntegration is BaseIntegration {
             }),
             ipMetadata: testIpMetadata,
             recipient: testSender,
-            dedup: false
+            allowDuplicates: true
         });
 
         uint256 amount1 = 1_000 * 10 ** StoryUSD.decimals(); // 1,000 tokens
@@ -375,12 +375,12 @@ contract GroupingIntegration is BaseIntegration {
         // mint a NFT from the spgNftContract
         uint256[] memory tokenIds = new uint256[](numCalls);
         for (uint256 i = 0; i < numCalls; i++) {
-            (tokenIds[i], ) = spgNftContract.mint(
-                testSender,
-                testIpMetadata.nftMetadataURI,
-                testIpMetadata.nftMetadataHash,
-                false
-            );
+            tokenIds[i] = spgNftContract.mint({
+                to: testSender,
+                nftMetadataURI: testIpMetadata.nftMetadataURI,
+                nftMetadataHash: testIpMetadata.nftMetadataHash,
+                allowDuplicates: true
+            });
         }
 
         // get the expected IP ID

--- a/test/integration/workflows/LicenseAttachmentIntegration.t.sol
+++ b/test/integration/workflows/LicenseAttachmentIntegration.t.sol
@@ -45,7 +45,8 @@ contract LicenseAttachmentIntegration is BaseIntegration {
         (address ipId, ) = registrationWorkflows.mintAndRegisterIp({
             spgNftContract: address(spgNftContract),
             recipient: testSender,
-            ipMetadata: testIpMetadata
+            ipMetadata: testIpMetadata,
+            dedup: false
         });
 
         uint256 deadline = block.timestamp + 1000;
@@ -82,7 +83,8 @@ contract LicenseAttachmentIntegration is BaseIntegration {
                     spgNftContract: address(spgNftContract),
                     recipient: testSender,
                     ipMetadata: testIpMetadata,
-                    terms: commUseTerms
+                    terms: commUseTerms,
+                    dedup: false
                 });
             assertTrue(ipAssetRegistry.isRegistered(ipId1));
             assertEq(tokenId1, spgNftContract.totalSupply());
@@ -104,7 +106,8 @@ contract LicenseAttachmentIntegration is BaseIntegration {
                     spgNftContract: address(spgNftContract),
                     recipient: testSender,
                     ipMetadata: testIpMetadata,
-                    terms: commUseTerms
+                    terms: commUseTerms,
+                    dedup: false
                 });
             assertTrue(ipAssetRegistry.isRegistered(ipId2));
             assertEq(tokenId2, spgNftContract.totalSupply());
@@ -124,7 +127,7 @@ contract LicenseAttachmentIntegration is BaseIntegration {
         StoryUSD.mint(testSender, testMintFee);
         StoryUSD.approve(address(spgNftContract), testMintFee);
 
-        uint256 tokenId = spgNftContract.mint(testSender, "");
+        (uint256 tokenId, ) = spgNftContract.mint(testSender, "", bytes32(0), false);
         address expectedIpId = ipAssetRegistry.ipId(block.chainid, address(spgNftContract), tokenId);
 
         uint256 deadline = block.timestamp + 1000;

--- a/test/integration/workflows/LicenseAttachmentIntegration.t.sol
+++ b/test/integration/workflows/LicenseAttachmentIntegration.t.sol
@@ -46,7 +46,7 @@ contract LicenseAttachmentIntegration is BaseIntegration {
             spgNftContract: address(spgNftContract),
             recipient: testSender,
             ipMetadata: testIpMetadata,
-            dedup: false
+            allowDuplicates: true
         });
 
         uint256 deadline = block.timestamp + 1000;
@@ -84,7 +84,7 @@ contract LicenseAttachmentIntegration is BaseIntegration {
                     recipient: testSender,
                     ipMetadata: testIpMetadata,
                     terms: commUseTerms,
-                    dedup: false
+                    allowDuplicates: true
                 });
             assertTrue(ipAssetRegistry.isRegistered(ipId1));
             assertEq(tokenId1, spgNftContract.totalSupply());
@@ -107,7 +107,7 @@ contract LicenseAttachmentIntegration is BaseIntegration {
                     recipient: testSender,
                     ipMetadata: testIpMetadata,
                     terms: commUseTerms,
-                    dedup: false
+                    allowDuplicates: true
                 });
             assertTrue(ipAssetRegistry.isRegistered(ipId2));
             assertEq(tokenId2, spgNftContract.totalSupply());
@@ -127,7 +127,12 @@ contract LicenseAttachmentIntegration is BaseIntegration {
         StoryUSD.mint(testSender, testMintFee);
         StoryUSD.approve(address(spgNftContract), testMintFee);
 
-        (uint256 tokenId, ) = spgNftContract.mint(testSender, "", bytes32(0), false);
+        uint256 tokenId = spgNftContract.mint({
+            to: testSender,
+            nftMetadataURI: "",
+            nftMetadataHash: bytes32(0),
+            allowDuplicates: true
+        });
         address expectedIpId = ipAssetRegistry.ipId(block.chainid, address(spgNftContract), tokenId);
 
         uint256 deadline = block.timestamp + 1000;

--- a/test/integration/workflows/RegistrationIntegration.t.sol
+++ b/test/integration/workflows/RegistrationIntegration.t.sol
@@ -80,7 +80,7 @@ contract RegistrationIntegration is BaseIntegration {
             spgNftContract: address(spgNftContract),
             recipient: testSender,
             ipMetadata: testIpMetadata,
-            dedup: false
+            allowDuplicates: true
         });
 
         assertEq(tokenId, 1);
@@ -92,7 +92,7 @@ contract RegistrationIntegration is BaseIntegration {
     function _test_RegistrationIntegration_registerIp() private logTest("test_RegistrationIntegration_registerIp") {
         StoryUSD.mint(testSender, testMintFee);
         StoryUSD.approve(address(spgNftContract), testMintFee);
-        (uint256 tokenId, ) = spgNftContract.mint(testSender, "", bytes32(0), false);
+        uint256 tokenId = spgNftContract.mint(testSender, "", bytes32(0), true);
 
         // get signature for setting IP metadata
         uint256 deadline = block.timestamp + 1000;

--- a/test/integration/workflows/RegistrationIntegration.t.sol
+++ b/test/integration/workflows/RegistrationIntegration.t.sol
@@ -79,7 +79,8 @@ contract RegistrationIntegration is BaseIntegration {
         (address ipId, uint256 tokenId) = registrationWorkflows.mintAndRegisterIp({
             spgNftContract: address(spgNftContract),
             recipient: testSender,
-            ipMetadata: testIpMetadata
+            ipMetadata: testIpMetadata,
+            dedup: false
         });
 
         assertEq(tokenId, 1);
@@ -91,7 +92,7 @@ contract RegistrationIntegration is BaseIntegration {
     function _test_RegistrationIntegration_registerIp() private logTest("test_RegistrationIntegration_registerIp") {
         StoryUSD.mint(testSender, testMintFee);
         StoryUSD.approve(address(spgNftContract), testMintFee);
-        uint256 tokenId = spgNftContract.mint(testSender, "");
+        (uint256 tokenId, ) = spgNftContract.mint(testSender, "", bytes32(0), false);
 
         // get signature for setting IP metadata
         uint256 deadline = block.timestamp + 1000;

--- a/test/integration/workflows/RoyaltyIntegration.t.sol
+++ b/test/integration/workflows/RoyaltyIntegration.t.sol
@@ -284,11 +284,11 @@ contract RoyaltyIntegration is BaseIntegration {
     /// - `grandChildIp`: It has all 3 license terms attached. It has 3 parents and 1 grandparent IPs.
     /// @param numSnapshots The number of snapshots to take of the ancestor IP's royalty vault.
     function _setupIpGraph(uint256 numSnapshots) private {
-        uint256 ancestorTokenId = spgNftContract.mint(testSender, "");
-        uint256 childTokenIdA = spgNftContract.mint(testSender, "");
-        uint256 childTokenIdB = spgNftContract.mint(testSender, "");
-        uint256 childTokenIdC = spgNftContract.mint(testSender, "");
-        uint256 grandChildTokenId = spgNftContract.mint(testSender, "");
+        (uint256 ancestorTokenId, ) = spgNftContract.mint(testSender, "", bytes32(0), false);
+        (uint256 childTokenIdA, ) = spgNftContract.mint(testSender, "", bytes32(0), false);
+        (uint256 childTokenIdB, ) = spgNftContract.mint(testSender, "", bytes32(0), false);
+        (uint256 childTokenIdC, ) = spgNftContract.mint(testSender, "", bytes32(0), false);
+        (uint256 grandChildTokenId, ) = spgNftContract.mint(testSender, "", bytes32(0), false);
 
         WorkflowStructs.IPMetadata memory emptyIpMetadata = WorkflowStructs.IPMetadata({
             ipMetadataURI: "",

--- a/test/integration/workflows/RoyaltyIntegration.t.sol
+++ b/test/integration/workflows/RoyaltyIntegration.t.sol
@@ -284,11 +284,11 @@ contract RoyaltyIntegration is BaseIntegration {
     /// - `grandChildIp`: It has all 3 license terms attached. It has 3 parents and 1 grandparent IPs.
     /// @param numSnapshots The number of snapshots to take of the ancestor IP's royalty vault.
     function _setupIpGraph(uint256 numSnapshots) private {
-        (uint256 ancestorTokenId, ) = spgNftContract.mint(testSender, "", bytes32(0), false);
-        (uint256 childTokenIdA, ) = spgNftContract.mint(testSender, "", bytes32(0), false);
-        (uint256 childTokenIdB, ) = spgNftContract.mint(testSender, "", bytes32(0), false);
-        (uint256 childTokenIdC, ) = spgNftContract.mint(testSender, "", bytes32(0), false);
-        (uint256 grandChildTokenId, ) = spgNftContract.mint(testSender, "", bytes32(0), false);
+        uint256 ancestorTokenId = spgNftContract.mint(testSender, "", bytes32(0), true);
+        uint256 childTokenIdA = spgNftContract.mint(testSender, "", bytes32(0), true);
+        uint256 childTokenIdB = spgNftContract.mint(testSender, "", bytes32(0), true);
+        uint256 childTokenIdC = spgNftContract.mint(testSender, "", bytes32(0), true);
+        uint256 grandChildTokenId = spgNftContract.mint(testSender, "", bytes32(0), true);
 
         WorkflowStructs.IPMetadata memory emptyIpMetadata = WorkflowStructs.IPMetadata({
             ipMetadataURI: "",

--- a/test/workflows/DerivativeWorkflows.t.sol
+++ b/test/workflows/DerivativeWorkflows.t.sol
@@ -10,6 +10,7 @@ import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensi
 import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
 
 // contracts
+import { Errors } from "../../contracts/lib/Errors.sol";
 import { WorkflowStructs } from "../../contracts/lib/WorkflowStructs.sol";
 
 // test
@@ -29,7 +30,8 @@ contract DerivativeWorkflowsTest is BaseTest {
             spgNftContract: address(nftContract),
             recipient: caller,
             ipMetadata: ipMetadataDefault,
-            terms: PILFlavors.nonCommercialSocialRemixing()
+            terms: PILFlavors.nonCommercialSocialRemixing(),
+            dedup: false
         });
         _;
     }
@@ -44,9 +46,67 @@ contract DerivativeWorkflowsTest is BaseTest {
                 commercialRevShare: 10 * 10 ** 6, // 10%
                 royaltyPolicy: address(royaltyPolicyLAP),
                 currencyToken: address(mockToken)
-            })
+            }),
+            dedup: false
         });
         _;
+    }
+
+    function test_DerivativeWorkflows_revert_DuplicatedNFTMetadataHash() public
+        withCollection
+        whenCallerHasMinterRole
+        withEnoughTokens(address(derivativeWorkflows))
+        withNonCommercialParentIp
+    {
+        // First, create an derivative with the same NFT metadata hash but with dedup turned off
+        (address licenseTemplateParent, uint256 licenseTermsIdParent) = licenseRegistry.getAttachedLicenseTerms(
+            ipIdParent,
+            0
+        );
+
+        address[] memory parentIpIds = new address[](1);
+        parentIpIds[0] = ipIdParent;
+
+        uint256[] memory licenseTermsIds = new uint256[](1);
+        licenseTermsIds[0] = licenseTermsIdParent;
+
+        (address ipIdChild, ) = derivativeWorkflows.mintAndRegisterIpAndMakeDerivative({
+            spgNftContract: address(nftContract),
+            derivData: WorkflowStructs.MakeDerivative({
+                parentIpIds: parentIpIds,
+                licenseTemplate: address(pilTemplate),
+                licenseTermsIds: licenseTermsIds,
+                royaltyContext: "",
+                maxMintingFee: 0
+            }),
+            ipMetadata: ipMetadataDefault,
+            recipient: caller,
+            dedup: false
+        });
+
+        // Now attempt to create another derivative with the same NFT metadata hash but with dedup turned on
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.DerivativeWorkflows__DuplicatedNFTMetadataHash.selector,
+                address(nftContract),
+                1,
+                ipIdParent,
+                ipMetadataDefault.nftMetadataHash
+            )
+        );
+        derivativeWorkflows.mintAndRegisterIpAndMakeDerivative({
+            spgNftContract: address(nftContract),
+            derivData: WorkflowStructs.MakeDerivative({
+                parentIpIds: parentIpIds,
+                licenseTemplate: address(pilTemplate),
+                licenseTermsIds: licenseTermsIds,
+                royaltyContext: "",
+                maxMintingFee: 0
+            }),
+            ipMetadata: ipMetadataDefault,
+            recipient: caller,
+            dedup: true
+        });
     }
 
     function test_DerivativeWorkflows_mintAndRegisterIpAndMakeDerivative_withNonCommercialLicense()
@@ -123,7 +183,8 @@ contract DerivativeWorkflowsTest is BaseTest {
                 licenseTokenIds: licenseTokenIds,
                 royaltyContext: "",
                 ipMetadata: ipMetadataDefault,
-                recipient: caller
+                recipient: caller,
+                dedup: false
             });
         assertTrue(ipAssetRegistry.isRegistered(ipIdChild));
         assertEq(tokenIdChild, 2);
@@ -157,7 +218,9 @@ contract DerivativeWorkflowsTest is BaseTest {
             0
         );
 
-        uint256 tokenIdChild = nftContract.mint(caller, ipMetadataDefault.nftMetadataURI);
+        (uint256 tokenIdChild, ) = nftContract.mint(caller, ipMetadataDefault.nftMetadataURI,
+            ipMetadataDefault.nftMetadataHash,
+            false);
         address ipIdChild = ipAssetRegistry.ipId(block.chainid, address(nftContract), tokenIdChild);
 
         uint256 deadline = block.timestamp + 1000;
@@ -252,7 +315,8 @@ contract DerivativeWorkflowsTest is BaseTest {
                     maxMintingFee: 0
                 }),
                 ipMetadataDefault,
-                caller
+                caller,
+                false
             );
         }
 
@@ -302,7 +366,8 @@ contract DerivativeWorkflowsTest is BaseTest {
                 maxMintingFee: 0
             }),
             ipMetadata: ipMetadataDefault,
-            recipient: caller
+            recipient: caller,
+            dedup: false
         });
         assertTrue(ipAssetRegistry.isRegistered(ipIdChild));
         assertEq(tokenIdChild, 2);
@@ -330,7 +395,9 @@ contract DerivativeWorkflowsTest is BaseTest {
             0
         );
 
-        uint256 tokenIdChild = nftContract.mint(address(caller), ipMetadataDefault.nftMetadataURI);
+        (uint256 tokenIdChild, ) = nftContract.mint(address(caller), ipMetadataDefault.nftMetadataURI,
+            ipMetadataDefault.nftMetadataHash,
+            false);
         address ipIdChild = ipAssetRegistry.ipId(block.chainid, address(nftContract), tokenIdChild);
 
         uint256 deadline = block.timestamp + 1000;

--- a/test/workflows/DerivativeWorkflows.t.sol
+++ b/test/workflows/DerivativeWorkflows.t.sol
@@ -31,7 +31,7 @@ contract DerivativeWorkflowsTest is BaseTest {
             recipient: caller,
             ipMetadata: ipMetadataDefault,
             terms: PILFlavors.nonCommercialSocialRemixing(),
-            dedup: false
+            allowDuplicates: true
         });
         _;
     }
@@ -47,7 +47,7 @@ contract DerivativeWorkflowsTest is BaseTest {
                 royaltyPolicy: address(royaltyPolicyLAP),
                 currencyToken: address(mockToken)
             }),
-            dedup: false
+            allowDuplicates: true
         });
         _;
     }
@@ -82,16 +82,15 @@ contract DerivativeWorkflowsTest is BaseTest {
             }),
             ipMetadata: ipMetadataDefault,
             recipient: caller,
-            dedup: false
+            allowDuplicates: true
         });
 
         // Now attempt to create another derivative with the same NFT metadata hash but with dedup turned on
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.DerivativeWorkflows__DuplicatedNFTMetadataHash.selector,
+                Errors.SPGNFT__DuplicatedNFTMetadataHash.selector,
                 address(nftContract),
                 1,
-                ipIdParent,
                 ipMetadataDefault.nftMetadataHash
             )
         );
@@ -106,7 +105,7 @@ contract DerivativeWorkflowsTest is BaseTest {
             }),
             ipMetadata: ipMetadataDefault,
             recipient: caller,
-            dedup: true
+            allowDuplicates: false
         });
     }
 
@@ -185,7 +184,7 @@ contract DerivativeWorkflowsTest is BaseTest {
                 royaltyContext: "",
                 ipMetadata: ipMetadataDefault,
                 recipient: caller,
-                dedup: false
+                allowDuplicates: true
             });
         assertTrue(ipAssetRegistry.isRegistered(ipIdChild));
         assertEq(tokenIdChild, 2);
@@ -219,12 +218,12 @@ contract DerivativeWorkflowsTest is BaseTest {
             0
         );
 
-        (uint256 tokenIdChild, ) = nftContract.mint(
-            caller,
-            ipMetadataDefault.nftMetadataURI,
-            ipMetadataDefault.nftMetadataHash,
-            false
-        );
+        uint256 tokenIdChild = nftContract.mint({
+            to: caller,
+            nftMetadataURI: ipMetadataDefault.nftMetadataURI,
+            nftMetadataHash: ipMetadataDefault.nftMetadataHash,
+            allowDuplicates: true
+        });
         address ipIdChild = ipAssetRegistry.ipId(block.chainid, address(nftContract), tokenIdChild);
 
         uint256 deadline = block.timestamp + 1000;
@@ -320,7 +319,7 @@ contract DerivativeWorkflowsTest is BaseTest {
                 }),
                 ipMetadataDefault,
                 caller,
-                false
+                true
             );
         }
 
@@ -371,7 +370,7 @@ contract DerivativeWorkflowsTest is BaseTest {
             }),
             ipMetadata: ipMetadataDefault,
             recipient: caller,
-            dedup: false
+            allowDuplicates: true
         });
         assertTrue(ipAssetRegistry.isRegistered(ipIdChild));
         assertEq(tokenIdChild, 2);
@@ -399,12 +398,12 @@ contract DerivativeWorkflowsTest is BaseTest {
             0
         );
 
-        (uint256 tokenIdChild, ) = nftContract.mint(
-            address(caller),
-            ipMetadataDefault.nftMetadataURI,
-            ipMetadataDefault.nftMetadataHash,
-            false
-        );
+        uint256 tokenIdChild = nftContract.mint({
+            to: caller,
+            nftMetadataURI: ipMetadataDefault.nftMetadataURI,
+            nftMetadataHash: ipMetadataDefault.nftMetadataHash,
+            allowDuplicates: true
+        });
         address ipIdChild = ipAssetRegistry.ipId(block.chainid, address(nftContract), tokenIdChild);
 
         uint256 deadline = block.timestamp + 1000;

--- a/test/workflows/DerivativeWorkflows.t.sol
+++ b/test/workflows/DerivativeWorkflows.t.sol
@@ -52,7 +52,8 @@ contract DerivativeWorkflowsTest is BaseTest {
         _;
     }
 
-    function test_DerivativeWorkflows_revert_DuplicatedNFTMetadataHash() public
+    function test_DerivativeWorkflows_revert_DuplicatedNFTMetadataHash()
+        public
         withCollection
         whenCallerHasMinterRole
         withEnoughTokens(address(derivativeWorkflows))
@@ -218,9 +219,12 @@ contract DerivativeWorkflowsTest is BaseTest {
             0
         );
 
-        (uint256 tokenIdChild, ) = nftContract.mint(caller, ipMetadataDefault.nftMetadataURI,
+        (uint256 tokenIdChild, ) = nftContract.mint(
+            caller,
+            ipMetadataDefault.nftMetadataURI,
             ipMetadataDefault.nftMetadataHash,
-            false);
+            false
+        );
         address ipIdChild = ipAssetRegistry.ipId(block.chainid, address(nftContract), tokenIdChild);
 
         uint256 deadline = block.timestamp + 1000;
@@ -395,9 +399,12 @@ contract DerivativeWorkflowsTest is BaseTest {
             0
         );
 
-        (uint256 tokenIdChild, ) = nftContract.mint(address(caller), ipMetadataDefault.nftMetadataURI,
+        (uint256 tokenIdChild, ) = nftContract.mint(
+            address(caller),
+            ipMetadataDefault.nftMetadataURI,
             ipMetadataDefault.nftMetadataHash,
-            false);
+            false
+        );
         address ipIdChild = ipAssetRegistry.ipId(block.chainid, address(nftContract), tokenIdChild);
 
         uint256 deadline = block.timestamp + 1000;

--- a/test/workflows/GroupingWorkflows.t.sol
+++ b/test/workflows/GroupingWorkflows.t.sol
@@ -77,10 +77,9 @@ contract GroupingWorkflowsTest is BaseTest {
         vm.startPrank(minter);
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.GroupingWorkflows__DuplicatedNFTMetadataHash.selector,
+                Errors.SPGNFT__DuplicatedNFTMetadataHash.selector,
                 address(spgNftPublic),
                 1,
-                ipIds[0],
                 ipMetadataDefault.nftMetadataHash
             )
         );
@@ -96,7 +95,7 @@ contract GroupingWorkflowsTest is BaseTest {
                 deadline: deadline,
                 signature: sigAddToGroup
             }),
-            dedup: true
+            allowDuplicates: false
         });
         vm.stopPrank();
     }
@@ -130,7 +129,7 @@ contract GroupingWorkflowsTest is BaseTest {
                 deadline: deadline,
                 signature: sigAddToGroup
             }),
-            dedup: false
+            allowDuplicates: true
         });
         vm.stopPrank();
 
@@ -319,7 +318,7 @@ contract GroupingWorkflowsTest is BaseTest {
             }),
             ipMetadata: ipMetadataDefault,
             recipient: ipOwner1,
-            dedup: false
+            allowDuplicates: true
         });
         vm.stopPrank();
 
@@ -339,7 +338,7 @@ contract GroupingWorkflowsTest is BaseTest {
             }),
             ipMetadata: ipMetadataDefault,
             recipient: ipOwner2,
-            dedup: false
+            allowDuplicates: true
         });
         vm.stopPrank();
 
@@ -443,7 +442,7 @@ contract GroupingWorkflowsTest is BaseTest {
                 testLicenseTermsId,
                 ipMetadataDefault,
                 WorkflowStructs.SignatureData({ signer: groupOwner, deadline: deadline, signature: sigsAddToGroup[i] }),
-                false
+                true
             );
         }
 
@@ -587,7 +586,7 @@ contract GroupingWorkflowsTest is BaseTest {
                 address(spgNftPublic),
                 minter,
                 ipMetadataDefault,
-                false
+                true
             );
         }
 

--- a/test/workflows/LicenseAttachmentWorkflows.t.sol
+++ b/test/workflows/LicenseAttachmentWorkflows.t.sol
@@ -152,9 +152,12 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
         whenCallerHasMinterRole
         withEnoughTokens(address(licenseAttachmentWorkflows))
     {
-        (uint256 tokenId, ) = nftContract.mint(address(caller), ipMetadataEmpty.nftMetadataURI,
+        (uint256 tokenId, ) = nftContract.mint(
+            address(caller),
+            ipMetadataEmpty.nftMetadataURI,
             ipMetadataEmpty.nftMetadataHash,
-            false);
+            false
+        );
         address payable ipId = payable(ipAssetRegistry.ipId(block.chainid, address(nftContract), tokenId));
 
         uint256 deadline = block.timestamp + 1000;

--- a/test/workflows/LicenseAttachmentWorkflows.t.sol
+++ b/test/workflows/LicenseAttachmentWorkflows.t.sol
@@ -11,8 +11,8 @@ import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensi
 import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
 
 // contracts
+import { Errors } from "../../contracts/lib/Errors.sol";
 import { WorkflowStructs } from "../../contracts/lib/WorkflowStructs.sol";
-
 // test
 import { BaseTest } from "../utils/BaseTest.t.sol";
 
@@ -38,11 +38,45 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
         (address ipId, uint256 tokenId) = registrationWorkflows.mintAndRegisterIp({
             spgNftContract: address(nftContract),
             recipient: owner,
-            ipMetadata: ipMetadataDefault
+            ipMetadata: ipMetadataDefault,
+            dedup: false
         });
         ipAsset[1] = IPAsset({ ipId: payable(ipId), tokenId: tokenId, owner: owner });
         vm.stopPrank();
         _;
+    }
+
+    function test_LicenseAttachmentWorkflows_revert_DuplicatedNFTMetadataHash()
+        public
+        withCollection
+        whenCallerHasMinterRole
+        withEnoughTokens(address(licenseAttachmentWorkflows))
+    {
+        (address ipId1, uint256 tokenId1, uint256 licenseTermsId1) = licenseAttachmentWorkflows
+            .mintAndRegisterIpAndAttachPILTerms({
+                spgNftContract: address(nftContract),
+                recipient: caller,
+                ipMetadata: ipMetadataDefault,
+                terms: PILFlavors.nonCommercialSocialRemixing(),
+                dedup: true
+            });
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.LicenseAttachmentWorkflows__DuplicatedNFTMetadataHash.selector,
+                address(nftContract),
+                1,
+                ipId1,
+                ipMetadataDefault.nftMetadataHash
+            )
+        );
+        licenseAttachmentWorkflows.mintAndRegisterIpAndAttachPILTerms({
+            spgNftContract: address(nftContract),
+            recipient: caller,
+            ipMetadata: ipMetadataDefault,
+            terms: PILFlavors.nonCommercialSocialRemixing(),
+            dedup: true
+        });
     }
 
     function test_LicenseAttachmentWorkflows_registerPILTermsAndAttach() public withCollection withIp(u.alice) {
@@ -85,7 +119,8 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
                 spgNftContract: address(nftContract),
                 recipient: caller,
                 ipMetadata: ipMetadataEmpty,
-                terms: PILFlavors.nonCommercialSocialRemixing()
+                terms: PILFlavors.nonCommercialSocialRemixing(),
+                dedup: false
             });
         assertTrue(ipAssetRegistry.isRegistered(ipId1));
         assertEq(tokenId1, 1);
@@ -101,7 +136,8 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
                 spgNftContract: address(nftContract),
                 recipient: caller,
                 ipMetadata: ipMetadataDefault,
-                terms: PILFlavors.nonCommercialSocialRemixing()
+                terms: PILFlavors.nonCommercialSocialRemixing(),
+                dedup: false
             });
         assertTrue(ipAssetRegistry.isRegistered(ipId2));
         assertEq(tokenId2, 2);
@@ -116,7 +152,9 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
         whenCallerHasMinterRole
         withEnoughTokens(address(licenseAttachmentWorkflows))
     {
-        uint256 tokenId = nftContract.mint(address(caller), ipMetadataEmpty.nftMetadataURI);
+        (uint256 tokenId, ) = nftContract.mint(address(caller), ipMetadataEmpty.nftMetadataURI,
+            ipMetadataEmpty.nftMetadataHash,
+            false);
         address payable ipId = payable(ipAssetRegistry.ipId(block.chainid, address(nftContract), tokenId));
 
         uint256 deadline = block.timestamp + 1000;
@@ -214,7 +252,8 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
                 spgNftContract: address(nftContract),
                 recipient: caller,
                 ipMetadata: ipMetadataDefault,
-                terms: PILFlavors.nonCommercialSocialRemixing()
+                terms: PILFlavors.nonCommercialSocialRemixing(),
+                dedup: false
             });
 
         address[] memory parentIpIds = new address[](1);
@@ -233,7 +272,8 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
                 maxMintingFee: 0
             }),
             ipMetadata: ipMetadataDefault,
-            recipient: caller
+            recipient: caller,
+            dedup: false
         });
 
         uint256 deadline = block.timestamp + 1000;

--- a/test/workflows/LicenseAttachmentWorkflows.t.sol
+++ b/test/workflows/LicenseAttachmentWorkflows.t.sol
@@ -39,7 +39,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
             spgNftContract: address(nftContract),
             recipient: owner,
             ipMetadata: ipMetadataDefault,
-            dedup: false
+            allowDuplicates: true
         });
         ipAsset[1] = IPAsset({ ipId: payable(ipId), tokenId: tokenId, owner: owner });
         vm.stopPrank();
@@ -58,15 +58,14 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
                 recipient: caller,
                 ipMetadata: ipMetadataDefault,
                 terms: PILFlavors.nonCommercialSocialRemixing(),
-                dedup: true
+                allowDuplicates: true
             });
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.LicenseAttachmentWorkflows__DuplicatedNFTMetadataHash.selector,
+                Errors.SPGNFT__DuplicatedNFTMetadataHash.selector,
                 address(nftContract),
                 1,
-                ipId1,
                 ipMetadataDefault.nftMetadataHash
             )
         );
@@ -75,7 +74,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
             recipient: caller,
             ipMetadata: ipMetadataDefault,
             terms: PILFlavors.nonCommercialSocialRemixing(),
-            dedup: true
+            allowDuplicates: false
         });
     }
 
@@ -120,7 +119,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
                 recipient: caller,
                 ipMetadata: ipMetadataEmpty,
                 terms: PILFlavors.nonCommercialSocialRemixing(),
-                dedup: false
+                allowDuplicates: true
             });
         assertTrue(ipAssetRegistry.isRegistered(ipId1));
         assertEq(tokenId1, 1);
@@ -137,7 +136,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
                 recipient: caller,
                 ipMetadata: ipMetadataDefault,
                 terms: PILFlavors.nonCommercialSocialRemixing(),
-                dedup: false
+                allowDuplicates: true
             });
         assertTrue(ipAssetRegistry.isRegistered(ipId2));
         assertEq(tokenId2, 2);
@@ -152,12 +151,12 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
         whenCallerHasMinterRole
         withEnoughTokens(address(licenseAttachmentWorkflows))
     {
-        (uint256 tokenId, ) = nftContract.mint(
-            address(caller),
-            ipMetadataEmpty.nftMetadataURI,
-            ipMetadataEmpty.nftMetadataHash,
-            false
-        );
+        uint256 tokenId = nftContract.mint({
+            to: caller,
+            nftMetadataURI: ipMetadataEmpty.nftMetadataURI,
+            nftMetadataHash: ipMetadataEmpty.nftMetadataHash,
+            allowDuplicates: true
+        });
         address payable ipId = payable(ipAssetRegistry.ipId(block.chainid, address(nftContract), tokenId));
 
         uint256 deadline = block.timestamp + 1000;
@@ -256,7 +255,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
                 recipient: caller,
                 ipMetadata: ipMetadataDefault,
                 terms: PILFlavors.nonCommercialSocialRemixing(),
-                dedup: false
+                allowDuplicates: true
             });
 
         address[] memory parentIpIds = new address[](1);
@@ -276,7 +275,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
             }),
             ipMetadata: ipMetadataDefault,
             recipient: caller,
-            dedup: false
+            allowDuplicates: true
         });
 
         uint256 deadline = block.timestamp + 1000;

--- a/test/workflows/RegistrationWorkflows.t.sol
+++ b/test/workflows/RegistrationWorkflows.t.sol
@@ -63,7 +63,7 @@ contract RegistrationWorkflowsTest is BaseTest {
             spgNftContract: address(nftContract),
             recipient: u.bob,
             ipMetadata: ipMetadataEmpty,
-            dedup: false
+            allowDuplicates: true
         });
     }
 
@@ -79,7 +79,7 @@ contract RegistrationWorkflowsTest is BaseTest {
             spgNftContract: address(nftContract),
             recipient: u.bob,
             ipMetadata: ipMetadataDefault,
-            dedup: true
+            allowDuplicates: false
         });
         assertEq(tokenId1, 1);
         assertTrue(ipAssetRegistry.isRegistered(ipId1));
@@ -88,10 +88,9 @@ contract RegistrationWorkflowsTest is BaseTest {
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                Errors.RegistrationWorkflows__DuplicatedNFTMetadataHash.selector,
+                Errors.SPGNFT__DuplicatedNFTMetadataHash.selector,
                 address(nftContract),
                 tokenId1,
-                ipId1,
                 ipMetadataDefault.nftMetadataHash
             )
         );
@@ -99,7 +98,7 @@ contract RegistrationWorkflowsTest is BaseTest {
             spgNftContract: address(nftContract),
             recipient: u.bob,
             ipMetadata: ipMetadataDefault,
-            dedup: true
+            allowDuplicates: false
         });
     }
 
@@ -132,7 +131,7 @@ contract RegistrationWorkflowsTest is BaseTest {
             spgNftContract: address(nftContract),
             recipient: u.bob,
             ipMetadata: ipMetadataEmpty,
-            dedup: false
+            allowDuplicates: true
         });
         vm.stopPrank();
 
@@ -150,7 +149,7 @@ contract RegistrationWorkflowsTest is BaseTest {
             spgNftContract: address(nftContract),
             recipient: u.bob,
             ipMetadata: ipMetadataEmpty,
-            dedup: false
+            allowDuplicates: true
         });
         assertEq(tokenId1, 1);
         assertTrue(ipAssetRegistry.isRegistered(ipId1));
@@ -161,7 +160,7 @@ contract RegistrationWorkflowsTest is BaseTest {
             spgNftContract: address(nftContract),
             recipient: u.bob,
             ipMetadata: ipMetadataDefault,
-            dedup: false
+            allowDuplicates: true
         });
         assertEq(tokenId2, 2);
         assertTrue(ipAssetRegistry.isRegistered(ipId2));
@@ -250,7 +249,7 @@ contract RegistrationWorkflowsTest is BaseTest {
                 address(nftContract),
                 u.bob,
                 ipMetadataDefault,
-                false
+                true
             );
         }
         bytes[] memory results = registrationWorkflows.multicall(data);


### PR DESCRIPTION
## Description
<!-- Add a description of the changes that this PR introduces -->
This PR adds a new deduplication option to the `mint` and `mintByPeriphery` functions in `SPGNFT`, integrating this option into the existing workflow functions that use `SPGNFT`.

## Function Behaviors
- In `SPGNFT`, the`mint` and `mintByPeriphery` functions will check if the dedup parameter is set to true and skip the minting process if the `nftMetadataHash` has already been used. Instead, the function will return the token ID of the original mint associated with that metadata hash.
- In `RegistrationWorkflows`, `DerivativeWorkflows`, `LicenseAttachmentWorkflows`, and `GroupingWorkflows`, attempting to mint with a duplicated `nftMetadataHash` while `dedup` is enabled will throw an error containing information about the IP that was first registered with the metadata hash.
- If the `dedup` flag is set to false, the same `nftMetadataHash` can be reused for minting and registering multiple IPs.

## Test Plan 
<!-- The test plan section indicates detailed steps on how to verify and test code changes. 
You can list the test cases or test steps that need to be performed.-->
Refactored existing tests to include the deduplication parameter. Added new tests to ensure the functions correctly revert when deduplication occurs.

## Related Issue
<!-- The related Issue section can indicate which issue or task the Pull Request is related with -->
- Closes #106 