### PR TITLE
feat(story-nft): implement IP metadata setting during mint

### DIFF
--- a/contracts/interfaces/story-nft/IOrgNFT.sol
+++ b/contracts/interfaces/story-nft/IOrgNFT.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.26;
 
 import { IERC721Metadata } from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
+import { WorkflowStructs } from "../../lib/WorkflowStructs.sol";
 
 /// @title Organization NFT Interface
 /// @notice Each organization token represents a Story ecosystem project.
@@ -46,23 +47,23 @@ interface IOrgNFT is IERC721Metadata {
     ////////////////////////////////////////////////////////////////////////////
     /// @notice Mints the root organization token and register it as an IP.
     /// @param recipient The address of the recipient of the root organization token.
-    /// @param tokenURI The URI of the root organization token.
+    /// @param orgIpMetadata OPTIONAL. The desired metadata for the newly minted OrgNFT and registered IP.
     /// @return rootOrgTokenId The ID of the root organization token.
     /// @return rootOrgIpId The ID of the root organization IP.
     function mintRootOrgNft(
         address recipient,
-        string memory tokenURI
+        WorkflowStructs.IPMetadata calldata orgIpMetadata
     ) external returns (uint256 rootOrgTokenId, address rootOrgIpId);
 
     /// @notice Mints a organization token, register it as an IP,
     /// and makes the IP as a derivative of the root organization IP.
     /// @param recipient The address of the recipient of the minted organization token.
-    /// @param tokenURI The URI of the minted organization token.
+    /// @param orgIpMetadata OPTIONAL. The desired metadata for the newly minted OrgNFT and registered IP.
     /// @return orgTokenId The ID of the minted organization token.
     /// @return orgIpId The ID of the organization IP.
     function mintOrgNft(
         address recipient,
-        string memory tokenURI
+        WorkflowStructs.IPMetadata calldata orgIpMetadata
     ) external returns (uint256 orgTokenId, address orgIpId);
 
     /// @notice Sets the tokenURI of `tokenId` organization token.

--- a/contracts/interfaces/story-nft/IOrgStoryNFTFactory.sol
+++ b/contracts/interfaces/story-nft/IOrgStoryNFTFactory.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.26;
 
 import { IStoryNFT } from "./IStoryNFT.sol";
+import { WorkflowStructs } from "../../lib/WorkflowStructs.sol";
 
 /// @title Organization Story NFT Factory Interface
 /// @notice Organization Story NFT Factory is the entrypoint for creating new Story NFT collections.
@@ -76,7 +77,7 @@ interface IOrgStoryNFTFactory {
     /// @param orgStoryNftTemplate The address of a whitelisted OrgStoryNFT template to be cloned.
     /// @param orgNftRecipient The address of the recipient of the organization NFT.
     /// @param orgName The name of the organization.
-    /// @param orgTokenURI The token URI of the organization NFT.
+    /// @param orgIpMetadata OPTIONAL. The desired metadata for the newly minted OrgNFT and registered IP.
     /// @param signature The signature from the OrgStoryNFTFactory's whitelist signer. This signautre is genreated by
     /// having the whitelist signer sign the caller's address (msg.sender) for this `deployOrgStoryNft` function.
     /// @param storyNftInitParams The initialization parameters for StoryNFT {see {IStoryNFT-StoryNftInitParams}}.
@@ -88,7 +89,7 @@ interface IOrgStoryNFTFactory {
         address orgStoryNftTemplate,
         address orgNftRecipient,
         string calldata orgName,
-        string calldata orgTokenURI,
+        WorkflowStructs.IPMetadata calldata orgIpMetadata,
         bytes calldata signature,
         IStoryNFT.StoryNftInitParams calldata storyNftInitParams
     ) external returns (address orgNft, uint256 orgTokenId, address orgIpId, address orgStoryNft);
@@ -99,7 +100,7 @@ interface IOrgStoryNFTFactory {
     /// @param orgStoryNftTemplate The address of a whitelisted OrgStoryNFT template to be cloned.
     /// @param orgNftRecipient The address of the recipient of the organization NFT.
     /// @param orgName The name of the organization.
-    /// @param orgTokenURI The token URI of the organization NFT.
+    /// @param orgIpMetadata OPTIONAL. The desired metadata for the newly minted OrgNFT and registered IP.
     /// @param storyNftInitParams The initialization parameters for StoryNFT {see {IStoryNFT-StoryNftInitParams}}.
     /// @param isRootOrg Whether the organization is the root organization.
     /// @return orgNft The address of the organization NFT.
@@ -110,7 +111,7 @@ interface IOrgStoryNFTFactory {
         address orgStoryNftTemplate,
         address orgNftRecipient,
         string calldata orgName,
-        string calldata orgTokenURI,
+        WorkflowStructs.IPMetadata calldata orgIpMetadata,
         IStoryNFT.StoryNftInitParams calldata storyNftInitParams,
         bool isRootOrg
     ) external returns (address orgNft, uint256 orgTokenId, address orgIpId, address orgStoryNft);

--- a/contracts/interfaces/story-nft/IStoryBadgeNFT.sol
+++ b/contracts/interfaces/story-nft/IStoryBadgeNFT.sol
@@ -30,9 +30,15 @@ interface IStoryBadgeNFT is IStoryNFT, IERC721Metadata, IERC5192 {
     /// @notice Struct for custom data for initializing the StoryBadgeNFT contract.
     /// @param tokenURI The token URI for all the badges (follows OpenSea metadata standard).
     /// @param signer The signer of the whitelist signatures.
+    /// @param ipMetadataURI The URI of the metadata for all IP from this collection.
+    /// @param ipMetadataHash The hash of the metadata for all IP from this collection.
+    /// @param nftMetadataHash The hash of the metadata for all IP NFTs from this collection.
     struct CustomInitParams {
         string tokenURI;
         address signer;
+        string ipMetadataURI;
+        bytes32 ipMetadataHash;
+        bytes32 nftMetadataHash;
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/contracts/story-nft/BaseOrgStoryNFT.sol
+++ b/contracts/story-nft/BaseOrgStoryNFT.sol
@@ -33,9 +33,10 @@ abstract contract BaseOrgStoryNFT is IOrgStoryNFT, BaseStoryNFT {
     constructor(
         address ipAssetRegistry,
         address licensingModule,
+        address coreMetadataModule,
         address upgradeableBeacon,
         address orgNft
-    ) BaseStoryNFT(ipAssetRegistry, licensingModule) {
+    ) BaseStoryNFT(ipAssetRegistry, licensingModule, coreMetadataModule) {
         if (orgNft == address(0)) revert StoryNFT__ZeroAddressParam();
         ORG_NFT = orgNft;
         UPGRADEABLE_BEACON = upgradeableBeacon;

--- a/contracts/story-nft/OrgStoryNFTFactory.sol
+++ b/contracts/story-nft/OrgStoryNFTFactory.sol
@@ -13,6 +13,7 @@ import { IOrgStoryNFT } from "../interfaces/story-nft/IOrgStoryNFT.sol";
 import { IOrgNFT } from "../interfaces/story-nft/IOrgNFT.sol";
 import { IStoryNFT } from "../interfaces/story-nft/IStoryNFT.sol";
 import { IOrgStoryNFTFactory } from "../interfaces/story-nft/IOrgStoryNFTFactory.sol";
+import { WorkflowStructs } from "../lib/WorkflowStructs.sol";
 
 /// @title Organization Story NFT Factory
 /// @notice Organization Story NFT Factory is the entrypoint for creating new Story NFT collections.
@@ -114,7 +115,7 @@ contract OrgStoryNFTFactory is IOrgStoryNFTFactory, AccessManagedUpgradeable, UU
     /// @param orgStoryNftTemplate The address of a whitelisted OrgStoryNFT template to be cloned.
     /// @param orgNftRecipient The address of the recipient of the organization NFT.
     /// @param orgName The name of the organization.
-    /// @param orgTokenURI The token URI of the organization NFT.
+    /// @param orgIpMetadata OPTIONAL. The desired metadata for the newly minted OrgNFT and registered IP.
     /// @param signature The signature from the OrgStoryNFTFactory's whitelist signer. This signautre is genreated by
     ///  having the whitelist signer sign the caller's address (msg.sender) for this `deployStoryNft` function.
     /// @param storyNftInitParams The initialization data for the OrgStoryNFT (see {IOrgStoryNFT-InitParams}).
@@ -126,7 +127,7 @@ contract OrgStoryNFTFactory is IOrgStoryNFTFactory, AccessManagedUpgradeable, UU
         address orgStoryNftTemplate,
         address orgNftRecipient,
         string calldata orgName,
-        string calldata orgTokenURI,
+        WorkflowStructs.IPMetadata calldata orgIpMetadata,
         bytes calldata signature,
         IStoryNFT.StoryNftInitParams calldata storyNftInitParams
     ) external returns (address orgNft, uint256 orgTokenId, address orgIpId, address orgStoryNft) {
@@ -152,7 +153,7 @@ contract OrgStoryNFTFactory is IOrgStoryNFTFactory, AccessManagedUpgradeable, UU
             revert OrgStoryNFTFactory__InvalidSignature(signature);
 
         // Mint the organization NFT and register it as an IP
-        (orgTokenId, orgIpId) = ORG_NFT.mintOrgNft(orgNftRecipient, orgTokenURI);
+        (orgTokenId, orgIpId) = ORG_NFT.mintOrgNft(orgNftRecipient, orgIpMetadata);
 
         orgNft = address(ORG_NFT);
 
@@ -178,7 +179,7 @@ contract OrgStoryNFTFactory is IOrgStoryNFTFactory, AccessManagedUpgradeable, UU
     /// @param orgStoryNftTemplate The address of a whitelisted OrgStoryNFT template to be cloned.
     /// @param orgNftRecipient The address of the recipient of the organization NFT.
     /// @param orgName The name of the organization.
-    /// @param orgTokenURI The token URI of the organization NFT.
+    /// @param orgIpMetadata OPTIONAL. The desired metadata for the newly minted OrgNFT and registered IP.
     /// @param storyNftInitParams The initialization data for the OrgStoryNFT (see {IOrgStoryNFT-InitParams}).
     /// @param isRootOrg Whether the organization is the root organization.
     /// @return orgNft The address of the organization NFT.
@@ -189,7 +190,7 @@ contract OrgStoryNFTFactory is IOrgStoryNFTFactory, AccessManagedUpgradeable, UU
         address orgStoryNftTemplate,
         address orgNftRecipient,
         string calldata orgName,
-        string calldata orgTokenURI,
+        WorkflowStructs.IPMetadata calldata orgIpMetadata,
         IStoryNFT.StoryNftInitParams calldata storyNftInitParams,
         bool isRootOrg
     ) external restricted returns (address orgNft, uint256 orgTokenId, address orgIpId, address orgStoryNft) {
@@ -205,9 +206,9 @@ contract OrgStoryNFTFactory is IOrgStoryNFTFactory, AccessManagedUpgradeable, UU
 
         // Mint the organization NFT and register it as an IP
         if (isRootOrg) {
-            (orgTokenId, orgIpId) = ORG_NFT.mintRootOrgNft(orgNftRecipient, orgTokenURI);
+            (orgTokenId, orgIpId) = ORG_NFT.mintRootOrgNft(orgNftRecipient, orgIpMetadata);
         } else {
-            (orgTokenId, orgIpId) = ORG_NFT.mintOrgNft(orgNftRecipient, orgTokenURI);
+            (orgTokenId, orgIpId) = ORG_NFT.mintOrgNft(orgNftRecipient, orgIpMetadata);
         }
 
         orgNft = address(ORG_NFT);

--- a/contracts/story-nft/StoryBadgeNFT.sol
+++ b/contracts/story-nft/StoryBadgeNFT.sol
@@ -29,11 +29,17 @@ contract StoryBadgeNFT is IStoryBadgeNFT, BaseOrgStoryNFT, ERC721Holder {
     /// @dev Storage structure for the StoryBadgeNFT
     /// @param signer The signer of the whitelist signatures.
     /// @param tokenURI The unified token URI for all tokens.
+    /// @param ipMetadataURI The URI of the metadata for all IP from this collection.
+    /// @param ipMetadataHash The hash of the metadata for all IP from this collection.
+    /// @param nftMetadataHash The hash of the metadata for all IP NFTs from this collection.
     /// @param usedSignatures Mapping of signatures to booleans indicating whether they have been used.
     /// @custom:storage-location erc7201:story-protocol-periphery.StoryBadgeNFT
     struct StoryBadgeNFTStorage {
         address signer;
         string tokenURI;
+        string ipMetadataURI;
+        bytes32 ipMetadataHash;
+        bytes32 nftMetadataHash;
         mapping(bytes signature => bool used) usedSignatures;
     }
 
@@ -44,11 +50,12 @@ contract StoryBadgeNFT is IStoryBadgeNFT, BaseOrgStoryNFT, ERC721Holder {
     constructor(
         address ipAssetRegistry,
         address licensingModule,
+        address coreMetadataModule,
         address upgradeableBeacon,
         address orgNft,
         address pilTemplate,
         uint256 defaultLicenseTermsId
-    ) BaseOrgStoryNFT(ipAssetRegistry, licensingModule, upgradeableBeacon, orgNft) {
+    ) BaseOrgStoryNFT(ipAssetRegistry, licensingModule, coreMetadataModule, upgradeableBeacon, orgNft) {
         if (
             ipAssetRegistry == address(0) ||
             licensingModule == address(0) ||
@@ -91,7 +98,13 @@ contract StoryBadgeNFT is IStoryBadgeNFT, BaseOrgStoryNFT, ERC721Holder {
             revert StoryBadgeNFT__InvalidSignature();
 
         // Mint the badge and register it as an IP
-        (tokenId, ipId) = _mintAndRegisterIp(address(this), $.tokenURI);
+        (tokenId, ipId) = _mintAndRegisterIp(
+            address(this),
+            $.tokenURI,
+            $.ipMetadataURI,
+            $.ipMetadataHash,
+            $.nftMetadataHash
+        );
 
         address[] memory parentIpIds = new address[](1);
         uint256[] memory licenseTermsIds = new uint256[](1);
@@ -140,6 +153,9 @@ contract StoryBadgeNFT is IStoryBadgeNFT, BaseOrgStoryNFT, ERC721Holder {
         StoryBadgeNFTStorage storage $ = _getStoryBadgeNFTStorage();
         $.tokenURI = customParams.tokenURI;
         $.signer = customParams.signer;
+        $.ipMetadataURI = customParams.ipMetadataURI;
+        $.ipMetadataHash = customParams.ipMetadataHash;
+        $.nftMetadataHash = customParams.nftMetadataHash;
     }
 
     /// @notice Returns the base URI

--- a/script/upgrade/UpdateDefaultOrgStoryNFTTemplate.s.sol
+++ b/script/upgrade/UpdateDefaultOrgStoryNFTTemplate.s.sol
@@ -35,6 +35,7 @@ contract UpdateDefaultOrgStoryNFTTemplate is UpgradeHelper {
         StoryBadgeNFT newDefaultOrgStoryNftTemplate = new StoryBadgeNFT(
             ipAssetRegistryAddr,
             licensingModuleAddr,
+            coreMetadataModuleAddr,
             defaultOrgStoryNftBeaconAddr,
             orgNftAddr,
             pilTemplateAddr,

--- a/script/upgrade/UpgradeOrgNFT.s.sol
+++ b/script/upgrade/UpgradeOrgNFT.s.sol
@@ -33,6 +33,7 @@ contract UpgradeOrgNFT is UpgradeHelper {
         OrgNFT newOrgNft = new OrgNFT(
             ipAssetRegistryAddr,
             licensingModuleAddr,
+            coreMetadataModuleAddr,
             orgStoryNftFactoryAddr,
             pilTemplateAddr,
             LICENSE_TERMS_ID

--- a/script/utils/DeployHelper.sol
+++ b/script/utils/DeployHelper.sol
@@ -202,6 +202,7 @@ contract DeployHelper is
             new OrgNFT(
                 ipAssetRegistryAddr,
                 licensingModuleAddr,
+                coreMetadataModuleAddr,
                 _getDeployedAddress(type(OrgStoryNFTFactory).name),
                 licenseTemplate_,
                 licenseTermsId_
@@ -223,6 +224,7 @@ contract DeployHelper is
         defaultOrgStoryNftTemplate = address(new StoryBadgeNFT(
             ipAssetRegistryAddr,
             licensingModuleAddr,
+            coreMetadataModuleAddr,
             _getDeployedAddress("DefaultOrgStoryNFTBeacon"),
             address(orgNft),
             pilTemplateAddr,

--- a/test/story-nft/OrgNFT.t.sol
+++ b/test/story-nft/OrgNFT.t.sol
@@ -23,6 +23,7 @@ contract OrgNFTTest is BaseTest {
             new OrgNFT({
                 ipAssetRegistry: address(ipAssetRegistry),
                 licensingModule: address(licensingModule),
+                coreMetadataModule: address(coreMetadataModule),
                 orgStoryNftFactory: address(orgStoryNftFactory),
                 licenseTemplate: address(pilTemplate),
                 licenseTermsId: 1
@@ -75,6 +76,7 @@ contract OrgNFTTest is BaseTest {
         OrgNFT testOrgNft = new OrgNFT({
             ipAssetRegistry: address(ipAssetRegistry),
             licensingModule: address(licensingModule),
+            coreMetadataModule: address(coreMetadataModule),
             orgStoryNftFactory: address(orgStoryNftFactory),
             licenseTemplate: address(0),
             licenseTermsId: 1
@@ -84,6 +86,7 @@ contract OrgNFTTest is BaseTest {
             new OrgNFT({
                 ipAssetRegistry: address(ipAssetRegistry),
                 licensingModule: address(licensingModule),
+                coreMetadataModule: address(coreMetadataModule),
                 orgStoryNftFactory: address(orgStoryNftFactory),
                 licenseTemplate: address(pilTemplate),
                 licenseTermsId: 1
@@ -111,7 +114,7 @@ contract OrgNFTTest is BaseTest {
                 address(orgStoryNftFactory)
             )
         );
-        orgNft.mintRootOrgNft(u.bob, "test");
+        orgNft.mintRootOrgNft(u.bob, ipMetadataDefault);
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -120,7 +123,7 @@ contract OrgNFTTest is BaseTest {
                 address(orgStoryNftFactory)
             )
         );
-        orgNft.mintOrgNft(u.bob, "test");
+        orgNft.mintOrgNft(u.bob, ipMetadataDefault);
         vm.stopPrank();
     }
 }

--- a/test/story-nft/OrgStoryNFTFactory.t.sol
+++ b/test/story-nft/OrgStoryNFTFactory.t.sol
@@ -44,7 +44,15 @@ contract OrgStoryNFTFactoryTest is BaseTest {
             symbol: storyNftSymbol,
             contractURI: storyNftContractURI,
             baseURI: storyNftBaseURI,
-            customInitData: abi.encode(IStoryBadgeNFT.CustomInitParams({ tokenURI: storyNftTokenURI, signer: u.carl }))
+            customInitData: abi.encode(
+                IStoryBadgeNFT.CustomInitParams({
+                    tokenURI: storyNftTokenURI,
+                    signer: u.carl,
+                    ipMetadataURI: ipMetadataDefault.ipMetadataURI,
+                    ipMetadataHash: ipMetadataDefault.ipMetadataHash,
+                    nftMetadataHash: ipMetadataDefault.nftMetadataHash
+                })
+            )
         });
     }
 
@@ -90,14 +98,15 @@ contract OrgStoryNFTFactoryTest is BaseTest {
             orgStoryNftTemplate: defaultOrgStoryNftTemplate,
             orgNftRecipient: u.carl,
             orgName: orgName,
-            orgTokenURI: orgTokenURI,
+            orgIpMetadata: ipMetadataDefault,
             signature: _signAddress(orgStoryNftFactorySignerSk, u.carl),
             storyNftInitParams: storyNftInitParams
         });
 
         assertEq(IOrgNFT(orgNft).totalSupply(), totalSupplyBefore + 1);
         assertEq(IOrgNFT(orgNft).ownerOf(orgTokenId), u.carl);
-        assertEq(IOrgNFT(orgNft).tokenURI(orgTokenId), orgTokenURI);
+        assertEq(IOrgNFT(orgNft).tokenURI(orgTokenId), ipMetadataDefault.nftMetadataURI);
+        assertMetadata(orgIpId, ipMetadataDefault);
         assertTrue(ipAssetRegistry.isRegistered(orgIpId));
         assertEq(Ownable(storyNft).owner(), u.carl);
         assertEq(IStoryBadgeNFT(storyNft).name(), storyNftName);
@@ -132,14 +141,15 @@ contract OrgStoryNFTFactoryTest is BaseTest {
                 orgStoryNftTemplate: defaultOrgStoryNftTemplate,
                 orgNftRecipient: u.carl,
                 orgName: orgName,
-                orgTokenURI: orgTokenURI,
+                orgIpMetadata: ipMetadataDefault,
                 storyNftInitParams: storyNftInitParams,
                 isRootOrg: false
             });
 
         assertEq(IOrgNFT(orgNft).totalSupply(), totalSupplyBefore + 1);
         assertEq(IOrgNFT(orgNft).ownerOf(orgTokenId), u.carl);
-        assertEq(IOrgNFT(orgNft).tokenURI(orgTokenId), orgTokenURI);
+        assertEq(IOrgNFT(orgNft).tokenURI(orgTokenId), ipMetadataDefault.nftMetadataURI);
+        assertMetadata(orgIpId, ipMetadataDefault);
         assertTrue(ipAssetRegistry.isRegistered(orgIpId));
         assertEq(Ownable(storyNft).owner(), u.carl);
         assertEq(IStoryBadgeNFT(storyNft).name(), storyNftName);
@@ -186,7 +196,7 @@ contract OrgStoryNFTFactoryTest is BaseTest {
             orgStoryNftTemplate: address(defaultOrgStoryNftTemplate),
             orgNftRecipient: u.carl,
             orgName: orgName,
-            orgTokenURI: orgTokenURI,
+            orgIpMetadata: ipMetadataDefault,
             signature: _signAddress(sk.bob, u.carl),
             storyNftInitParams: storyNftInitParams
         });
@@ -208,7 +218,7 @@ contract OrgStoryNFTFactoryTest is BaseTest {
             orgStoryNftTemplate: defaultOrgStoryNftTemplate,
             orgNftRecipient: u.carl,
             orgName: orgName,
-            orgTokenURI: orgTokenURI,
+            orgIpMetadata: ipMetadataDefault,
             signature: _signAddress(orgStoryNftFactorySignerSk, u.carl),
             storyNftInitParams: storyNftInitParams
         });
@@ -300,7 +310,7 @@ contract OrgStoryNFTFactoryTest is BaseTest {
             orgStoryNftTemplate: address(rootOrgStoryNft),
             orgNftRecipient: u.carl,
             orgName: orgName,
-            orgTokenURI: orgTokenURI,
+            orgIpMetadata: ipMetadataDefault,
             signature: _signAddress(orgStoryNftFactorySignerSk, u.carl),
             storyNftInitParams: storyNftInitParams
         });
@@ -311,7 +321,7 @@ contract OrgStoryNFTFactoryTest is BaseTest {
             orgStoryNftTemplate: address(defaultOrgStoryNftTemplate),
             orgNftRecipient: u.carl,
             orgName: orgName,
-            orgTokenURI: orgTokenURI,
+            orgIpMetadata: ipMetadataDefault,
             signature: signature,
             storyNftInitParams: storyNftInitParams
         });
@@ -322,7 +332,7 @@ contract OrgStoryNFTFactoryTest is BaseTest {
             orgStoryNftTemplate: address(defaultOrgStoryNftTemplate),
             orgNftRecipient: u.carl,
             orgName: orgName,
-            orgTokenURI: orgTokenURI,
+            orgIpMetadata: ipMetadataDefault,
             signature: signature,
             storyNftInitParams: storyNftInitParams
         });
@@ -340,7 +350,7 @@ contract OrgStoryNFTFactoryTest is BaseTest {
             orgStoryNftTemplate: address(defaultOrgStoryNftTemplate),
             orgNftRecipient: u.carl,
             orgName: orgName,
-            orgTokenURI: orgTokenURI,
+            orgIpMetadata: ipMetadataDefault,
             signature: _signAddress(orgStoryNftFactorySignerSk, u.bob),
             storyNftInitParams: storyNftInitParams
         });
@@ -354,7 +364,7 @@ contract OrgStoryNFTFactoryTest is BaseTest {
             orgStoryNftTemplate: address(defaultOrgStoryNftTemplate),
             orgNftRecipient: u.alice,
             orgName: "Alice's Org",
-            orgTokenURI: orgTokenURI,
+            orgIpMetadata: ipMetadataDefault,
             signature: signature,
             storyNftInitParams: storyNftInitParams
         });

--- a/test/story-nft/StoryBadgeNFT.t.sol
+++ b/test/story-nft/StoryBadgeNFT.t.sol
@@ -28,6 +28,7 @@ contract StoryBadgeNFTTest is BaseTest {
             new StoryBadgeNFT({
                 ipAssetRegistry: address(ipAssetRegistry),
                 licensingModule: address(licensingModule),
+                coreMetadataModule: address(coreMetadataModule),
                 upgradeableBeacon: address(defaultOrgStoryNftBeacon),
                 orgNft: address(orgNft),
                 pilTemplate: address(pilTemplate),
@@ -38,7 +39,13 @@ contract StoryBadgeNFTTest is BaseTest {
         string memory tokenURI = "Test Token URI";
 
         bytes memory storyBadgeNftCustomInitParams = abi.encode(
-            IStoryBadgeNFT.CustomInitParams({ tokenURI: tokenURI, signer: rootOrgStoryNftSigner })
+            IStoryBadgeNFT.CustomInitParams({
+                tokenURI: tokenURI,
+                signer: rootOrgStoryNftSigner,
+                ipMetadataURI: ipMetadataDefault.ipMetadataURI,
+                ipMetadataHash: ipMetadataDefault.ipMetadataHash,
+                nftMetadataHash: ipMetadataDefault.nftMetadataHash
+            })
         );
 
         IStoryNFT.StoryNftInitParams memory storyBadgeNftInitParams = IStoryNFT.StoryNftInitParams({
@@ -76,6 +83,7 @@ contract StoryBadgeNFTTest is BaseTest {
         StoryBadgeNFT testStoryBadgeNft = new StoryBadgeNFT(
             address(ipAssetRegistry),
             address(licensingModule),
+            address(coreMetadataModule),
             address(defaultOrgStoryNftBeacon),
             address(0),
             address(pilTemplate),
@@ -86,6 +94,7 @@ contract StoryBadgeNFTTest is BaseTest {
             new StoryBadgeNFT({
                 ipAssetRegistry: address(ipAssetRegistry),
                 licensingModule: address(licensingModule),
+                coreMetadataModule: address(coreMetadataModule),
                 upgradeableBeacon: address(defaultOrgStoryNftBeacon),
                 orgNft: address(orgNft),
                 pilTemplate: address(pilTemplate),
@@ -98,7 +107,10 @@ contract StoryBadgeNFTTest is BaseTest {
         bytes memory storyBadgeNftCustomInitParams = abi.encode(
             IStoryBadgeNFT.CustomInitParams({
                 tokenURI: tokenURI,
-                signer: address(0) // Should revert
+                signer: address(0), // Should revert
+                ipMetadataURI: ipMetadataDefault.ipMetadataURI,
+                ipMetadataHash: ipMetadataDefault.ipMetadataHash,
+                nftMetadataHash: ipMetadataDefault.nftMetadataHash
             })
         );
 
@@ -137,6 +149,7 @@ contract StoryBadgeNFTTest is BaseTest {
         assertEq(rootOrgStoryNft.ownerOf(tokenId), u.carl);
         assertTrue(ipAssetRegistry.isRegistered(ipId));
         assertEq(rootOrgStoryNft.tokenURI(tokenId), "Test Token URI");
+        assertMetadata(ipId, ipMetadataDefault);
         assertEq(rootOrgStoryNft.totalSupply(), totalSupplyBefore + 1);
         (address licenseTemplateChild, uint256 licenseTermsIdChild) = licenseRegistry.getAttachedLicenseTerms(ipId, 0);
         (address licenseTemplateParent, uint256 licenseTermsIdParent) = licenseRegistry.getAttachedLicenseTerms(

--- a/test/utils/BaseTest.t.sol
+++ b/test/utils/BaseTest.t.sol
@@ -200,7 +200,13 @@ contract BaseTest is Test, DeployHelper {
         string memory rootOrgTokenURI = "Test Token URI";
 
         bytes memory rootOrgStoryNftCustomInitParams = abi.encode(
-            IStoryBadgeNFT.CustomInitParams({ tokenURI: rootOrgTokenURI, signer: rootOrgStoryNftSigner })
+            IStoryBadgeNFT.CustomInitParams({
+                tokenURI: rootOrgTokenURI,
+                signer: rootOrgStoryNftSigner,
+                ipMetadataURI: ipMetadataDefault.ipMetadataURI,
+                ipMetadataHash: ipMetadataDefault.ipMetadataHash,
+                nftMetadataHash: ipMetadataDefault.nftMetadataHash
+            })
         );
 
         IStoryNFT.StoryNftInitParams memory rootOrgStoryNftInitParams = IStoryNFT.StoryNftInitParams({
@@ -224,7 +230,7 @@ contract BaseTest is Test, DeployHelper {
             orgStoryNftTemplate: defaultOrgStoryNftTemplate,
             orgNftRecipient: rootOrgStoryNftOwner,
             orgName: rootOrgName,
-            orgTokenURI: rootOrgTokenURI,
+            orgIpMetadata: ipMetadataDefault,
             storyNftInitParams: rootOrgStoryNftInitParams,
             isRootOrg: true
         });


### PR DESCRIPTION
### Description
This PR introduces the ability to set IP metadata during the minting process for `OrgNFT` and `BaseStoryNFT`. It ensures that when a new IP is registered, its metadata is provided by the user and set through `CoreMetadataModule`.

#### Key Changes
- Integrated logic for setting IP metadata into the internal `_mintAndRegisterIp` function in both `BaseStoryNFT` and `OrgNFT`.
- Added three storage variables to `StorageBadgeNFT` for storing IP metadata, which will be initialized during deployment. The same metadata will be the same across all badges in the collection.
- Updated mint functions in `OrgNFT` to accept the `IPMetadata` struct defined in `WorkflowStructs`.
- Updated `OrgStoryNFTFactory` deployment functions to accept the `IPMetadata` struct and pass it during the minting of `OrgNFTs`.

### Test Plan
Added calls to `assertMetadata` to verify that IP metadata is correctly set for IPs minted from `OrgNFT` and `StoryBadgeNFT`. All existing tests pass locally.