### PR TITLE
Simplify Royalty Claims in `RoyaltyWorkflows` and `GroupingWorkflows` by Removing Snapshots

### DIFF
--- a/contracts/interfaces/workflows/IGroupingWorkflows.sol
+++ b/contracts/interfaces/workflows/IGroupingWorkflows.sol
@@ -82,13 +82,11 @@ interface IGroupingWorkflows {
     /// @notice Collect royalties for the entire group and distribute the rewards to each member IP's royalty vault
     /// @param groupIpId The ID of the group IP.
     /// @param currencyTokens The addresses of the currency (revenue) tokens to claim.
-    /// @param groupSnapshotIds The IDs of the snapshots to collect royalties on.
     /// @param memberIpIds The IDs of the member IPs to distribute the rewards to.
     /// @return collectedRoyalties The amounts of royalties collected for each currency token.
     function collectRoyaltiesAndClaimReward(
         address groupIpId,
         address[] calldata currencyTokens,
-        uint256[] calldata groupSnapshotIds,
         address[] calldata memberIpIds
     ) external returns (uint256[] memory collectedRoyalties);
 }

--- a/contracts/interfaces/workflows/IRoyaltyWorkflows.sol
+++ b/contracts/interfaces/workflows/IRoyaltyWorkflows.sol
@@ -4,73 +4,36 @@ pragma solidity 0.8.26;
 /// @title Royalty Workflows Interface
 /// @notice Interface for IP royalty workflows.
 interface IRoyaltyWorkflows {
-    /// @notice Details for claiming royalties from a child IP.
-    /// @param childIpId The address of the child IP.
-    /// @param royaltyPolicy The address of the royalty policy.
-    /// @param currencyToken The address of the currency (revenue) token to claim.
-    /// @param amount The amount of currency (revenue) token to claim.
-    struct RoyaltyClaimDetails {
-        address childIpId;
-        address royaltyPolicy;
-        address currencyToken;
-        uint256 amount;
-    }
-
-    /// @notice Transfers royalties from royalty policy to the ancestor IP's royalty vault, takes a snapshot,
-    /// and claims revenue on that snapshot for each specified currency token.
+    /// @notice Transfers royalties from royalty policy to the ancestor IP's royalty vault, and claims revenue
+    /// for each specified currency token.
     /// @param ancestorIpId The address of the ancestor IP.
     /// @param claimer The address of the claimer of the revenue tokens (must be a royalty token holder).
-    /// @param royaltyClaimDetails The details of the royalty claim from child IPs,
-    /// see {IRoyaltyWorkflows-RoyaltyClaimDetails}.
-    /// @return snapshotId The ID of the snapshot taken.
+    /// @param childIpIds The addresses of the child IPs.
+    /// @param royaltyPolicies The addresses of the royalty policies.
+    /// @param currencyTokens The addresses of the currency (revenue) tokens to claim.
+    /// @param amounts The amounts of currency (revenue) tokens to claim.
     /// @return amountsClaimed The amount of revenue claimed for each currency token.
-    function transferToVaultAndSnapshotAndClaimByTokenBatch(
+    function transferToVaultAndClaimByTokenBatch(
         address ancestorIpId,
         address claimer,
-        RoyaltyClaimDetails[] calldata royaltyClaimDetails
-    ) external returns (uint256 snapshotId, uint256[] memory amountsClaimed);
+        address[] calldata childIpIds,
+        address[] calldata royaltyPolicies,
+        address[] calldata currencyTokens,
+        uint256[] calldata amounts
+    ) external returns (uint256[] memory amountsClaimed);
 
-    /// @notice Transfers royalties to the ancestor IP's royalty vault, takes a snapshot, claims revenue for each
-    /// specified currency token both on the new snapshot and on each specified unclaimed snapshots.
+    /// @notice Claims all revenue for each specified currency token.
     /// @param ancestorIpId The address of the ancestor IP.
     /// @param claimer The address of the claimer of the revenue tokens (must be a royalty token holder).
-    /// @param unclaimedSnapshotIds The IDs of unclaimed snapshots to include in the claim.
-    /// @param royaltyClaimDetails The details of the royalty claim from child IPs,
-    /// see {IRoyaltyWorkflows-RoyaltyClaimDetails}.
-    /// @return snapshotId The ID of the snapshot taken.
-    /// @return amountsClaimed The amounts of revenue claimed for each currency token.
-    function transferToVaultAndSnapshotAndClaimBySnapshotBatch(
+    /// @param childIpIds The addresses of the child IPs.
+    /// @param royaltyPolicies The addresses of the royalty policies.
+    /// @param currencyTokens The addresses of the currency (revenue) tokens to claim.
+    /// @return amountsClaimed The amount of revenue claimed for each currency token.
+    function claimAllRevenue(
         address ancestorIpId,
         address claimer,
-        uint256[] calldata unclaimedSnapshotIds,
-        RoyaltyClaimDetails[] calldata royaltyClaimDetails
-    ) external returns (uint256 snapshotId, uint256[] memory amountsClaimed);
-
-    /// @notice Takes a snapshot of the IP's royalty vault and claims revenue on that snapshot for each
-    /// specified currency token.
-    /// @param ipId The address of the IP.
-    /// @param claimer The address of the claimer of the revenue tokens (must be a royalty token holder).
-    /// @param currencyTokens The addresses of the currency (revenue) tokens to claim.
-    /// @return snapshotId The ID of the snapshot taken.
-    /// @return amountsClaimed The amounts of revenue claimed for each currency token.
-    function snapshotAndClaimByTokenBatch(
-        address ipId,
-        address claimer,
+        address[] calldata childIpIds,
+        address[] calldata royaltyPolicies,
         address[] calldata currencyTokens
-    ) external returns (uint256 snapshotId, uint256[] memory amountsClaimed);
-
-    /// @notice Takes a snapshot of the IP's royalty vault and claims revenue for each specified currency token
-    /// both on the new snapshot and on each specified unclaimed snapshot.
-    /// @param ipId The address of the IP.
-    /// @param claimer The address of the claimer of the revenue tokens (must be a royalty token holder).
-    /// @param unclaimedSnapshotIds The IDs of unclaimed snapshots to include in the claim.
-    /// @param currencyTokens The addresses of the currency (revenue) tokens to claim.
-    /// @return snapshotId The ID of the snapshot taken.
-    /// @return amountsClaimed The amounts of revenue claimed for each currency token.
-    function snapshotAndClaimBySnapshotBatch(
-        address ipId,
-        address claimer,
-        uint256[] calldata unclaimedSnapshotIds,
-        address[] calldata currencyTokens
-    ) external returns (uint256 snapshotId, uint256[] memory amountsClaimed);
+    ) external returns (uint256[] memory amountsClaimed);
 }

