### PR TITLE
fix(cachable-nft): fix removing NFT from cache & add cache state getter

### DIFF
--- a/contracts/story-nft/CachableNFT.sol
+++ b/contracts/story-nft/CachableNFT.sol
@@ -49,6 +49,26 @@ abstract contract CachableNFT is OwnableUpgradeable {
         return $.cache.length();
     }
 
+    /// @notice Returns the cache mode.
+    /// @return The cache mode, true for cache mode, false for passthrough mode.
+    function getCacheMode() external view returns (bool) {
+        return _getCacheableNFTStorage().cacheMode;
+    }
+
+    /// @notice Returns the NFT at the given index in the cache.
+    /// @param index The index of the NFT in the cache.
+    /// @return tokenId The token ID of the NFT.
+    /// @return ipId The IP ID of the NFT.
+    function getCacheAtIndex(uint256 index) external view returns (uint256 tokenId, address ipId) {
+        return _getCacheableNFTStorage().cache.at(index);
+    }
+
+    /// @notice Returns the number of NFTs in the cache.
+    /// @return The number of NFTs in the cache.
+    function getCacheLength() external view returns (uint256) {
+        return _getCacheableNFTStorage().cache.length();
+    }
+
     /// @notice Transfers the first NFT from the cache to the recipient.
     /// @param recipient The recipient of the NFT.
     /// @return tokenId The token ID of the transferred NFT.
@@ -59,7 +79,7 @@ abstract contract CachableNFT is OwnableUpgradeable {
             return (0, address(0));
         }
         (tokenId, ipId) = $.cache.at(0);
-        $.cache.remove(0);
+        $.cache.remove(tokenId);
 
         _transferFrom(address(this), recipient, tokenId);
     }

--- a/contracts/story-nft/CachableNFT.sol
+++ b/contracts/story-nft/CachableNFT.sol
@@ -63,12 +63,6 @@ abstract contract CachableNFT is OwnableUpgradeable {
         return _getCacheableNFTStorage().cache.at(index);
     }
 
-    /// @notice Returns the number of NFTs in the cache.
-    /// @return The number of NFTs in the cache.
-    function getCacheLength() external view returns (uint256) {
-        return _getCacheableNFTStorage().cache.length();
-    }
-
     /// @notice Transfers the first NFT from the cache to the recipient.
     /// @param recipient The recipient of the NFT.
     /// @return tokenId The token ID of the transferred NFT.

--- a/test/story-nft/StoryBadgeNFT.t.sol
+++ b/test/story-nft/StoryBadgeNFT.t.sol
@@ -213,6 +213,12 @@ contract StoryBadgeNFTTest is BaseTest {
     }
 
     function test_StoryBadgeNFT_cachedMint() public {
+        bytes memory signature = _signAddress(rootOrgStoryNftSignerSk, u.alice);
+        vm.startPrank(u.alice);
+        (uint256 tokenId, ) = rootOrgStoryNft.mint(u.alice, signature);
+        assertEq(rootOrgStoryNft.ownerOf(tokenId), u.alice); // minted directly
+        vm.stopPrank();
+
         vm.startPrank(rootOrgStoryNftOwner);
         rootOrgStoryNft.mintToCache(1);
         assertEq(rootOrgStoryNft.cacheSize(), 1); // 1 cached
@@ -221,9 +227,9 @@ contract StoryBadgeNFTTest is BaseTest {
         rootOrgStoryNft.setCacheMode(true); // enable cache mode
         vm.stopPrank();
 
-        bytes memory signature = _signAddress(rootOrgStoryNftSignerSk, u.carl);
+        signature = _signAddress(rootOrgStoryNftSignerSk, u.carl);
         vm.startPrank(u.carl);
-        (uint256 tokenId, ) = rootOrgStoryNft.mint(u.carl, signature);
+        (tokenId, ) = rootOrgStoryNft.mint(u.carl, signature);
         assertEq(rootOrgStoryNft.ownerOf(tokenId), u.carl); // minted from cache
         vm.stopPrank();
         assertEq(rootOrgStoryNft.cacheSize(), 100); // cache size is reduced by 1


### PR DESCRIPTION
## Description
<!-- Add a description of the changes that this PR introduces -->
This PR fixes an issue where NFT information was not properly removed from the cache after `transferFromCache` due to incorrect usage of the `remove` method from `EnumerableMap`. Additionally, this PR introduces new getter functions to allow viewing the current state of the cache.