--- a/contracts/interfaces/workflows/IRoyaltyWorkflows.sol
+++ b/contracts/interfaces/workflows/IRoyaltyWorkflows.sol
@@ -4,15 +4,17 @@ pragma solidity 0.8.26;
 /// @title Royalty Workflows Interface
 /// @notice Interface for IP royalty workflows.
 interface IRoyaltyWorkflows {
-    /// @notice Transfers royalties from royalty policy to the ancestor IP's royalty vault, and claims revenue
-    /// for each specified currency token.
-    /// @param ancestorIpId The address of the ancestor IP.
-    /// @param claimer The address of the claimer of the revenue tokens (must be a royalty token holder).
-    /// @param childIpIds The addresses of the child IPs.
-    /// @param royaltyPolicies The addresses of the royalty policies.
-    /// @param currencyTokens The addresses of the currency (revenue) tokens to claim.
-    /// @param amounts The amounts of currency (revenue) tokens to claim.
-    /// @return amountsClaimed The amount of revenue claimed for each currency token.
+    /// @notice Transfers specified amounts of royalties from various royalty policies to the royalty
+    ///         vault of an ancestor IP, and claims all the revenue for each currency token from the
+    ///         ancestor IP's royalty vault to the claimer.
+    /// @param ancestorIpId The address of the ancestor IP from which the revenue is being claimed.
+    /// @param claimer The address of the claimer of the currency (revenue) tokens.
+    /// @param childIpIds The addresses of the child IPs from which royalties are derived.
+    /// @param royaltyPolicies The addresses of the royalty policies that govern royalty flows for each child IP.
+    /// @param currencyTokens The addresses of the currency tokens in which the royalties will be claimed.
+    /// @param amounts The amounts (in each currency) of royalties to be transferred to the ancestor IP's
+    ///        royalty vault and subsequently claimed by the claimer.
+    /// @return amountsClaimed The amounts of successfully claimed revenue for each specified currency token.
     function transferToVaultAndClaimByTokenBatch(
         address ancestorIpId,
         address claimer,
@@ -22,13 +24,15 @@ interface IRoyaltyWorkflows {
         uint256[] calldata amounts
     ) external returns (uint256[] memory amountsClaimed);
 
-    /// @notice Claims all revenue for each specified currency token.
-    /// @param ancestorIpId The address of the ancestor IP.
-    /// @param claimer The address of the claimer of the revenue tokens (must be a royalty token holder).
-    /// @param childIpIds The addresses of the child IPs.
-    /// @param royaltyPolicies The addresses of the royalty policies.
-    /// @param currencyTokens The addresses of the currency (revenue) tokens to claim.
-    /// @return amountsClaimed The amount of revenue claimed for each currency token.
+    /// @notice Transfers all avaiable royalties from various royalty policies to the royalty
+    ///         vault of an ancestor IP, and claims all the revenue for each currency token
+    ///         from the ancestor IP's royalty vault to the claimer.
+    /// @param ancestorIpId The address of the ancestor IP from which the revenue is being claimed.
+    /// @param claimer The address of the claimer of the currency (revenue) tokens.
+    /// @param childIpIds The addresses of the child IPs from which royalties are derived.
+    /// @param royaltyPolicies The addresses of the royalty policies that govern royalty flows for each child IP.
+    /// @param currencyTokens The addresses of the currency tokens in which the royalties will be claimed.
+    /// @return amountsClaimed The amounts of successfully claimed revenue for each specified currency token.
     function claimAllRevenue(
         address ancestorIpId,
         address claimer,

--- a/contracts/interfaces/workflows/IRoyaltyWorkflows.sol
+++ b/contracts/interfaces/workflows/IRoyaltyWorkflows.sol
@@ -10,10 +10,13 @@ interface IRoyaltyWorkflows {
     /// @param ancestorIpId The address of the ancestor IP from which the revenue is being claimed.
     /// @param claimer The address of the claimer of the currency (revenue) tokens.
     /// @param childIpIds The addresses of the child IPs from which royalties are derived.
-    /// @param royaltyPolicies The addresses of the royalty policies that govern royalty flows for each child IP.
-    /// @param currencyTokens The addresses of the currency tokens in which the royalties will be claimed.
-    /// @param amounts The amounts (in each currency) of royalties to be transferred to the ancestor IP's
-    ///        royalty vault and subsequently claimed by the claimer.
+    /// @param royaltyPolicies The addresses of the royalty policies, where royaltyPolicies[i] governs
+    ///        the royalty flow for childIpIds[i].
+    /// @param currencyTokens The addresses of the currency tokens in which royalties will be claimed,
+    ///        where currencyTokens[i] is the token used for royalties from childIpIds[i].
+    /// @param amounts The amounts to transfer and claim, where amounts[i] represents the amount of
+    ///        royalties in currencyTokens[i] to transfer from childIpIds[i]'s royaltyPolicies[i] to the ancestor's
+    ///        royalty vault.
     /// @return amountsClaimed The amounts of successfully claimed revenue for each specified currency token.
     function transferToVaultAndClaimByTokenBatch(
         address ancestorIpId,
@@ -30,8 +33,10 @@ interface IRoyaltyWorkflows {
     /// @param ancestorIpId The address of the ancestor IP from which the revenue is being claimed.
     /// @param claimer The address of the claimer of the currency (revenue) tokens.
     /// @param childIpIds The addresses of the child IPs from which royalties are derived.
-    /// @param royaltyPolicies The addresses of the royalty policies that govern royalty flows for each child IP.
-    /// @param currencyTokens The addresses of the currency tokens in which the royalties will be claimed.
+    /// @param royaltyPolicies The addresses of the royalty policies, where royaltyPolicies[i] governs
+    ///        the royalty flow for childIpIds[i].
+    /// @param currencyTokens The addresses of the currency tokens in which royalties will be claimed,
+    ///        where currencyTokens[i] is the token used for royalties from childIpIds[i].
     /// @return amountsClaimed The amounts of successfully claimed revenue for each specified currency token.
     function claimAllRevenue(
         address ancestorIpId,

--- a/contracts/workflows/GroupingWorkflows.sol
+++ b/contracts/workflows/GroupingWorkflows.sol
@@ -288,19 +288,18 @@ contract GroupingWorkflows is
     /// @notice Collect royalties for the entire group and distribute the rewards to each member IP's royalty vault
     /// @param groupIpId The ID of the group IP.
     /// @param currencyTokens The addresses of the currency (revenue) tokens to claim.
-    /// @param groupSnapshotIds The IDs of the snapshots to collect royalties on.
     /// @param memberIpIds The IDs of the member IPs to distribute the rewards to.
     /// @return collectedRoyalties The amounts of royalties collected for each currency token.
     function collectRoyaltiesAndClaimReward(
         address groupIpId,
         address[] calldata currencyTokens,
-        uint256[] calldata groupSnapshotIds,
         address[] calldata memberIpIds
     ) external returns (uint256[] memory collectedRoyalties) {
         (address groupLicenseTemplate, uint256 groupLicenseTermsId) = LICENSE_REGISTRY.getAttachedLicenseTerms(
             groupIpId,
             0
         );
+
         for (uint256 i = 0; i < memberIpIds.length; i++) {
             // check if given member IPs already have a royalty vault
             if (ROYALTY_MODULE.ipRoyaltyVaults(memberIpIds[i]) == address(0)) {
@@ -320,7 +319,7 @@ contract GroupingWorkflows is
         collectedRoyalties = new uint256[](currencyTokens.length);
         for (uint256 i = 0; i < currencyTokens.length; i++) {
             if (currencyTokens[i] == address(0)) revert Errors.GroupingWorkflows__ZeroAddressParam();
-            collectedRoyalties[i] = GROUPING_MODULE.collectRoyalties(groupIpId, currencyTokens[i], groupSnapshotIds);
+            collectedRoyalties[i] = GROUPING_MODULE.collectRoyalties(groupIpId, currencyTokens[i]);
             GROUPING_MODULE.claimReward(groupIpId, currencyTokens[i], memberIpIds);
         }
     }

--- a/contracts/workflows/RoyaltyWorkflows.sol
+++ b/contracts/workflows/RoyaltyWorkflows.sol
@@ -42,208 +42,129 @@ contract RoyaltyWorkflows is IRoyaltyWorkflows, MulticallUpgradeable, AccessMana
         __UUPSUpgradeable_init();
     }
 
-    /// @notice Transfers royalties from royalty policy to the ancestor IP's royalty vault, takes a snapshot,
-    /// and claims revenue on that snapshot for each specified currency token.
+    /// @notice Transfers royalties from royalty policy to the ancestor IP's royalty vault, and claims revenue
+    /// for each specified currency token.
     /// @param ancestorIpId The address of the ancestor IP.
     /// @param claimer The address of the claimer of the revenue tokens (must be a royalty token holder).
-    /// @param royaltyClaimDetails The details of the royalty claim from child IPs,
-    /// see {IRoyaltyWorkflows-RoyaltyClaimDetails}.
-    /// @return snapshotId The ID of the snapshot taken.
+    /// @param childIpIds The addresses of the child IPs.
+    /// @param royaltyPolicies The addresses of the royalty policies.
+    /// @param currencyTokens The addresses of the currency (revenue) tokens to claim.
+    /// @param amounts The amounts of currency (revenue) tokens to claim.
     /// @return amountsClaimed The amount of revenue claimed for each currency token.
-    function transferToVaultAndSnapshotAndClaimByTokenBatch(
+    function transferToVaultAndClaimByTokenBatch(
         address ancestorIpId,
         address claimer,
-        RoyaltyClaimDetails[] calldata royaltyClaimDetails
-    ) external returns (uint256 snapshotId, uint256[] memory amountsClaimed) {
+        address[] calldata childIpIds,
+        address[] calldata royaltyPolicies,
+        address[] calldata currencyTokens,
+        uint256[] calldata amounts
+    ) external returns (uint256[] memory amountsClaimed) {
         // Transfers to ancestor's vault an amount of revenue tokens claimable via the given royalty policy
-        for (uint256 i = 0; i < royaltyClaimDetails.length; i++) {
-            IGraphAwareRoyaltyPolicy(royaltyClaimDetails[i].royaltyPolicy).transferToVault({
-                ipId: royaltyClaimDetails[i].childIpId,
+        for (uint256 i = 0; i < childIpIds.length; i++) {
+            IGraphAwareRoyaltyPolicy(royaltyPolicies[i]).transferToVault({
+                ipId: childIpIds[i],
                 ancestorIpId: ancestorIpId,
-                token: royaltyClaimDetails[i].currencyToken,
-                amount: royaltyClaimDetails[i].amount
+                token: currencyTokens[i],
+                amount: amounts[i]
             });
         }
 
         // Gets the ancestor IP's royalty vault
         IIpRoyaltyVault ancestorIpRoyaltyVault = IIpRoyaltyVault(ROYALTY_MODULE.ipRoyaltyVaults(ancestorIpId));
 
-        // Takes a snapshot of the ancestor IP's royalty vault
-        snapshotId = ancestorIpRoyaltyVault.snapshot();
-
-        // Claims revenue for each specified currency token from the latest snapshot
+        // Claims revenue for each specified currency token
         amountsClaimed = ancestorIpRoyaltyVault.claimRevenueOnBehalfByTokenBatch({
-            snapshotId: snapshotId,
-            tokenList: _getCurrencyTokenList(royaltyClaimDetails),
-            claimer: claimer
+            claimer: claimer,
+            tokenList: _getUniqueCurrencyTokens(currencyTokens)
         });
     }
 
-    /// @notice Transfers royalties to the ancestor IP's royalty vault, takes a snapshot, claims revenue for each
-    /// specified currency token both on the new snapshot and on each specified unclaimed snapshots.
+    /// @notice Claims all revenue for each specified currency token.
     /// @param ancestorIpId The address of the ancestor IP.
     /// @param claimer The address of the claimer of the revenue tokens (must be a royalty token holder).
-    /// @param unclaimedSnapshotIds The IDs of unclaimed snapshots to include in the claim.
-    /// @param royaltyClaimDetails The details of the royalty claim from child IPs,
-    /// see {IRoyaltyWorkflows-RoyaltyClaimDetails}.
-    /// @return snapshotId The ID of the snapshot taken.
-    /// @return amountsClaimed The amounts of revenue claimed for each currency token.
-    function transferToVaultAndSnapshotAndClaimBySnapshotBatch(
+    /// @param childIpIds The addresses of the child IPs.
+    /// @param royaltyPolicies The addresses of the royalty policies.
+    /// @param currencyTokens The addresses of the currency (revenue) tokens to claim.
+    /// @return amountsClaimed The amount of revenue claimed for each currency token.
+    function claimAllRevenue(
         address ancestorIpId,
         address claimer,
-        uint256[] calldata unclaimedSnapshotIds,
-        RoyaltyClaimDetails[] calldata royaltyClaimDetails
-    ) external returns (uint256 snapshotId, uint256[] memory amountsClaimed) {
-        // Transfers to ancestor's vault an amount of revenue tokens claimable via the given royalty policy
-        for (uint256 i = 0; i < royaltyClaimDetails.length; i++) {
-            IGraphAwareRoyaltyPolicy(royaltyClaimDetails[i].royaltyPolicy).transferToVault({
-                ipId: royaltyClaimDetails[i].childIpId,
+        address[] calldata childIpIds,
+        address[] calldata royaltyPolicies,
+        address[] calldata currencyTokens
+    ) external returns (uint256[] memory amountsClaimed) {
+        for (uint256 i = 0; i < childIpIds.length; i++) {
+            // Gets the total lifetime revenue tokens received for a given IP asset
+            uint256 totalTokenReceivedByChild = ROYALTY_MODULE.totalRevenueTokensReceived({
+                ipId: childIpIds[i],
+                token: currencyTokens[i]
+            });
+
+            // Gets the total lifetime revenue tokens transferred to a vault from a descendant IP via the policy
+            uint256 totalTokenTransferredToAncestor = IGraphAwareRoyaltyPolicy(royaltyPolicies[i]).getTransferredTokens({
+                ipId: childIpIds[i],
                 ancestorIpId: ancestorIpId,
-                token: royaltyClaimDetails[i].currencyToken,
-                amount: royaltyClaimDetails[i].amount
+                token: currencyTokens[i]
+            });
+
+            uint32 ancestorPercentage = IGraphAwareRoyaltyPolicy(royaltyPolicies[i]).getPolicyRoyalty({
+                ipId: childIpIds[i],
+                ancestorIpId: ancestorIpId
+            });
+
+            // Transfer all available revenue tokens to the ancestor's vault
+            IGraphAwareRoyaltyPolicy(royaltyPolicies[i]).transferToVault({
+                ipId: childIpIds[i],
+                ancestorIpId: ancestorIpId,
+                token: currencyTokens[i],
+                amount: ((totalTokenReceivedByChild * ancestorPercentage) / ROYALTY_MODULE.maxPercent()) -
+                    totalTokenTransferredToAncestor
             });
         }
 
         // Gets the ancestor IP's royalty vault
         IIpRoyaltyVault ancestorIpRoyaltyVault = IIpRoyaltyVault(ROYALTY_MODULE.ipRoyaltyVaults(ancestorIpId));
 
-        // Takes a snapshot of the ancestor IP's royalty vault
-        snapshotId = ancestorIpRoyaltyVault.snapshot();
-
-        address[] memory currencyTokens = _getCurrencyTokenList(royaltyClaimDetails);
-
-        // Claims revenue for each specified currency token from the latest snapshot
+        // Claims revenue for each specified currency token
         amountsClaimed = ancestorIpRoyaltyVault.claimRevenueOnBehalfByTokenBatch({
-            snapshotId: snapshotId,
-            tokenList: currencyTokens,
-            claimer: claimer
+            claimer: claimer,
+            tokenList: _getUniqueCurrencyTokens(currencyTokens)
         });
-
-        // Claims revenue for each specified currency token from the unclaimed snapshots
-        for (uint256 i = 0; i < currencyTokens.length; i++) {
-            try
-                ancestorIpRoyaltyVault.claimRevenueOnBehalfBySnapshotBatch({
-                    snapshotIds: unclaimedSnapshotIds,
-                    token: currencyTokens[i],
-                    claimer: claimer
-                })
-            returns (uint256 claimedAmount) {
-                amountsClaimed[i] += claimedAmount;
-            } catch (bytes memory reason) {
-                // If the error is not IpRoyaltyVault__NoClaimableTokens, revert with the original error
-                if (CoreErrors.IpRoyaltyVault__NoClaimableTokens.selector != bytes4(reason)) {
-                    assembly {
-                        revert(add(reason, 32), mload(reason))
-                    }
-                }
-            }
-        }
     }
 
-    /// @notice Takes a snapshot of the IP's royalty vault and claims revenue on that snapshot for each
-    /// specified currency token.
-    /// @param ipId The address of the IP.
-    /// @param claimer The address of the claimer of the revenue tokens (must be a royalty token holder).
-    /// @param currencyTokens The addresses of the currency (revenue) tokens to claim.
-    /// @return snapshotId The ID of the snapshot taken.
-    /// @return amountsClaimed The amounts of revenue claimed for each currency token.
-    function snapshotAndClaimByTokenBatch(
-        address ipId,
-        address claimer,
+    /// @notice Returns an array of unique currency token addresses, filtering out duplicates.
+    /// @param currencyTokens The addresses of the currency (revenue) tokens to filter.
+    /// @return uniqueCurrencyTokens An array containing only unique currency token addresses.
+    function _getUniqueCurrencyTokens(
         address[] calldata currencyTokens
-    ) external returns (uint256 snapshotId, uint256[] memory amountsClaimed) {
-        // Gets the IP's royalty vault
-        IIpRoyaltyVault ipRoyaltyVault = IIpRoyaltyVault(ROYALTY_MODULE.ipRoyaltyVaults(ipId));
-
-        // Claims revenue for each specified currency token from the latest snapshot
-        snapshotId = ipRoyaltyVault.snapshot();
-        amountsClaimed = ipRoyaltyVault.claimRevenueOnBehalfByTokenBatch({
-            snapshotId: snapshotId,
-            tokenList: currencyTokens,
-            claimer: claimer
-        });
-    }
-
-    /// @notice Takes a snapshot of the IP's royalty vault and claims revenue for each specified currency token
-    /// both on the new snapshot and on each specified unclaimed snapshot.
-    /// @param ipId The address of the IP.
-    /// @param claimer The address of the claimer of the revenue tokens (must be a royalty token holder).
-    /// @param unclaimedSnapshotIds The IDs of unclaimed snapshots to include in the claim.
-    /// @param currencyTokens The addresses of the currency (revenue) tokens to claim.
-    /// @return snapshotId The ID of the snapshot taken.
-    /// @return amountsClaimed The amounts of revenue claimed for each currency token.
-    function snapshotAndClaimBySnapshotBatch(
-        address ipId,
-        address claimer,
-        uint256[] calldata unclaimedSnapshotIds,
-        address[] calldata currencyTokens
-    ) external returns (uint256 snapshotId, uint256[] memory amountsClaimed) {
-        // Gets the IP's royalty vault
-        IIpRoyaltyVault ipRoyaltyVault = IIpRoyaltyVault(ROYALTY_MODULE.ipRoyaltyVaults(ipId));
-
-        // Claims revenue for each specified currency token from the latest snapshot
-        snapshotId = ipRoyaltyVault.snapshot();
-        amountsClaimed = ipRoyaltyVault.claimRevenueOnBehalfByTokenBatch({
-            snapshotId: snapshotId,
-            tokenList: currencyTokens,
-            claimer: claimer
-        });
-
-        // Claims revenue for each specified currency token from the unclaimed snapshots
-        for (uint256 i = 0; i < currencyTokens.length; i++) {
-            try
-                ipRoyaltyVault.claimRevenueOnBehalfBySnapshotBatch({
-                    snapshotIds: unclaimedSnapshotIds,
-                    token: currencyTokens[i],
-                    claimer: claimer
-                })
-            returns (uint256 claimedAmount) {
-                amountsClaimed[i] += claimedAmount;
-            } catch (bytes memory reason) {
-                // If the error is not IpRoyaltyVault__NoClaimableTokens, revert with the original error
-                if (CoreErrors.IpRoyaltyVault__NoClaimableTokens.selector != bytes4(reason)) {
-                    assembly {
-                        revert(add(reason, 32), mload(reason))
-                    }
-                }
-            }
-        }
-    }
-
-    /// @dev Extracts all unique currency token addresses from an array of RoyaltyClaimDetails.
-    /// @param royaltyClaimDetails The details of the royalty claim from child IPs,
-    /// see {IRoyaltyWorkflows-RoyaltyClaimDetails}.
-    /// @return currencyTokenList An array of unique currency token addresses extracted from `royaltyClaimDetails`.
-    function _getCurrencyTokenList(
-        RoyaltyClaimDetails[] calldata royaltyClaimDetails
-    ) private pure returns (address[] memory currencyTokenList) {
-        uint256 length = royaltyClaimDetails.length;
+    ) internal pure returns (address[] memory uniqueCurrencyTokens){
+        uint256 length = currencyTokens.length;
         address[] memory tempUniqueTokenList = new address[](length);
         uint256 uniqueCount = 0;
 
         for (uint256 i = 0; i < length; i++) {
-            address currencyToken = royaltyClaimDetails[i].currencyToken;
+            address currencyToken = currencyTokens[i];
             bool isDuplicate = false;
 
-            // Check if `currencyToken` already in `tempUniqueTokenList`
+            // Check if `currencyToken` already exists in `tempUniqueTokenList`
             for (uint256 j = 0; j < uniqueCount; j++) {
                 if (tempUniqueTokenList[j] == currencyToken) {
-                    // set the `isDuplicate` flag if `currencyToken` already in `tempUniqueTokenList`
                     isDuplicate = true;
                     break;
                 }
             }
 
-            // Add `currencyToken` to `tempUniqueTokenList` if it's not already in `tempUniqueTokenList`
+            // Add `currencyToken` to `tempUniqueTokenList` if it's unique
             if (!isDuplicate) {
                 tempUniqueTokenList[uniqueCount] = currencyToken;
                 uniqueCount++;
             }
         }
 
-        currencyTokenList = new address[](uniqueCount);
+        // Populate `uniqueCurrencyTokens` array with unique tokens
+        uniqueCurrencyTokens = new address[](uniqueCount);
         for (uint256 i = 0; i < uniqueCount; i++) {
-            currencyTokenList[i] = tempUniqueTokenList[i];
+            uniqueCurrencyTokens[i] = tempUniqueTokenList[i];
         }
     }
 

--- a/contracts/workflows/RoyaltyWorkflows.sol
+++ b/contracts/workflows/RoyaltyWorkflows.sol
@@ -48,10 +48,13 @@ contract RoyaltyWorkflows is IRoyaltyWorkflows, MulticallUpgradeable, AccessMana
     /// @param ancestorIpId The address of the ancestor IP from which the revenue is being claimed.
     /// @param claimer The address of the claimer of the currency (revenue) tokens.
     /// @param childIpIds The addresses of the child IPs from which royalties are derived.
-    /// @param royaltyPolicies The addresses of the royalty policies that govern royalty flows for each child IP.
-    /// @param currencyTokens The addresses of the currency tokens in which the royalties will be claimed.
-    /// @param amounts The amounts (in each currency) of royalties to be transferred to the ancestor IP's
-    ///        royalty vault and subsequently claimed by the claimer.
+    /// @param royaltyPolicies The addresses of the royalty policies, where royaltyPolicies[i] governs
+    ///        the royalty flow for childIpIds[i].
+    /// @param currencyTokens The addresses of the currency tokens in which royalties will be claimed,
+    ///        where currencyTokens[i] is the token used for royalties from childIpIds[i].
+    /// @param amounts The amounts to transfer and claim, where amounts[i] represents the amount of
+    ///        royalties in currencyTokens[i] to transfer from childIpIds[i]'s royaltyPolicies[i] to the ancestor's
+    ///        royalty vault.
     /// @return amountsClaimed The amounts of successfully claimed revenue for each specified currency token.
     function transferToVaultAndClaimByTokenBatch(
         address ancestorIpId,
@@ -87,8 +90,10 @@ contract RoyaltyWorkflows is IRoyaltyWorkflows, MulticallUpgradeable, AccessMana
     /// @param ancestorIpId The address of the ancestor IP from which the revenue is being claimed.
     /// @param claimer The address of the claimer of the currency (revenue) tokens.
     /// @param childIpIds The addresses of the child IPs from which royalties are derived.
-    /// @param royaltyPolicies The addresses of the royalty policies that govern royalty flows for each child IP.
-    /// @param currencyTokens The addresses of the currency tokens in which the royalties will be claimed.
+    /// @param royaltyPolicies The addresses of the royalty policies, where royaltyPolicies[i] governs
+    ///        the royalty flow for childIpIds[i].
+    /// @param currencyTokens The addresses of the currency tokens in which royalties will be claimed,
+    ///        where currencyTokens[i] is the token used for royalties from childIpIds[i].
     /// @return amountsClaimed The amounts of successfully claimed revenue for each specified currency token.
     function claimAllRevenue(
         address ancestorIpId,

--- a/contracts/workflows/RoyaltyWorkflows.sol
+++ b/contracts/workflows/RoyaltyWorkflows.sol
@@ -42,15 +42,17 @@ contract RoyaltyWorkflows is IRoyaltyWorkflows, MulticallUpgradeable, AccessMana
         __UUPSUpgradeable_init();
     }
 
-    /// @notice Transfers royalties from royalty policy to the ancestor IP's royalty vault, and claims revenue
-    /// for each specified currency token.
-    /// @param ancestorIpId The address of the ancestor IP.
-    /// @param claimer The address of the claimer of the revenue tokens (must be a royalty token holder).
-    /// @param childIpIds The addresses of the child IPs.
-    /// @param royaltyPolicies The addresses of the royalty policies.
-    /// @param currencyTokens The addresses of the currency (revenue) tokens to claim.
-    /// @param amounts The amounts of currency (revenue) tokens to claim.
-    /// @return amountsClaimed The amount of revenue claimed for each currency token.
+    /// @notice Transfers specified amounts of royalties from various royalty policies to the royalty
+    ///         vault of an ancestor IP, and claims all the revenue for each currency token from the
+    ///         ancestor IP's royalty vault to the claimer.
+    /// @param ancestorIpId The address of the ancestor IP from which the revenue is being claimed.
+    /// @param claimer The address of the claimer of the currency (revenue) tokens.
+    /// @param childIpIds The addresses of the child IPs from which royalties are derived.
+    /// @param royaltyPolicies The addresses of the royalty policies that govern royalty flows for each child IP.
+    /// @param currencyTokens The addresses of the currency tokens in which the royalties will be claimed.
+    /// @param amounts The amounts (in each currency) of royalties to be transferred to the ancestor IP's
+    ///        royalty vault and subsequently claimed by the claimer.
+    /// @return amountsClaimed The amounts of successfully claimed revenue for each specified currency token.
     function transferToVaultAndClaimByTokenBatch(
         address ancestorIpId,
         address claimer,
@@ -79,13 +81,15 @@ contract RoyaltyWorkflows is IRoyaltyWorkflows, MulticallUpgradeable, AccessMana
         });
     }
 
-    /// @notice Claims all revenue for each specified currency token.
-    /// @param ancestorIpId The address of the ancestor IP.
-    /// @param claimer The address of the claimer of the revenue tokens (must be a royalty token holder).
-    /// @param childIpIds The addresses of the child IPs.
-    /// @param royaltyPolicies The addresses of the royalty policies.
-    /// @param currencyTokens The addresses of the currency (revenue) tokens to claim.
-    /// @return amountsClaimed The amount of revenue claimed for each currency token.
+    /// @notice Transfers all avaiable royalties from various royalty policies to the royalty
+    ///         vault of an ancestor IP, and claims all the revenue for each currency token
+    ///         from the ancestor IP's royalty vault to the claimer.
+    /// @param ancestorIpId The address of the ancestor IP from which the revenue is being claimed.
+    /// @param claimer The address of the claimer of the currency (revenue) tokens.
+    /// @param childIpIds The addresses of the child IPs from which royalties are derived.
+    /// @param royaltyPolicies The addresses of the royalty policies that govern royalty flows for each child IP.
+    /// @param currencyTokens The addresses of the currency tokens in which the royalties will be claimed.
+    /// @return amountsClaimed The amounts of successfully claimed revenue for each specified currency token.
     function claimAllRevenue(
         address ancestorIpId,
         address claimer,

--- a/contracts/workflows/RoyaltyWorkflows.sol
+++ b/contracts/workflows/RoyaltyWorkflows.sol
@@ -101,11 +101,8 @@ contract RoyaltyWorkflows is IRoyaltyWorkflows, MulticallUpgradeable, AccessMana
             });
 
             // Gets the total lifetime revenue tokens transferred to a vault from a descendant IP via the policy
-            uint256 totalTokenTransferredToAncestor = IGraphAwareRoyaltyPolicy(royaltyPolicies[i]).getTransferredTokens({
-                ipId: childIpIds[i],
-                ancestorIpId: ancestorIpId,
-                token: currencyTokens[i]
-            });
+            uint256 totalTokenTransferredToAncestor = IGraphAwareRoyaltyPolicy(royaltyPolicies[i])
+                .getTransferredTokens({ ipId: childIpIds[i], ancestorIpId: ancestorIpId, token: currencyTokens[i] });
 
             uint32 ancestorPercentage = IGraphAwareRoyaltyPolicy(royaltyPolicies[i]).getPolicyRoyalty({
                 ipId: childIpIds[i],
@@ -137,7 +134,7 @@ contract RoyaltyWorkflows is IRoyaltyWorkflows, MulticallUpgradeable, AccessMana
     /// @return uniqueCurrencyTokens An array containing only unique currency token addresses.
     function _getUniqueCurrencyTokens(
         address[] calldata currencyTokens
-    ) internal pure returns (address[] memory uniqueCurrencyTokens){
+    ) internal pure returns (address[] memory uniqueCurrencyTokens) {
         uint256 length = currencyTokens.length;
         address[] memory tempUniqueTokenList = new address[](length);
         uint256 uniqueCount = 0;

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -46,15 +46,8 @@
 
 ### [Royalty Workflows](../contracts/interfaces/workflows/IRoyaltyWorkflows.sol)
 
-- `transferToVaultAndSnapshotAndClaimByTokenBatch`:
-  - Transfers revenue tokens to ancestor IP’s royalty vault → Takes a snapshot of the royalty vault → Claims all available revenue tokens from the snapshot to the claimer’s wallet
-  - *Use Case*: For IP royalty token holders who want to claim both their direct revenue and royalties from descendant IPs.
-- `transferToVaultAndSnapshotAndClaimBySnapshotBatch`:
-  - Transfers revenue tokens to ancestor IP’s royalty vault → Takes a snapshot of the royalty vault → Claims all available revenue tokens from the new snapshot to the claimer’s wallet → Claims all available revenue tokens from each provided unclaimed snapshot to the claimer’s wallet
-  - *Use Case*: For IP royalty token holders who want to claim both direct revenue and descendant royalties from the latest snapshot and previously taken snapshots.
-- `snapshotAndClaimByTokenBatch`:
-  - Takes a snapshot of the royalty vault → Claims all available revenue tokens from the new snapshot to the claimer’s wallet
-  - *Use Case*: For IP royalty token holders who want to claim the current revenue in their IP’s royalty vault (which may or may not include descendant royalties).
-- `snapshotAndClaimBySnapshotBatch`:
-  - Takes a snapshot of the royalty vault → Claims all available revenue tokens from the new snapshot to the claimer’s wallet → Claims all available revenue tokens from each provided unclaimed snapshot to the claimer’s wallet
-  - *Use Case*: For IP royalty token holders who want to claim the current revenue in their IP’s royalty vault from the latest snapshot and previously taken snapshots.
+- `transferToVaultAndClaimByTokenBatch`:
+  - Transfers specified amounts of royalties from various royalty policies to the royalty vault of the ancestor IP -> Claims all the revenue in each currency token from the ancestor IP's royalty vault to the claimer.
+
+- `claimAllRevenue`:
+  - Transfers all avaiable royalties from various royalty policies to the royalty vault of the ancestor IP -> Claims all the revenue in each currency token from the ancestor IP's royalty vault to the claimer.

--- a/test/integration/workflows/GroupingIntegration.t.sol
+++ b/test/integration/workflows/GroupingIntegration.t.sol
@@ -7,7 +7,6 @@ import { EvenSplitGroupPool } from "@storyprotocol/core/modules/grouping/EvenSpl
 import { IGroupingModule } from "@storyprotocol/core/interfaces/modules/grouping/IGroupingModule.sol";
 import { IGroupIPAssetRegistry } from "@storyprotocol/core/interfaces/registries/IGroupIPAssetRegistry.sol";
 import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
-import { IIpRoyaltyVault } from "@storyprotocol/core/interfaces/modules/royalty/policies/IIpRoyaltyVault.sol";
 import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
 /* solhint-disable max-line-length */
 import { IGraphAwareRoyaltyPolicy } from "@storyprotocol/core/interfaces/modules/royalty/policies/IGraphAwareRoyaltyPolicy.sol";
@@ -267,7 +266,6 @@ contract GroupingIntegration is BaseIntegration {
             address(StoryUSD),
             (amount1 * revShare) / royaltyModule.maxPercent()
         );
-        uint256 snapshotId1 = IIpRoyaltyVault(royaltyModule.ipRoyaltyVaults(newGroupId)).snapshot();
 
         uint256 amount2 = 10_000 * 10 ** StoryUSD.decimals(); // 10,000 tokens
         StoryUSD.mint(testSender, amount2);
@@ -279,18 +277,13 @@ contract GroupingIntegration is BaseIntegration {
             address(StoryUSD),
             (amount2 * revShare) / royaltyModule.maxPercent()
         );
-        uint256 snapshotId2 = IIpRoyaltyVault(royaltyModule.ipRoyaltyVaults(newGroupId)).snapshot();
 
-        uint256[] memory snapshotIds = new uint256[](2);
-        snapshotIds[0] = snapshotId1;
-        snapshotIds[1] = snapshotId2;
         address[] memory royaltyTokens = new address[](1);
         royaltyTokens[0] = address(StoryUSD);
 
         uint256[] memory collectedRoyalties = groupingWorkflows.collectRoyaltiesAndClaimReward(
             newGroupId,
             royaltyTokens,
-            snapshotIds,
             ipIds
         );
 

--- a/test/integration/workflows/RoyaltyIntegration.t.sol
+++ b/test/integration/workflows/RoyaltyIntegration.t.sol
@@ -38,77 +38,111 @@ contract RoyaltyIntegration is BaseIntegration {
 
     uint256 internal amountLicenseTokensToMint = 1;
 
-    uint256[] internal unclaimedSnapshotIds;
-
-    /// @notice This test can only be run when royalty module's snapshot interval is 0.
     /// @dev To use, run the following command:
     /// forge script test/integration/workflows/RoyaltyIntegration.t.sol:RoyaltyIntegration \
     /// --rpc-url=$TESTNET_URL -vvvv --broadcast --priority-gas-price=1 --legacy
     function run() public override {
         super.run();
         _beginBroadcast();
-        if (IVaultController(royaltyModuleAddr).snapshotInterval() != 0) {
-            console2.log("RoyaltyIntegration did not run: snapshot interval is not zero");
-            return;
-        }
         _setupTest();
-        _test_RoyaltyIntegration_transferToVaultAndSnapshotAndClaimByTokenBatch();
-        _test_RoyaltyIntegration_snapshotAndClaimByTokenBatch();
-        _test_RoyaltyIntegration_transferToVaultAndSnapshotAndClaimBySnapshotBatch();
-        _test_RoyaltyIntegration_snapshotAndClaimBySnapshotBatch();
+        _test_RoyaltyIntegration_transferToVaultAndClaimByTokenBatch();
+        _test_RoyaltyIntegration_claimAllRevenue();
         _endBroadcast();
     }
 
-    function _test_RoyaltyIntegration_transferToVaultAndSnapshotAndClaimByTokenBatch()
+    function _test_RoyaltyIntegration_transferToVaultAndClaimByTokenBatch()
         private
-        logTest("test_RoyaltyIntegration_transferToVaultAndSnapshotAndClaimByTokenBatch")
+        logTest("test_RoyaltyIntegration_transferToVaultAndClaimByTokenBatch")
     {
-        // setup IP graph with no snapshot
-        uint256 numSnapshots = 0;
-        _setupIpGraph(numSnapshots);
+        // setup IP graph
+        _setupIpGraph();
 
-        IRoyaltyWorkflows.RoyaltyClaimDetails[] memory claimDetails = new IRoyaltyWorkflows.RoyaltyClaimDetails[](4);
-        claimDetails[0] = IRoyaltyWorkflows.RoyaltyClaimDetails({
-            childIpId: childIpIdA,
-            royaltyPolicy: royaltyPolicyLRPAddr,
-            currencyToken: address(StoryUSD),
-            amount: (defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent() // 1000 * 10% = 100
+        address[] memory childIpIds = new address[](3);
+        address[] memory royaltyPolicies = new address[](3);
+        address[] memory currencyTokens = new address[](3);
+        uint256[] memory amounts = new uint256[](3);
+
+        childIpIds[0] = childIpIdA;
+        royaltyPolicies[0] = royaltyPolicyLRPAddr;
+        currencyTokens[0] = address(StoryUSD);
+        amounts[0] = 10 ether;
+
+        childIpIds[1] = childIpIdB;
+        royaltyPolicies[1] = royaltyPolicyLRPAddr;
+        currencyTokens[1] = address(StoryUSD);
+        amounts[1] = 10 ether;
+
+        childIpIds[2] = grandChildIpId;
+        royaltyPolicies[2] = royaltyPolicyLRPAddr;
+        currencyTokens[2] = address(StoryUSD);
+        amounts[2] = 2 ether;
+
+        childIpIds[3] = childIpIdC;
+        royaltyPolicies[3] = royaltyPolicyLAPAddr;
+        currencyTokens[3] = address(StoryUSD);
+        amounts[3] = 10 ether;
+
+        uint256 claimerBalanceBefore = StoryUSD.balanceOf(ancestorIpId);
+
+        uint256[] memory amountsClaimed = royaltyWorkflows.transferToVaultAndClaimByTokenBatch({
+            ancestorIpId: ancestorIpId,
+            claimer: ancestorIpId,
+            childIpIds: childIpIds,
+            royaltyPolicies: royaltyPolicies,
+            currencyTokens: currencyTokens,
+            amounts: amounts
         });
 
-        claimDetails[1] = IRoyaltyWorkflows.RoyaltyClaimDetails({
-            childIpId: childIpIdB,
-            royaltyPolicy: royaltyPolicyLRPAddr,
-            currencyToken: address(StoryUSD),
-            amount: (defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent() // 1000 * 10% = 100
+        uint256 claimerBalanceAfter = StoryUSD.balanceOf(ancestorIpId);
+
+        assertEq(amountsClaimed.length, 1); // there is 1 currency token
+        assertEq(claimerBalanceAfter - claimerBalanceBefore, amountsClaimed[0]);
+        assertEq(
+            claimerBalanceAfter - claimerBalanceBefore,
+            defaultMintingFeeA + defaultMintingFeeA + // 1000 + 1000 from minting fee of childIpA and childIpB
+                10 ether + // 10 currency tokens from childIpA transferred to vault
+                10 ether + // 10 currency tokens from childIpB transferred to vault
+                2 ether + // 2 currency tokens from grandChildIp transferred to vault
+                10 ether // 10 currency tokens from childIpC transferred to vault
+        );
+    }
+
+    function _test_RoyaltyIntegration_claimAllRevenue() private logTest("test_RoyaltyIntegration_claimAllRevenue") {
+        // setup IP graph
+        _setupIpGraph();
+
+        address[] memory childIpIds = new address[](3);
+        address[] memory royaltyPolicies = new address[](3);
+        address[] memory currencyTokens = new address[](3);
+
+        childIpIds[0] = childIpIdA;
+        royaltyPolicies[0] = royaltyPolicyLRPAddr;
+        currencyTokens[0] = address(StoryUSD);
+
+        childIpIds[1] = childIpIdB;
+        royaltyPolicies[1] = royaltyPolicyLRPAddr;
+        currencyTokens[1] = address(StoryUSD);
+
+        childIpIds[2] = grandChildIpId;
+        royaltyPolicies[2] = royaltyPolicyLRPAddr;
+        currencyTokens[2] = address(StoryUSD);
+
+        childIpIds[3] = childIpIdC;
+        royaltyPolicies[3] = royaltyPolicyLAPAddr;
+        currencyTokens[3] = address(StoryUSD);
+
+        uint256 claimerBalanceBefore = StoryUSD.balanceOf(ancestorIpId);
+
+        uint256[] memory amountsClaimed = royaltyWorkflows.claimAllRevenue({
+            ancestorIpId: ancestorIpId,
+            claimer: ancestorIpId,
+            childIpIds: childIpIds,
+            royaltyPolicies: royaltyPolicies,
+            currencyTokens: currencyTokens
         });
 
-        claimDetails[2] = IRoyaltyWorkflows.RoyaltyClaimDetails({
-            childIpId: grandChildIpId,
-            royaltyPolicy: royaltyPolicyLRPAddr,
-            currencyToken: address(StoryUSD),
-            amount: (((defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent()) *
-                defaultCommRevShareA) / royaltyModule.maxPercent() // 1000 * 10% * 10% * 2 = 20
-        });
+        uint256 claimerBalanceAfter = StoryUSD.balanceOf(ancestorIpId);
 
-        claimDetails[3] = IRoyaltyWorkflows.RoyaltyClaimDetails({
-            childIpId: childIpIdC,
-            royaltyPolicy: royaltyPolicyLAPAddr,
-            currencyToken: address(StoryUSD),
-            amount: (defaultMintingFeeC * defaultCommRevShareC) / royaltyModule.maxPercent() // 500 * 20% = 100
-        });
-
-        uint256 claimerBalanceBefore = StoryUSD.balanceOf(testSender);
-
-        (uint256 snapshotId, uint256[] memory amountsClaimed) = royaltyWorkflows
-            .transferToVaultAndSnapshotAndClaimByTokenBatch({
-                ancestorIpId: ancestorIpId,
-                claimer: testSender,
-                royaltyClaimDetails: claimDetails
-            });
-
-        uint256 claimerBalanceAfter = StoryUSD.balanceOf(testSender);
-
-        assertEq(snapshotId, numSnapshots + 1);
         assertEq(amountsClaimed.length, 1); // there is 1 currency token
         assertEq(claimerBalanceAfter - claimerBalanceBefore, amountsClaimed[0]);
         assertEq(
@@ -124,138 +158,6 @@ contract RoyaltyIntegration is BaseIntegration {
                 defaultMintingFeeC +
                 (defaultMintingFeeC * defaultCommRevShareC) /
                 royaltyModule.maxPercent() // 500 from from minting fee of childIpC,500 * 20% = 100 royalty from childIpC
-        );
-    }
-
-    function _test_RoyaltyIntegration_transferToVaultAndSnapshotAndClaimBySnapshotBatch()
-        private
-        logTest("test_RoyaltyIntegration_transferToVaultAndSnapshotAndClaimBySnapshotBatch")
-    {
-        // setup IP graph and takes 3 snapshots of ancestor IP's royalty vault
-        uint256 numSnapshots = 3;
-        _setupIpGraph(numSnapshots);
-
-        IRoyaltyWorkflows.RoyaltyClaimDetails[] memory claimDetails = new IRoyaltyWorkflows.RoyaltyClaimDetails[](4);
-        claimDetails[0] = IRoyaltyWorkflows.RoyaltyClaimDetails({
-            childIpId: childIpIdA,
-            royaltyPolicy: royaltyPolicyLRPAddr,
-            currencyToken: address(StoryUSD),
-            amount: (defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent() // 1000 * 10% = 100
-        });
-
-        claimDetails[1] = IRoyaltyWorkflows.RoyaltyClaimDetails({
-            childIpId: childIpIdB,
-            royaltyPolicy: royaltyPolicyLRPAddr,
-            currencyToken: address(StoryUSD),
-            amount: (defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent() // 1000 * 10% = 100
-        });
-
-        claimDetails[2] = IRoyaltyWorkflows.RoyaltyClaimDetails({
-            childIpId: grandChildIpId,
-            royaltyPolicy: royaltyPolicyLRPAddr,
-            currencyToken: address(StoryUSD),
-            amount: (((defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent()) *
-                defaultCommRevShareA) / royaltyModule.maxPercent() // 1000 * 10% * 10% = 10
-        });
-
-        claimDetails[3] = IRoyaltyWorkflows.RoyaltyClaimDetails({
-            childIpId: childIpIdC,
-            royaltyPolicy: royaltyPolicyLAPAddr,
-            currencyToken: address(StoryUSD),
-            amount: (defaultMintingFeeC * defaultCommRevShareC) / royaltyModule.maxPercent() // 500 * 20% = 100
-        });
-
-        uint256 claimerBalanceBefore = StoryUSD.balanceOf(testSender);
-
-        (uint256 snapshotId, uint256[] memory amountsClaimed) = royaltyWorkflows
-            .transferToVaultAndSnapshotAndClaimBySnapshotBatch({
-                ancestorIpId: ancestorIpId,
-                claimer: testSender,
-                unclaimedSnapshotIds: unclaimedSnapshotIds,
-                royaltyClaimDetails: claimDetails
-            });
-
-        uint256 claimerBalanceAfter = StoryUSD.balanceOf(testSender);
-
-        assertEq(snapshotId, numSnapshots + 1);
-        assertEq(amountsClaimed.length, 1); // there is 1 currency token
-        assertEq(claimerBalanceAfter - claimerBalanceBefore, amountsClaimed[0]);
-        assertEq(
-            claimerBalanceAfter - claimerBalanceBefore,
-            defaultMintingFeeA +
-                defaultMintingFeeA + // 1000 + 1000 from minting fee of childIpA and childIpB
-                (defaultMintingFeeA * defaultCommRevShareA) /
-                royaltyModule.maxPercent() + // 1000 * 10% = 100 royalty from childIpA
-                (defaultMintingFeeA * defaultCommRevShareA) /
-                royaltyModule.maxPercent() + // 1000 * 10% = 100 royalty from childIpB
-                (((defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent()) * defaultCommRevShareA) /
-                royaltyModule.maxPercent() + // 1000 * 10% * 10% = 10 royalty from grandChildIp
-                defaultMintingFeeC +
-                (defaultMintingFeeC * defaultCommRevShareC) /
-                royaltyModule.maxPercent() // 500 from from minting fee of childIpC, 500 * 20% = 100 royalty from childIpC
-        );
-    }
-
-    function _test_RoyaltyIntegration_snapshotAndClaimByTokenBatch()
-        private
-        logTest("test_RoyaltyIntegration_snapshotAndClaimByTokenBatch")
-    {
-        // setup IP graph with no snapshot
-        uint256 numSnapshots = 0;
-        _setupIpGraph(numSnapshots);
-
-        address[] memory currencyTokens = new address[](1);
-        currencyTokens[0] = address(StoryUSD);
-
-        uint256 claimerBalanceBefore = StoryUSD.balanceOf(testSender);
-
-        (uint256 snapshotId, uint256[] memory amountsClaimed) = royaltyWorkflows.snapshotAndClaimByTokenBatch({
-            ipId: ancestorIpId,
-            claimer: testSender,
-            currencyTokens: currencyTokens
-        });
-
-        uint256 claimerBalanceAfter = StoryUSD.balanceOf(testSender);
-
-        assertEq(snapshotId, numSnapshots + 1);
-        assertEq(amountsClaimed.length, 1); // there is 1 currency token
-        assertEq(claimerBalanceAfter - claimerBalanceBefore, amountsClaimed[0]);
-        assertEq(
-            claimerBalanceAfter - claimerBalanceBefore,
-            // 1000 + 1000 + 500 from minting fee of childIpA, childIpB, and childIpC
-            defaultMintingFeeA + defaultMintingFeeA + defaultMintingFeeC
-        );
-    }
-
-    function _test_RoyaltyIntegration_snapshotAndClaimBySnapshotBatch()
-        private
-        logTest("test_RoyaltyIntegration_snapshotAndClaimBySnapshotBatch")
-    {
-        // setup IP graph and takes 1 snapshot of ancestor IP's royalty vault
-        uint256 numSnapshots = 1;
-        _setupIpGraph(numSnapshots);
-
-        address[] memory currencyTokens = new address[](1);
-        currencyTokens[0] = address(StoryUSD);
-
-        uint256 claimerBalanceBefore = StoryUSD.balanceOf(testSender);
-
-        (uint256 snapshotId, uint256[] memory amountsClaimed) = royaltyWorkflows.snapshotAndClaimBySnapshotBatch({
-            ipId: ancestorIpId,
-            claimer: testSender,
-            unclaimedSnapshotIds: unclaimedSnapshotIds,
-            currencyTokens: currencyTokens
-        });
-
-        uint256 claimerBalanceAfter = StoryUSD.balanceOf(testSender);
-
-        assertEq(snapshotId, numSnapshots + 1);
-        assertEq(amountsClaimed.length, 1); // there is 1 currency token
-        assertEq(claimerBalanceAfter - claimerBalanceBefore, amountsClaimed[0]);
-        assertEq(
-            claimerBalanceAfter - claimerBalanceBefore,
-            // 1000 + 1000 + 500 from minting fee of childIpA, childIpB, and childIpC
-            defaultMintingFeeA + defaultMintingFeeA + defaultMintingFeeC
         );
     }
 
@@ -282,8 +184,7 @@ contract RoyaltyIntegration is BaseIntegration {
     /// - `childIpB`: It has licenseTermsA attached, has 1 parent `ancestorIp`, and has 1 grandchild `grandChildIp`.
     /// - `childIpC`: It has licenseTermsC attached, has 1 parent `ancestorIp`, and has 1 grandchild `grandChildIp`.
     /// - `grandChildIp`: It has all 3 license terms attached. It has 3 parents and 1 grandparent IPs.
-    /// @param numSnapshots The number of snapshots to take of the ancestor IP's royalty vault.
-    function _setupIpGraph(uint256 numSnapshots) private {
+    function _setupIpGraph() private {
         uint256 ancestorTokenId = spgNftContract.mint(testSender, "", bytes32(0), true);
         uint256 childTokenIdA = spgNftContract.mint(testSender, "", bytes32(0), true);
         uint256 childTokenIdB = spgNftContract.mint(testSender, "", bytes32(0), true);
@@ -302,8 +203,6 @@ contract RoyaltyIntegration is BaseIntegration {
             deadline: 0,
             signature: ""
         });
-
-        unclaimedSnapshotIds = new uint256[](numSnapshots);
 
         // register ancestor IP
         ancestorIpId = ipAssetRegistry.register(block.chainid, address(spgNftContract), ancestorTokenId);
@@ -396,29 +295,6 @@ contract RoyaltyIntegration is BaseIntegration {
             vm.label(childIpIdA, "ChildIpA");
         }
 
-        IpRoyaltyVault ancestorIpRoyaltyVault = IpRoyaltyVault(royaltyModule.ipRoyaltyVaults(ancestorIpId));
-
-        // transfer all ancestor royalties tokens to the claimer of the ancestor IP
-        {
-            bytes memory data = abi.encodeWithSelector(
-                ancestorIpRoyaltyVault.transfer.selector,
-                testSender,
-                ancestorIpRoyaltyVault.totalSupply()
-            );
-
-            IIPAccount(payable(ancestorIpId)).execute({ to: address(ancestorIpRoyaltyVault), value: 0, data: data });
-        }
-
-        // takes a snapshot of the ancestor IP's royalty vault and populates unclaimedSnapshotIds
-        // In this snapshot:
-        // - admin has all the royalty tokens from ancestorIp
-        // - ancestorIp's royalty vault has `defaultMintingFeeA` tokens from alice for registering childIpA
-        // as derivative of ancestorIp under Terms A
-        if (numSnapshots >= 1) {
-            unclaimedSnapshotIds[0] = ancestorIpRoyaltyVault.snapshot();
-            numSnapshots--;
-        }
-
         // register childIpB as derivative of ancestorIp under Terms A
         {
             (bytes memory sigRegister, , ) = _getSetPermissionSigForPeriphery({
@@ -459,16 +335,6 @@ contract RoyaltyIntegration is BaseIntegration {
             vm.label(childIpIdB, "ChildIpB");
         }
 
-        // takes a snapshot of the ancestor IP's royalty vault and populates unclaimedSnapshotIds
-        // In this snapshot:
-        // - admin has all the royalty tokens from ancestorIp
-        // - ancestorIp's royalty vault has `defaultMintingFeeA` tokens from bob for registering childIpB
-        // as derivative of ancestorIp under Terms A
-        if (numSnapshots >= 1) {
-            unclaimedSnapshotIds[1] = IpRoyaltyVault(royaltyModule.ipRoyaltyVaults(ancestorIpId)).snapshot();
-            numSnapshots--;
-        }
-
         /// register childIpC as derivative of ancestorIp under Terms C
         {
             (bytes memory sigRegister, , ) = _getSetPermissionSigForPeriphery({
@@ -507,16 +373,6 @@ contract RoyaltyIntegration is BaseIntegration {
                 })
             });
             vm.label(childIpIdC, "ChildIpC");
-        }
-
-        // takes a snapshot of the ancestor IP's royalty vault and populates unclaimedSnapshotIds
-        // In this snapshot:
-        // - admin has all the royalty tokens from ancestorIp
-        // - ancestorIp's royalty vault has `defaultMintingFeeC` tokens from carl for registering childIpC
-        // as derivative of ancestorIp under Terms C
-        if (numSnapshots >= 1) {
-            unclaimedSnapshotIds[2] = IpRoyaltyVault(royaltyModule.ipRoyaltyVaults(ancestorIpId)).snapshot();
-            numSnapshots--;
         }
 
         // register grandChildIp as derivative for childIp A and B under Terms A

--- a/test/integration/workflows/RoyaltyIntegration.t.sol
+++ b/test/integration/workflows/RoyaltyIntegration.t.sol
@@ -99,7 +99,8 @@ contract RoyaltyIntegration is BaseIntegration {
         assertEq(claimerBalanceAfter - claimerBalanceBefore, amountsClaimed[0]);
         assertEq(
             claimerBalanceAfter - claimerBalanceBefore,
-            defaultMintingFeeA + defaultMintingFeeA + // 1000 + 1000 from minting fee of childIpA and childIpB
+            defaultMintingFeeA +
+                defaultMintingFeeA + // 1000 + 1000 from minting fee of childIpA and childIpB
                 10 ether + // 10 currency tokens from childIpA transferred to vault
                 10 ether + // 10 currency tokens from childIpB transferred to vault
                 2 ether + // 2 currency tokens from grandChildIp transferred to vault

--- a/test/workflows/GroupingWorkflows.t.sol
+++ b/test/workflows/GroupingWorkflows.t.sol
@@ -354,7 +354,6 @@ contract GroupingWorkflowsTest is BaseTest {
             (amount1 * revShare) / royaltyModule.maxPercent()
         );
         vm.stopPrank();
-        uint256 snapshotId1 = IIpRoyaltyVault(royaltyModule.ipRoyaltyVaults(newGroupId)).snapshot();
 
         uint256 amount2 = 10_000 * 10 ** mockToken.decimals(); // 10,000 tokens
         mockToken.mint(ipOwner2, amount2);
@@ -368,18 +367,13 @@ contract GroupingWorkflowsTest is BaseTest {
             (amount2 * revShare) / royaltyModule.maxPercent()
         );
         vm.stopPrank();
-        uint256 snapshotId2 = IIpRoyaltyVault(royaltyModule.ipRoyaltyVaults(newGroupId)).snapshot();
 
-        uint256[] memory snapshotIds = new uint256[](2);
         address[] memory royaltyTokens = new address[](1);
-        snapshotIds[0] = snapshotId1;
-        snapshotIds[1] = snapshotId2;
         royaltyTokens[0] = address(mockToken);
 
         uint256[] memory collectedRoyalties = groupingWorkflows.collectRoyaltiesAndClaimReward(
             newGroupId,
             royaltyTokens,
-            snapshotIds,
             ipIds
         );
 
@@ -407,7 +401,7 @@ contract GroupingWorkflowsTest is BaseTest {
         snapshotIds[0] = 0;
 
         vm.expectRevert(Errors.GroupingWorkflows__ZeroAddressParam.selector);
-        groupingWorkflows.collectRoyaltiesAndClaimReward(groupId, currencyTokens, snapshotIds, ipIds);
+        groupingWorkflows.collectRoyaltiesAndClaimReward(groupId, currencyTokens, ipIds);
     }
 
     // Multicall (mint → Register IP → Attach PIL terms → Add new IP to group IPA)

--- a/test/workflows/RoyaltyWorkflows.t.sol
+++ b/test/workflows/RoyaltyWorkflows.t.sol
@@ -88,7 +88,8 @@ contract RoyaltyWorkflowsTest is BaseTest {
         assertEq(claimerBalanceCAfter - claimerBalanceCBefore, amountsClaimed[1]);
         assertEq(
             claimerBalanceAAfter - claimerBalanceABefore,
-            defaultMintingFeeA + defaultMintingFeeA + // 1000 + 1000 from minting fee of childIpA and childIpB
+            defaultMintingFeeA +
+                defaultMintingFeeA + // 1000 + 1000 from minting fee of childIpA and childIpB
                 10 ether + // 10 currency tokens from childIpA transferred to vault
                 10 ether + // 10 currency tokens from childIpB transferred to vault
                 1 ether // 1 currency token from grandChildIp transferred to vault

--- a/test/workflows/RoyaltyWorkflows.t.sol
+++ b/test/workflows/RoyaltyWorkflows.t.sol
@@ -3,13 +3,10 @@ pragma solidity 0.8.26;
 
 // external
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
-import { Errors as CoreErrors } from "@storyprotocol/core/lib/Errors.sol";
 import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
-import { IpRoyaltyVault } from "@storyprotocol/core/modules/royalty/policies/IpRoyaltyVault.sol";
 import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
 
 // contracts
-import { IRoyaltyWorkflows } from "../../contracts/interfaces/workflows/IRoyaltyWorkflows.sol";
 import { WorkflowStructs } from "../../contracts/lib/WorkflowStructs.sol";
 
 // test
@@ -37,64 +34,108 @@ contract RoyaltyWorkflowsTest is BaseTest {
 
     uint256 internal amountLicenseTokensToMint = 1;
 
-    uint256[] internal unclaimedSnapshotIds;
-
     function setUp() public override {
         super.setUp();
 
         _setupCurrencyTokens();
     }
 
-    function test_RoyaltyWorkflows_transferToVaultAndSnapshotAndClaimByTokenBatch() public {
-        // setup IP graph with no snapshot
-        uint256 numSnapshots = 0;
-        _setupIpGraph(numSnapshots);
+    function test_RoyaltyWorkflows_transferToVaultAndClaimByTokenBatch() public {
+        _setupIpGraph();
 
-        IRoyaltyWorkflows.RoyaltyClaimDetails[] memory claimDetails = new IRoyaltyWorkflows.RoyaltyClaimDetails[](4);
-        claimDetails[0] = IRoyaltyWorkflows.RoyaltyClaimDetails({
-            childIpId: childIpIdA,
-            royaltyPolicy: address(royaltyPolicyLRP),
-            currencyToken: address(mockTokenA),
-            amount: (defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent() // 1000 * 10% = 100
+        address[] memory childIpIds = new address[](4);
+        address[] memory royaltyPolicies = new address[](4);
+        address[] memory currencyTokens = new address[](4);
+        uint256[] memory amounts = new uint256[](4);
+
+        childIpIds[0] = childIpIdA;
+        royaltyPolicies[0] = address(royaltyPolicyLRP);
+        currencyTokens[0] = address(mockTokenA);
+        amounts[0] = 10 ether;
+
+        childIpIds[1] = childIpIdB;
+        royaltyPolicies[1] = address(royaltyPolicyLRP);
+        currencyTokens[1] = address(mockTokenA);
+        amounts[1] = 10 ether;
+
+        childIpIds[2] = grandChildIpId;
+        royaltyPolicies[2] = address(royaltyPolicyLRP);
+        currencyTokens[2] = address(mockTokenA);
+        amounts[2] = 1 ether;
+
+        childIpIds[3] = childIpIdC;
+        royaltyPolicies[3] = address(royaltyPolicyLAP);
+        currencyTokens[3] = address(mockTokenC);
+        amounts[3] = 10 ether;
+
+        uint256 claimerBalanceABefore = mockTokenA.balanceOf(ancestorIpId);
+        uint256 claimerBalanceCBefore = mockTokenC.balanceOf(ancestorIpId);
+
+        uint256[] memory amountsClaimed = royaltyWorkflows.transferToVaultAndClaimByTokenBatch({
+            ancestorIpId: ancestorIpId,
+            claimer: ancestorIpId,
+            childIpIds: childIpIds,
+            royaltyPolicies: royaltyPolicies,
+            currencyTokens: currencyTokens,
+            amounts: amounts
         });
 
-        claimDetails[1] = IRoyaltyWorkflows.RoyaltyClaimDetails({
-            childIpId: childIpIdB,
-            royaltyPolicy: address(royaltyPolicyLRP),
-            currencyToken: address(mockTokenA),
-            amount: (defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent() // 1000 * 10% = 100
+        uint256 claimerBalanceAAfter = mockTokenA.balanceOf(ancestorIpId);
+        uint256 claimerBalanceCAfter = mockTokenC.balanceOf(ancestorIpId);
+
+        assertEq(amountsClaimed.length, 2); // there are 2 currency tokens
+        assertEq(claimerBalanceAAfter - claimerBalanceABefore, amountsClaimed[0]);
+        assertEq(claimerBalanceCAfter - claimerBalanceCBefore, amountsClaimed[1]);
+        assertEq(
+            claimerBalanceAAfter - claimerBalanceABefore,
+            defaultMintingFeeA + defaultMintingFeeA + // 1000 + 1000 from minting fee of childIpA and childIpB
+                10 ether + // 10 currency tokens from childIpA transferred to vault
+                10 ether + // 10 currency tokens from childIpB transferred to vault
+                1 ether // 1 currency token from grandChildIp transferred to vault
+        );
+        assertEq(
+            claimerBalanceCAfter - claimerBalanceCBefore,
+            defaultMintingFeeC + 10 ether // 10 currency tokens from childIpC transferred to vault
+        );
+    }
+
+    function test_RoyaltyWorkflows_claimAllRevenue() public {
+        _setupIpGraph();
+
+        address[] memory childIpIds = new address[](4);
+        address[] memory royaltyPolicies = new address[](4);
+        address[] memory currencyTokens = new address[](4);
+
+        childIpIds[0] = childIpIdA;
+        royaltyPolicies[0] = address(royaltyPolicyLRP);
+        currencyTokens[0] = address(mockTokenA);
+
+        childIpIds[1] = childIpIdB;
+        royaltyPolicies[1] = address(royaltyPolicyLRP);
+        currencyTokens[1] = address(mockTokenA);
+
+        childIpIds[2] = grandChildIpId;
+        royaltyPolicies[2] = address(royaltyPolicyLRP);
+        currencyTokens[2] = address(mockTokenA);
+
+        childIpIds[3] = childIpIdC;
+        royaltyPolicies[3] = address(royaltyPolicyLAP);
+        currencyTokens[3] = address(mockTokenC);
+
+        uint256 claimerBalanceABefore = mockTokenA.balanceOf(ancestorIpId);
+        uint256 claimerBalanceCBefore = mockTokenC.balanceOf(ancestorIpId);
+
+        uint256[] memory amountsClaimed = royaltyWorkflows.claimAllRevenue({
+            ancestorIpId: ancestorIpId,
+            claimer: ancestorIpId,
+            childIpIds: childIpIds,
+            royaltyPolicies: royaltyPolicies,
+            currencyTokens: currencyTokens
         });
 
-        claimDetails[2] = IRoyaltyWorkflows.RoyaltyClaimDetails({
-            childIpId: grandChildIpId,
-            royaltyPolicy: address(royaltyPolicyLRP),
-            currencyToken: address(mockTokenA),
-            amount: (((defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent()) *
-                defaultCommRevShareA) / royaltyModule.maxPercent() // 1000 * 10% * 10% = 10
-            // TODO: should be (1000 * 10% * 10%) * 2 = 20 but MockIPGraph currently only supports single-path calculation
-        });
+        uint256 claimerBalanceAAfter = mockTokenA.balanceOf(ancestorIpId);
+        uint256 claimerBalanceCAfter = mockTokenC.balanceOf(ancestorIpId);
 
-        claimDetails[3] = IRoyaltyWorkflows.RoyaltyClaimDetails({
-            childIpId: childIpIdC,
-            royaltyPolicy: address(royaltyPolicyLAP),
-            currencyToken: address(mockTokenC),
-            amount: (defaultMintingFeeC * defaultCommRevShareC) / royaltyModule.maxPercent() // 500 * 20% = 100
-        });
-
-        uint256 claimerBalanceABefore = mockTokenA.balanceOf(u.admin);
-        uint256 claimerBalanceCBefore = mockTokenC.balanceOf(u.admin);
-
-        (uint256 snapshotId, uint256[] memory amountsClaimed) = royaltyWorkflows
-            .transferToVaultAndSnapshotAndClaimByTokenBatch({
-                ancestorIpId: ancestorIpId,
-                claimer: u.admin,
-                royaltyClaimDetails: claimDetails
-            });
-
-        uint256 claimerBalanceAAfter = mockTokenA.balanceOf(u.admin);
-        uint256 claimerBalanceCAfter = mockTokenC.balanceOf(u.admin);
-
-        assertEq(snapshotId, numSnapshots + 1);
         assertEq(amountsClaimed.length, 2); // there are 2 currency tokens
         assertEq(claimerBalanceAAfter - claimerBalanceABefore, amountsClaimed[0]);
         assertEq(claimerBalanceCAfter - claimerBalanceCBefore, amountsClaimed[1]);
@@ -114,213 +155,6 @@ contract RoyaltyWorkflowsTest is BaseTest {
             claimerBalanceCAfter - claimerBalanceCBefore,
             defaultMintingFeeC + (defaultMintingFeeC * defaultCommRevShareC) / royaltyModule.maxPercent() // 500 from from minting fee of childIpC, 500 * 20% = 100 royalty from childIpC
         );
-    }
-
-    function test_RoyaltyWorkflows_transferToVaultAndSnapshotAndClaimBySnapshotBatch() public {
-        // setup IP graph and takes 3 snapshots of ancestor IP's royalty vault
-        uint256 numSnapshots = 3;
-        _setupIpGraph(numSnapshots);
-
-        IRoyaltyWorkflows.RoyaltyClaimDetails[] memory claimDetails = new IRoyaltyWorkflows.RoyaltyClaimDetails[](4);
-        claimDetails[0] = IRoyaltyWorkflows.RoyaltyClaimDetails({
-            childIpId: childIpIdA,
-            royaltyPolicy: address(royaltyPolicyLRP),
-            currencyToken: address(mockTokenA),
-            amount: (defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent() // 1000 * 10% = 100
-        });
-
-        claimDetails[1] = IRoyaltyWorkflows.RoyaltyClaimDetails({
-            childIpId: childIpIdB,
-            royaltyPolicy: address(royaltyPolicyLRP),
-            currencyToken: address(mockTokenA),
-            amount: (defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent() // 1000 * 10% = 100
-        });
-
-        claimDetails[2] = IRoyaltyWorkflows.RoyaltyClaimDetails({
-            childIpId: grandChildIpId,
-            royaltyPolicy: address(royaltyPolicyLRP),
-            currencyToken: address(mockTokenA),
-            amount: (((defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent()) *
-                defaultCommRevShareA) / royaltyModule.maxPercent() // 1000 * 10% * 10% = 10
-        });
-
-        claimDetails[3] = IRoyaltyWorkflows.RoyaltyClaimDetails({
-            childIpId: childIpIdC,
-            royaltyPolicy: address(royaltyPolicyLAP),
-            currencyToken: address(mockTokenC),
-            amount: (defaultMintingFeeC * defaultCommRevShareC) / royaltyModule.maxPercent() // 500 * 20% = 100
-        });
-
-        uint256 claimerBalanceABefore = mockTokenA.balanceOf(u.admin);
-        uint256 claimerBalanceCBefore = mockTokenC.balanceOf(u.admin);
-
-        (uint256 snapshotId, uint256[] memory amountsClaimed) = royaltyWorkflows
-            .transferToVaultAndSnapshotAndClaimBySnapshotBatch({
-                ancestorIpId: ancestorIpId,
-                claimer: u.admin,
-                unclaimedSnapshotIds: unclaimedSnapshotIds,
-                royaltyClaimDetails: claimDetails
-            });
-
-        uint256 claimerBalanceAAfter = mockTokenA.balanceOf(u.admin);
-        uint256 claimerBalanceCAfter = mockTokenC.balanceOf(u.admin);
-
-        assertEq(snapshotId, numSnapshots + 1);
-        assertEq(amountsClaimed.length, 2); // there are 2 currency tokens
-        assertEq(claimerBalanceAAfter - claimerBalanceABefore, amountsClaimed[0]);
-        assertEq(claimerBalanceCAfter - claimerBalanceCBefore, amountsClaimed[1]);
-        assertEq(
-            claimerBalanceAAfter - claimerBalanceABefore,
-            defaultMintingFeeA +
-                defaultMintingFeeA + // 1000 + 1000 from minting fee of childIpA and childIpB
-                (defaultMintingFeeA * defaultCommRevShareA) /
-                royaltyModule.maxPercent() + // 1000 * 10% = 100 royalty from childIpA
-                (defaultMintingFeeA * defaultCommRevShareA) /
-                royaltyModule.maxPercent() + // 1000 * 10% = 100 royalty from childIpB
-                (((defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent()) * defaultCommRevShareA) /
-                royaltyModule.maxPercent() // 1000 * 10% * 10% = 10 royalty from grandChildIp
-        );
-        assertEq(
-            claimerBalanceCAfter - claimerBalanceCBefore,
-            defaultMintingFeeC + (defaultMintingFeeC * defaultCommRevShareC) / royaltyModule.maxPercent() // 500 from minting fee of childIpC, 500 * 20% = 100 royalty from childIpC
-        );
-    }
-
-    function test_RoyaltyWorkflows_revert_transferToVaultAndSnapshotAndClaimBySnapshotBatch() public {
-        // setup IP graph and takes 3 snapshots of ancestor IP's royalty vault
-        uint256 numSnapshots = 3;
-        _setupIpGraph(numSnapshots);
-
-        IRoyaltyWorkflows.RoyaltyClaimDetails[] memory claimDetails = new IRoyaltyWorkflows.RoyaltyClaimDetails[](4);
-        claimDetails[0] = IRoyaltyWorkflows.RoyaltyClaimDetails({
-            childIpId: childIpIdA,
-            royaltyPolicy: address(royaltyPolicyLRP),
-            currencyToken: address(mockTokenA),
-            amount: (defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent() // 1000 * 10% = 100
-        });
-
-        claimDetails[1] = IRoyaltyWorkflows.RoyaltyClaimDetails({
-            childIpId: childIpIdB,
-            royaltyPolicy: address(royaltyPolicyLRP),
-            currencyToken: address(mockTokenA),
-            amount: (defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent() // 1000 * 10% = 100
-        });
-
-        claimDetails[2] = IRoyaltyWorkflows.RoyaltyClaimDetails({
-            childIpId: grandChildIpId,
-            royaltyPolicy: address(royaltyPolicyLRP),
-            currencyToken: address(mockTokenA),
-            amount: (((defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent()) *
-                defaultCommRevShareA) / royaltyModule.maxPercent() // 1000 * 10% * 10% = 10
-        });
-
-        claimDetails[3] = IRoyaltyWorkflows.RoyaltyClaimDetails({
-            childIpId: childIpIdC,
-            royaltyPolicy: address(royaltyPolicyLAP),
-            currencyToken: address(mockTokenC),
-            amount: (defaultMintingFeeC * defaultCommRevShareC) / royaltyModule.maxPercent() // 500 * 20% = 100
-        });
-
-        address ancestorVault = royaltyModule.ipRoyaltyVaults(ancestorIpId);
-
-        vm.expectRevert(CoreErrors.IpRoyaltyVault__VaultsMustClaimAsSelf.selector);
-        royaltyWorkflows.transferToVaultAndSnapshotAndClaimBySnapshotBatch({
-            ancestorIpId: ancestorIpId,
-            claimer: ancestorVault,
-            unclaimedSnapshotIds: unclaimedSnapshotIds,
-            royaltyClaimDetails: claimDetails
-        });
-    }
-
-    function test_RoyaltyWorkflows_snapshotAndClaimByTokenBatch() public {
-        // setup IP graph with no snapshot
-        uint256 numSnapshots = 0;
-        _setupIpGraph(numSnapshots);
-
-        address[] memory currencyTokens = new address[](2);
-        currencyTokens[0] = address(mockTokenA);
-        currencyTokens[1] = address(mockTokenC);
-
-        uint256 claimerBalanceABefore = mockTokenA.balanceOf(u.admin);
-        uint256 claimerBalanceCBefore = mockTokenC.balanceOf(u.admin);
-
-        (uint256 snapshotId, uint256[] memory amountsClaimed) = royaltyWorkflows.snapshotAndClaimByTokenBatch({
-            ipId: ancestorIpId,
-            claimer: u.admin,
-            currencyTokens: currencyTokens
-        });
-
-        uint256 claimerBalanceAAfter = mockTokenA.balanceOf(u.admin);
-        uint256 claimerBalanceCAfter = mockTokenC.balanceOf(u.admin);
-
-        assertEq(snapshotId, numSnapshots + 1);
-        assertEq(amountsClaimed.length, 2); // there are 2 currency tokens
-        assertEq(claimerBalanceAAfter - claimerBalanceABefore, amountsClaimed[0]);
-        assertEq(claimerBalanceCAfter - claimerBalanceCBefore, amountsClaimed[1]);
-        assertEq(
-            claimerBalanceAAfter - claimerBalanceABefore,
-            defaultMintingFeeA + defaultMintingFeeA // 1000 + 1000 from minting fee of childIpA and childIpB
-        );
-        assertEq(
-            claimerBalanceCAfter - claimerBalanceCBefore,
-            defaultMintingFeeC // 500 from from minting fee of childIpC
-        );
-    }
-
-    function test_RoyaltyWorkflows_snapshotAndClaimBySnapshotBatch() public {
-        // setup IP graph and takes 1 snapshot of ancestor IP's royalty vault
-        uint256 numSnapshots = 1;
-        _setupIpGraph(numSnapshots);
-
-        address[] memory currencyTokens = new address[](2);
-        currencyTokens[0] = address(mockTokenA);
-        currencyTokens[1] = address(mockTokenC);
-
-        uint256 claimerBalanceABefore = mockTokenA.balanceOf(u.admin);
-        uint256 claimerBalanceCBefore = mockTokenC.balanceOf(u.admin);
-
-        (uint256 snapshotId, uint256[] memory amountsClaimed) = royaltyWorkflows.snapshotAndClaimBySnapshotBatch({
-            ipId: ancestorIpId,
-            claimer: u.admin,
-            unclaimedSnapshotIds: unclaimedSnapshotIds,
-            currencyTokens: currencyTokens
-        });
-
-        uint256 claimerBalanceAAfter = mockTokenA.balanceOf(u.admin);
-        uint256 claimerBalanceCAfter = mockTokenC.balanceOf(u.admin);
-
-        assertEq(snapshotId, numSnapshots + 1);
-        assertEq(amountsClaimed.length, 2); // there are 2 currency tokens
-        assertEq(claimerBalanceAAfter - claimerBalanceABefore, amountsClaimed[0]);
-        assertEq(claimerBalanceCAfter - claimerBalanceCBefore, amountsClaimed[1]);
-        assertEq(
-            claimerBalanceAAfter - claimerBalanceABefore,
-            defaultMintingFeeA + defaultMintingFeeA // 1000 + 1000 from minting fee of childIpA and childIpB
-        );
-        assertEq(
-            claimerBalanceCAfter - claimerBalanceCBefore,
-            defaultMintingFeeC // 500 from from minting fee of childIpC
-        );
-    }
-
-    function test_RoyaltyWorkflows_revert_snapshotAndClaimBySnapshotBatch() public {
-        // setup IP graph and takes 1 snapshot of ancestor IP's royalty vault
-        uint256 numSnapshots = 1;
-        _setupIpGraph(numSnapshots);
-
-        address[] memory currencyTokens = new address[](2);
-        currencyTokens[0] = address(mockTokenA);
-        currencyTokens[1] = address(mockTokenC);
-
-        address ancestorVault = royaltyModule.ipRoyaltyVaults(ancestorIpId);
-
-        vm.expectRevert(CoreErrors.IpRoyaltyVault__VaultsMustClaimAsSelf.selector);
-        royaltyWorkflows.snapshotAndClaimBySnapshotBatch({
-            ipId: ancestorIpId,
-            claimer: ancestorVault,
-            unclaimedSnapshotIds: unclaimedSnapshotIds,
-            currencyTokens: currencyTokens
-        });
     }
 
     function _setupCurrencyTokens() private {
@@ -363,8 +197,7 @@ contract RoyaltyWorkflowsTest is BaseTest {
     /// - `childIpB`: It has licenseTermsA attached, has 1 parent `ancestorIp`, and has 1 grandchild `grandChildIp`.
     /// - `childIpC`: It has licenseTermsC attached, has 1 parent `ancestorIp`, and has 1 grandchild `grandChildIp`.
     /// - `grandChildIp`: It has all 3 license terms attached. It has 3 parents and 1 grandparent IPs.
-    /// @param numSnapshots The number of snapshots to take of the ancestor IP's royalty vault.
-    function _setupIpGraph(uint256 numSnapshots) private {
+    function _setupIpGraph() private {
         uint256 ancestorTokenId = mockNft.mint(u.admin);
         uint256 childTokenIdA = mockNft.mint(u.alice);
         uint256 childTokenIdB = mockNft.mint(u.bob);
@@ -383,8 +216,6 @@ contract RoyaltyWorkflowsTest is BaseTest {
             deadline: 0,
             signature: ""
         });
-
-        unclaimedSnapshotIds = new uint256[](numSnapshots);
 
         // register ancestor IP
         ancestorIpId = ipAssetRegistry.register(block.chainid, address(mockNft), ancestorTokenId);
@@ -481,25 +312,6 @@ contract RoyaltyWorkflowsTest is BaseTest {
             vm.label(childIpIdA, "ChildIpA");
         }
 
-        IpRoyaltyVault ancestorIpRoyaltyVault = IpRoyaltyVault(royaltyModule.ipRoyaltyVaults(ancestorIpId));
-
-        // transfer all ancestor royalties tokens to the claimer of the ancestor IP
-        {
-            vm.startPrank(ancestorIpId);
-            ancestorIpRoyaltyVault.transfer(u.admin, ancestorIpRoyaltyVault.totalSupply());
-            vm.stopPrank();
-        }
-
-        // takes a snapshot of the ancestor IP's royalty vault and populates unclaimedSnapshotIds
-        // In this snapshot:
-        // - admin has all the royalty tokens from ancestorIp
-        // - ancestorIp's royalty vault has `defaultMintingFeeA` tokens from alice for registering childIpA
-        // as derivative of ancestorIp under Terms A
-        if (numSnapshots >= 1) {
-            unclaimedSnapshotIds[0] = ancestorIpRoyaltyVault.snapshot();
-            numSnapshots--;
-        }
-
         // register childIpB as derivative of ancestorIp under Terms A
         {
             (bytes memory sigRegisterBob, , ) = _getSetPermissionSigForPeriphery({
@@ -541,16 +353,6 @@ contract RoyaltyWorkflowsTest is BaseTest {
             vm.label(childIpIdB, "ChildIpB");
         }
 
-        // takes a snapshot of the ancestor IP's royalty vault and populates unclaimedSnapshotIds
-        // In this snapshot:
-        // - admin has all the royalty tokens from ancestorIp
-        // - ancestorIp's royalty vault has `defaultMintingFeeA` tokens from bob for registering childIpB
-        // as derivative of ancestorIp under Terms A
-        if (numSnapshots >= 1) {
-            unclaimedSnapshotIds[1] = IpRoyaltyVault(royaltyModule.ipRoyaltyVaults(ancestorIpId)).snapshot();
-            numSnapshots--;
-        }
-
         /// register childIpC as derivative of ancestorIp under Terms C
         {
             (bytes memory sigRegisterCarl, , ) = _getSetPermissionSigForPeriphery({
@@ -590,16 +392,6 @@ contract RoyaltyWorkflowsTest is BaseTest {
             });
             vm.stopPrank();
             vm.label(childIpIdC, "ChildIpC");
-        }
-
-        // takes a snapshot of the ancestor IP's royalty vault and populates unclaimedSnapshotIds
-        // In this snapshot:
-        // - admin has all the royalty tokens from ancestorIp
-        // - ancestorIp's royalty vault has `defaultMintingFeeC` tokens from carl for registering childIpC
-        // as derivative of ancestorIp under Terms C
-        if (numSnapshots >= 1) {
-            unclaimedSnapshotIds[2] = IpRoyaltyVault(royaltyModule.ipRoyaltyVaults(ancestorIpId)).snapshot();
-            numSnapshots--;
         }
 
         // register grandChildIp as derivative for childIp A and B under Terms A

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,27 +8,18 @@
   integrity sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==
 
 "@babel/code-frame@^7.0.0":
-  version "7.25.7"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.25.7.tgz#438f2c524071531d643c6f0188e1e28f130cebc7"
-  integrity sha512-0xZJFNE5XMpENsgfHYTw8FbX4kv53mFLn2i3XPoq69LyhYSCBJtitaHx9QnsVTrsogI4Z3+HtEfZ2/GFPOtf5g==
+  version "7.26.2"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.26.2.tgz#4b5fab97d33338eff916235055f0ebc21e573a85"
+  integrity sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==
   dependencies:
-    "@babel/highlight" "^7.25.7"
-    picocolors "^1.0.0"
-
-"@babel/helper-validator-identifier@^7.25.7":
-  version "7.25.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.7.tgz#77b7f60c40b15c97df735b38a66ba1d7c3e93da5"
-  integrity sha512-AM6TzwYqGChO45oiuPqwL2t20/HdMC1rTPAesnBCgPCSF1x3oN9MVUwQV2iyz4xqWrctwK5RNC8LV22kaQCNYg==
-
-"@babel/highlight@^7.25.7":
-  version "7.25.7"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.25.7.tgz#20383b5f442aa606e7b5e3043b0b1aafe9f37de5"
-  integrity sha512-iYyACpW3iW8Fw+ZybQK+drQre+ns/tKpXbNESfrhNnPLIklLbXr7MYJ6gPEd0iETGLOK+SxMjVvKb/ffmk+FEw==
-  dependencies:
-    "@babel/helper-validator-identifier" "^7.25.7"
-    chalk "^2.4.2"
+    "@babel/helper-validator-identifier" "^7.25.9"
     js-tokens "^4.0.0"
     picocolors "^1.0.0"
+
+"@babel/helper-validator-identifier@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz#24b64e2c3ec7cd3b3c547729b8d16871f22cbdc7"
+  integrity sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==
 
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
@@ -38,16 +29,16 @@
     "@jridgewell/trace-mapping" "0.3.9"
 
 "@eslint-community/eslint-utils@^4.2.0":
-  version "4.4.0"
-  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz#a23514e8fb9af1269d5f7788aa556798d61c6b59"
-  integrity sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz#d1145bf2c20132d6400495d6df4bf59362fd9d56"
+  integrity sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==
   dependencies:
-    eslint-visitor-keys "^3.3.0"
+    eslint-visitor-keys "^3.4.3"
 
 "@eslint-community/regexpp@^4.6.1":
-  version "4.11.1"
-  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.11.1.tgz#a547badfc719eb3e5f4b556325e542fbe9d7a18f"
-  integrity sha512-m4DVN9ZqskZoLU5GlWZadwDnYo3vAEydiUayB9widCl9ffWx2IvPnp6n3on5rJmziJSw9Bv+Z3ChDVdMwXCY8Q==
+  version "4.12.1"
+  resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.12.1.tgz#cfc6cffe39df390a3841cde2abccf92eaa7ae0e0"
+  integrity sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==
 
 "@eslint/eslintrc@^2.1.4":
   version "2.1.4"
@@ -347,11 +338,6 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@openzeppelin/contracts-upgradeable-v4@npm:@openzeppelin/contracts-upgradeable@4.9.6":
-  version "4.9.6"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.9.6.tgz#38b21708a719da647de4bb0e4802ee235a0d24df"
-  integrity sha512-m4iHazOsOCv1DgM7eD7GupTJ+NFVujRZt1wzddDPSVGpWdKq1SKkla5htKG7+IS4d2XOCtzkUNwRZ7Vq5aEUMA==
-
 "@openzeppelin/contracts-upgradeable@5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-5.0.1.tgz#ebc163cbed2de6b8b69bff628261d18deb912a81"
@@ -441,11 +427,10 @@
 
 "@story-protocol/protocol-core@github:storyprotocol/protocol-core-v1#main":
   version "1.1.0"
-  resolved "https://codeload.github.com/storyprotocol/protocol-core-v1/tar.gz/3ef2a99a99192587d24b4805d5848e3a799dcf5e"
+  resolved "https://codeload.github.com/storyprotocol/protocol-core-v1/tar.gz/c1b0f11f7ad41a3525b13ca09423e87be5ee2d93"
   dependencies:
     "@openzeppelin/contracts" "5.0.2"
     "@openzeppelin/contracts-upgradeable" "5.0.2"
-    "@openzeppelin/contracts-upgradeable-v4" "npm:@openzeppelin/contracts-upgradeable@4.9.6"
     erc6551 "^0.3.1"
     solady "^0.0.192"
 
@@ -495,11 +480,11 @@
   integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
 "@types/node@*":
-  version "22.7.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.7.7.tgz#6cd9541c3dccb4f7e8b141b491443f4a1570e307"
-  integrity sha512-SRxCrrg9CL/y54aiMCG3edPKdprgMVGDXjA3gB8UmmBW5TcXzRUYAh8EWzTnSJFAd1rgImPELza+A3bJ+qxz8Q==
+  version "22.9.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.9.0.tgz#b7f16e5c3384788542c72dc3d561a7ceae2c0365"
+  integrity sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==
   dependencies:
-    undici-types "~6.19.2"
+    undici-types "~6.19.8"
 
 "@types/node@22.7.5":
   version "22.7.5"
@@ -541,9 +526,9 @@ acorn-walk@^8.1.1:
     acorn "^8.11.0"
 
 acorn@^8.11.0, acorn@^8.4.1, acorn@^8.9.0:
-  version "8.13.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.13.0.tgz#2a30d670818ad16ddd6a35d3842dacec9e5d7ca3"
-  integrity sha512-8zSiw54Oxrdym50NlZ9sUusyO1Z1ZchgRLWRaK6c86XJFClyCgFKetdowBg5bKxyp/u+CDBJG4Mpp0m3HLZl9w==
+  version "8.14.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.0.tgz#063e2c70cac5fb4f6467f0b11152e04c682795b0"
+  integrity sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==
 
 aes-js@4.0.0-beta.5:
   version "4.0.0-beta.5"
@@ -680,9 +665,9 @@ bn.js@4.11.6:
   integrity sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA==
 
 bn.js@^4.11.9:
-  version "4.12.0"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
-  integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
+  version "4.12.1"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.1.tgz#215741fe3c9dba2d7e12c001d0cfdbae43975ba7"
+  integrity sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg==
 
 bn.js@^5.2.1:
   version "5.2.1"
@@ -750,9 +735,9 @@ camelcase@^6.0.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 chai@^5.0.3:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/chai/-/chai-5.1.1.tgz#f035d9792a22b481ead1c65908d14bb62ec1c82c"
-  integrity sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-5.1.2.tgz#3afbc340b994ae3610ca519a6c70ace77ad4378d"
+  integrity sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==
   dependencies:
     assertion-error "^2.0.1"
     check-error "^2.1.1"
@@ -884,9 +869,9 @@ create-require@^1.1.0:
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
 cross-spawn@^7.0.2:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
-  integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.5.tgz#910aac880ff5243da96b728bc6521a5f6c2f2f82"
+  integrity sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==
   dependencies:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
@@ -1045,7 +1030,7 @@ eslint-scope@^7.2.2:
     esrecurse "^4.3.0"
     estraverse "^5.2.0"
 
-eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4.3:
+eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4.3:
   version "3.4.3"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
@@ -1864,9 +1849,9 @@ mkdirp@^1.0.4:
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
 mocha@^10.2.0:
-  version "10.7.3"
-  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.7.3.tgz#ae32003cabbd52b59aece17846056a68eb4b0752"
-  integrity sha512-uQWxAu44wwiACGqjbPYmjo7Lg8sFrS3dQe7PP2FQI+woptP4vZXSMcfMyFL/e1yFEeEpV4RtyTpZROOKmxis+A==
+  version "10.8.2"
+  resolved "https://registry.yarnpkg.com/mocha/-/mocha-10.8.2.tgz#8d8342d016ed411b12a429eb731b825f961afb96"
+  integrity sha512-VZlYo/WE8t1tstuRmqgeyBgCbJc/lEdopaa+axcKzTBJ+UIdlAB9XnmvTCAH4pwR4ElNInaedhEBmZD8iCSVEg==
   dependencies:
     ansi-colors "^4.1.3"
     browser-stdout "^1.3.1"
@@ -2540,9 +2525,9 @@ tslib@2.7.0:
   integrity sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==
 
 tslib@^2.6.2:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.0.tgz#d124c86c3c05a40a91e6fdea4021bd31d377971b"
-  integrity sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -2594,7 +2579,7 @@ uglify-js@^3.1.4:
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.19.3.tgz#82315e9bbc6f2b25888858acd1fff8441035b77f"
   integrity sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==
 
-undici-types@~6.19.2:
+undici-types@~6.19.2, undici-types@~6.19.8:
   version "6.19.8"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
   integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==


### PR DESCRIPTION
## Description
This PR simplifies `RoyaltyWorkflows` and `GroupingWorkflows` to use the updated royalty vault API, introduced in [PR#291](https://github.com/storyprotocol/protocol-core-v1/pull/291/) of the core protocol, which simplifies the royalty claiming process by removing the need for snapshots.

#### Key Changes
- Removed the following functions from `RoyaltyWorkflows`:
  - `transferToVaultAndSnapshotAndClaimBySnapshotBatch`
  - `snapshotAndClaimBySnapshotBatch`
  - `snapshotAndClaimByTokenBatch`
- Modified `transferToVaultAndSnapshotAndClaimBySnapshotBatch` in `RoyaltyWorkflows` to remove snapshot logic and renamed it to `transferToVaultAndClaimByTokenBatch`.
- Added `claimAllRevenue` in `RoyaltyWorkflows` to allow claiming all available revenue for an ancestor IP.
- Removed snapshot logic from `collectRoyaltiesAndClaimReward` in `GroupingWorkflows`.
- Updated tests and documentation to reflect these changes.

## Test Plan
New test cases were added for the `claimAllRevenue` function, and existing unit and integration tests for `RoyaltyWorkflows` and `GroupingWorkflows` were updated.

## Related Issue
- Closes #112 

## Notes
This PR introduces major interface changes to `RoyaltyWorkflows`.