### PR TITLE
feat(licensing): support custom license templates and decouple terms registration from attachment

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ function mintAndRegisterIpAndAttachPILTerms(
   address nftContract,
   address recipient,
   IPMetadata calldata ipMetadata,
-  PILTerms calldata terms
+  PILTerms calldata terms,
+  bool allowDuplicates
 ) external onlyCallerWithMinterRole(nftContract) returns (address ipId, uint256 tokenId, uint256 licenseTermsId)
 ```
 

--- a/contracts/interfaces/workflows/ILicenseAttachmentWorkflows.sol
+++ b/contracts/interfaces/workflows/ILicenseAttachmentWorkflows.sol
@@ -8,25 +8,13 @@ import { WorkflowStructs } from "../../lib/WorkflowStructs.sol";
 /// @title License Attachment Workflows Interface
 /// @notice Interface for IP license attachment workflows.
 interface ILicenseAttachmentWorkflows {
-    /// @notice Register Programmable IP License Terms (if unregistered) and attach it to IP.
-    /// @param ipId The ID of the IP.
-    /// @param terms The PIL terms to be registered.
-    /// @param sigAttach Signature data for attachLicenseTerms to the IP via the Licensing Module.
-    /// @return licenseTermsId The ID of the newly registered PIL terms.
-    function registerPILTermsAndAttach(
-        address ipId,
-        PILTerms calldata terms,
-        WorkflowStructs.SignatureData calldata sigAttach
-    ) external returns (uint256 licenseTermsId);
-
-    /// @notice Mint an NFT from a SPGNFT collection, register it with metadata as an IP,
-    /// register Programmable IPLicense
-    /// Terms (if unregistered), and attach it to the registered IP.
+    /// @notice Mint an NFT from a SPGNFT collection, register it as an IP, attach provided IP metadata,
+    /// register Programmable IPLicense Terms (if unregistered), and attach it to the newly registered IP.
     /// @dev Requires caller to have the minter role or the SPG NFT to allow public minting.
     /// @param spgNftContract The address of the SPGNFT collection.
     /// @param recipient The address of the recipient of the minted NFT.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
-    /// @param terms The PIL terms to be registered.
+    /// @param terms The PIL terms to be registered and attached to the newly registered IP.
     /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
     /// @return ipId The ID of the newly registered IP.
     /// @return tokenId The ID of the newly minted NFT.
@@ -39,23 +27,47 @@ interface ILicenseAttachmentWorkflows {
         bool allowDuplicates
     ) external returns (address ipId, uint256 tokenId, uint256 licenseTermsId);
 
-    /// @notice Register a given NFT as an IP and attach Programmable IP License Terms.
-    /// @dev Because IP Account is created in this function, we need to set the permission via signature to allow this
-    /// contract to attach PIL Terms to the newly created IP Account in the same function.
+    /// @notice Mint an NFT from a SPGNFT collection, register as an IP, attach provided IP metadata,
+    /// and attach the provided license terms to the newly registered IP.
+    /// @dev Requires caller to have the minter role or the SPG NFT to allow public minting.
+    /// @param spgNftContract The address of the SPGNFT collection.
+    /// @param recipient The address of the recipient of the newly minted NFT.
+    /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
+    /// @param licenseTemplate The address of the license template used of the license terms to be attached.
+    /// @param licenseTermsId The ID of the license terms to attach. Must be a valid ID that exists
+    ///        in the specified license template.
+    /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
+    /// @return ipId The ID of the newly registered IP.
+    /// @return tokenId The ID of the newly minted NFT.
+    function mintAndRegisterIpAndAttachLicenseTerms(
+        address spgNftContract,
+        address recipient,
+        WorkflowStructs.IPMetadata calldata ipMetadata,
+        address licenseTemplate,
+        uint256 licenseTermsId,
+        bool allowDuplicates
+    ) external returns (address ipId, uint256 tokenId);
+
+    /// @notice Register a given NFT as an IP, attach provided IP metadata, and attach the provided license terms to the
+    ///         newly registered IP.
+    /// @dev Since IP Account is created in this function, we need signatures to allow this contract to set metadata
+    ///      and attach PIL Terms to the newly created IP Account on behalf of the owner.
     /// @param nftContract The address of the NFT collection.
     /// @param tokenId The ID of the NFT.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
-    /// @param terms The PIL terms to be registered.
+    /// @param licenseTemplate The address of the license template used of the license terms to be attached.
+    /// @param licenseTermsId The ID of the license terms to attach. Must be a valid ID that exists
+    ///        in the specified license template.
     /// @param sigMetadata OPTIONAL. Signature data for setAll (metadata) for the IP via the Core Metadata Module.
     /// @param sigAttach Signature data for attachLicenseTerms to the IP via the Licensing Module.
     /// @return ipId The ID of the newly registered IP.
-    /// @return licenseTermsId The ID of the newly registered PIL terms.
-    function registerIpAndAttachPILTerms(
+    function registerIpAndAttachLicenseTerms(
         address nftContract,
         uint256 tokenId,
         WorkflowStructs.IPMetadata calldata ipMetadata,
-        PILTerms calldata terms,
+        address licenseTemplate,
+        uint256 licenseTermsId,
         WorkflowStructs.SignatureData calldata sigMetadata,
         WorkflowStructs.SignatureData calldata sigAttach
-    ) external returns (address ipId, uint256 licenseTermsId);
+    ) external returns (address ipId);
 }

--- a/contracts/lib/LicensingHelper.sol
+++ b/contracts/lib/LicensingHelper.sol
@@ -21,7 +21,7 @@ library LicensingHelper {
         address ipId,
         address pilTemplate,
         address licensingModule,
-        PILTerms calldata terms
+        PILTerms memory terms
     ) internal returns (uint256 licenseTermsId) {
         licenseTermsId = IPILicenseTemplate(pilTemplate).registerLicenseTerms(terms);
         attachLicenseTerms(ipId, licensingModule, pilTemplate, licenseTermsId);
@@ -62,7 +62,7 @@ library LicensingHelper {
         address pilTemplate,
         address licensingModule,
         PILTerms calldata terms,
-        WorkflowStructs.SignatureData calldata sigAttach
+        WorkflowStructs.SignatureData memory sigAttach
     ) internal returns (uint256 licenseTermsId) {
         licenseTermsId = IPILicenseTemplate(pilTemplate).registerLicenseTerms(terms);
         attachLicenseTermsWithSig(ipId, licensingModule, pilTemplate, licenseTermsId, sigAttach);
@@ -79,7 +79,7 @@ library LicensingHelper {
         address licensingModule,
         address licenseTemplate,
         uint256 licenseTermsId,
-        WorkflowStructs.SignatureData calldata sigAttach
+        WorkflowStructs.SignatureData memory sigAttach
     ) internal {
         try
             IIPAccount(payable(ipId)).executeWithSig({

--- a/contracts/workflows/DerivativeWorkflows.sol
+++ b/contracts/workflows/DerivativeWorkflows.sol
@@ -314,7 +314,8 @@ contract DerivativeWorkflows is
     /// @param licenseTemplate The address of the license template.
     /// @param parentIpIds The IDs of all the parent IPs.
     /// @param licenseTermsIds The IDs of the license terms for each corresponding parent IP.
-    /// @param sigMintingFee OPTIONAL. Signature data for approving license minting fee for the IP via the currency token.
+    /// @param sigMintingFee OPTIONAL. Signature data for approving license minting fee for the IP
+    ///                      via the currency token.
     function _collectMintFeesAndSetApproval(
         address ipId,
         address ipOwnerAddress,
@@ -344,7 +345,8 @@ contract DerivativeWorkflows is
                     IERC20(mintFeeCurrencyToken).transferFrom(payerAddress, address(this), totalMintFee);
                     IERC20(mintFeeCurrencyToken).forceApprove(address(ROYALTY_MODULE), totalMintFee);
                 } else {
-                    // if owner is not this contract, we need to transfer the minting fee to IP account and use `executeWithSig` to approve royalty module
+                    // if owner is not this contract, we need to transfer the minting fee to IP account and
+                    // use `executeWithSig` to approve royalty module
                     IERC20(mintFeeCurrencyToken).transferFrom(payerAddress, address(ipId), totalMintFee);
                     IIPAccount(payable(ipId)).executeWithSig({
                         to: address(mintFeeCurrencyToken),

--- a/contracts/workflows/LicenseAttachmentWorkflows.sol
+++ b/contracts/workflows/LicenseAttachmentWorkflows.sol
@@ -115,7 +115,6 @@ contract LicenseAttachmentWorkflows is
         ISPGNFT(spgNftContract).safeTransferFrom(address(this), recipient, tokenId, "");
     }
 
-
     // TODO: add comments
     function mintAndRegisterIpAndAttachLicenseTerms(
         address spgNftContract,
@@ -136,12 +135,7 @@ contract LicenseAttachmentWorkflows is
         ipId = IP_ASSET_REGISTRY.register(block.chainid, spgNftContract, tokenId);
         MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);
 
-        LicensingHelper.attachLicenseTerms(
-            ipId,
-            address(LICENSING_MODULE),
-            licenseTemplate,
-            licenseTermsId
-        );
+        LicensingHelper.attachLicenseTerms(ipId, address(LICENSING_MODULE), licenseTemplate, licenseTermsId);
 
         ISPGNFT(spgNftContract).safeTransferFrom(address(this), recipient, tokenId, "");
     }

--- a/contracts/workflows/LicenseAttachmentWorkflows.sol
+++ b/contracts/workflows/LicenseAttachmentWorkflows.sol
@@ -6,8 +6,6 @@ import { AccessManagedUpgradeable } from "@openzeppelin/contracts-upgradeable/ac
 import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import { MulticallUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/MulticallUpgradeable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
-
-import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingModule.sol";
 import { PILTerms } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
 
 import { BaseWorkflow } from "../BaseWorkflow.sol";
@@ -88,36 +86,7 @@ contract LicenseAttachmentWorkflows is
         $.nftContractBeacon = newNftContractBeacon;
     }
 
-    /// @notice Register Programmable IP License Terms (if unregistered) and attach it to IP.
-    /// @param ipId The ID of the IP.
-    /// @param terms The PIL terms to be registered.
-    /// @param sigAttach Signature data for attachLicenseTerms to the IP via the Licensing Module.
-    /// @return licenseTermsId The ID of the newly registered PIL terms.
-    function registerPILTermsAndAttach(
-        address ipId,
-        PILTerms calldata terms,
-        WorkflowStructs.SignatureData calldata sigAttach
-    ) external returns (uint256 licenseTermsId) {
-        licenseTermsId = LicensingHelper.registerPILTermsAndAttachWithSig(
-            ipId,
-            address(PIL_TEMPLATE),
-            address(LICENSING_MODULE),
-            terms,
-            sigAttach
-        );
-    }
-
-    /// @notice Mint an NFT from a SPGNFT collection, register it with metadata as an IP,
-    /// register Programmable IP License Terms (if unregistered), and attach it to the registered IP.
-    /// @dev Requires caller to have the minter role or the SPG NFT to allow public minting.
-    /// @param spgNftContract The address of the SPGNFT collection.
-    /// @param recipient The address of the recipient of the minted NFT.
-    /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
-    /// @param terms The PIL terms to be registered.
-    /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
-    /// @return ipId The ID of the newly registered IP.
-    /// @return tokenId The ID of the newly minted NFT.
-    /// @return licenseTermsId The ID of the newly registered PIL terms.
+    /// TODO: add comments
     function mintAndRegisterIpAndAttachPILTerms(
         address spgNftContract,
         address recipient,
@@ -146,33 +115,54 @@ contract LicenseAttachmentWorkflows is
         ISPGNFT(spgNftContract).safeTransferFrom(address(this), recipient, tokenId, "");
     }
 
-    /// @notice Register a given NFT as an IP and attach Programmable IP License Terms.
-    /// @dev Because IP Account is created in this function, we need to set the permission via signature to allow this
-    /// contract to attach PIL Terms to the newly created IP Account in the same function.
-    /// @param nftContract The address of the NFT collection.
-    /// @param tokenId The ID of the NFT.
-    /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
-    /// @param terms The PIL terms to be registered.
-    /// @param sigMetadata OPTIONAL. Signature data for setAll (metadata) for the IP via the Core Metadata Module.
-    /// @param sigAttach Signature data for attachLicenseTerms to the IP via the Licensing Module.
-    /// @return ipId The ID of the newly registered IP.
-    /// @return licenseTermsId The ID of the newly registered PIL terms.
-    function registerIpAndAttachPILTerms(
+
+    // TODO: add comments
+    function mintAndRegisterIpAndAttachLicenseTerms(
+        address spgNftContract,
+        address recipient,
+        WorkflowStructs.IPMetadata calldata ipMetadata,
+        address licenseTemplate,
+        uint256 licenseTermsId,
+        bool allowDuplicates
+    ) external onlyMintAuthorized(spgNftContract) returns (address ipId, uint256 tokenId) {
+        tokenId = ISPGNFT(spgNftContract).mintByPeriphery({
+            to: address(this),
+            payer: msg.sender,
+            nftMetadataURI: ipMetadata.nftMetadataURI,
+            nftMetadataHash: ipMetadata.nftMetadataHash,
+            allowDuplicates: allowDuplicates
+        });
+
+        ipId = IP_ASSET_REGISTRY.register(block.chainid, spgNftContract, tokenId);
+        MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);
+
+        LicensingHelper.attachLicenseTerms(
+            ipId,
+            address(LICENSING_MODULE),
+            licenseTemplate,
+            licenseTermsId
+        );
+
+        ISPGNFT(spgNftContract).safeTransferFrom(address(this), recipient, tokenId, "");
+    }
+
+    function registerIpAndAttachLicenseTerms(
         address nftContract,
         uint256 tokenId,
         WorkflowStructs.IPMetadata calldata ipMetadata,
-        PILTerms calldata terms,
+        address licenseTemplate,
+        uint256 licenseTermsId,
         WorkflowStructs.SignatureData calldata sigMetadata,
         WorkflowStructs.SignatureData calldata sigAttach
-    ) external returns (address ipId, uint256 licenseTermsId) {
+    ) external returns (address ipId) {
         ipId = IP_ASSET_REGISTRY.register(block.chainid, nftContract, tokenId);
         MetadataHelper.setMetadataWithSig(ipId, address(CORE_METADATA_MODULE), ipMetadata, sigMetadata);
 
-        licenseTermsId = LicensingHelper.registerPILTermsAndAttachWithSig(
+        LicensingHelper.attachLicenseTermsWithSig(
             ipId,
-            address(PIL_TEMPLATE),
             address(LICENSING_MODULE),
-            terms,
+            licenseTemplate,
+            licenseTermsId,
             sigAttach
         );
     }

--- a/contracts/workflows/RoyaltyWorkflows.sol
+++ b/contracts/workflows/RoyaltyWorkflows.sol
@@ -7,7 +7,6 @@ import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC16
 import { MulticallUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/MulticallUpgradeable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
-import { Errors as CoreErrors } from "@storyprotocol/core/lib/Errors.sol";
 // solhint-disable-next-line max-line-length
 import { IGraphAwareRoyaltyPolicy } from "@storyprotocol/core/interfaces/modules/royalty/policies/IGraphAwareRoyaltyPolicy.sol";
 import { IIpRoyaltyVault } from "@storyprotocol/core/interfaces/modules/royalty/policies/IIpRoyaltyVault.sol";

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -13,12 +13,12 @@
 
 ### [License Attachment Workflows](../contracts/interfaces/workflows/ILicenseAttachmentWorkflows.sol)
 
-- `registerPILTermsAndAttach`:
-  - Registers PIL terms → Attaches them to an IP
-- `registerIpAndAttachPILTerms`:
-  - Registers an IP → Registers PIL terms → Attaches them to the IP
 - `mintAndRegisterIpAndAttachPILTerms`:
   - Mints a NFT → Registers it as an IP → Registers PIL terms → Attaches them to the IP
+- `mintAndRegisterIpAndAttachLicenseTerms`:
+  - Mints a NFT → Registers it as an IP → Attaches license terms to the IP
+- `registerIpAndAttachLicenseTerms`:
+  - Registers an IP → Attaches license terms to the IP
 
 ### [Derivative Workflows](../contracts/interfaces/workflows/IDerivativeWorkflows.sol)
 
@@ -50,4 +50,4 @@
   - Transfers specified amounts of royalties from various royalty policies to the royalty vault of the ancestor IP -> Claims all the revenue in each currency token from the ancestor IP's royalty vault to the claimer.
 
 - `claimAllRevenue`:
-  - Transfers all avaiable royalties from various royalty policies to the royalty vault of the ancestor IP -> Claims all the revenue in each currency token from the ancestor IP's royalty vault to the claimer.
+  - Transfers all available royalties from various royalty policies to the royalty vault of the ancestor IP -> Claims all the revenue in each currency token from the ancestor IP's royalty vault to the claimer.

--- a/test/integration/workflows/LicenseAttachmentIntegration.t.sol
+++ b/test/integration/workflows/LicenseAttachmentIntegration.t.sol
@@ -233,10 +233,12 @@ contract LicenseAttachmentIntegration is BaseIntegration {
             currencyToken: testMintFeeToken
         });
 
-        commUseTermsId = pilTemplate.registerLicenseTerms(PILFlavors.commercialUse({
-            mintingFee: testMintFee,
-            currencyToken: testMintFeeToken,
-            royaltyPolicy: royaltyPolicyLRPAddr
-        }));
+        commUseTermsId = pilTemplate.registerLicenseTerms(
+            PILFlavors.commercialUse({
+                mintingFee: testMintFee,
+                currencyToken: testMintFeeToken,
+                royaltyPolicy: royaltyPolicyLRPAddr
+            })
+        );
     }
 }

--- a/test/integration/workflows/LicenseAttachmentIntegration.t.sol
+++ b/test/integration/workflows/LicenseAttachmentIntegration.t.sol
@@ -20,7 +20,7 @@ contract LicenseAttachmentIntegration is BaseIntegration {
     using Strings for uint256;
 
     ISPGNFT private spgNftContract;
-    PILTerms private commUseTerms;
+    PILTerms private commRemixTerms;
     uint256 private commUseTermsId;
 
     /// @dev To use, run the following command:
@@ -30,48 +30,10 @@ contract LicenseAttachmentIntegration is BaseIntegration {
         super.run();
         _beginBroadcast();
         _setUpTest();
-        _test_LicenseAttachmentIntegration_registerPILTermsAndAttach();
         _test_LicenseAttachmentIntegration_mintAndRegisterIpAndAttachPILTerms();
-        _test_LicenseAttachmentIntegration_registerIpAndAttachPILTerms();
+        _test_LicenseAttachmentIntegration_mintAndRegisterIpAndAttachLicenseTerms();
+        _test_LicenseAttachmentIntegration_registerIpAndAttachLicenseTerms();
         _endBroadcast();
-    }
-
-    function _test_LicenseAttachmentIntegration_registerPILTermsAndAttach()
-        private
-        logTest("test_LicenseAttachmentIntegration_registerPILTermsAndAttach")
-    {
-        StoryUSD.mint(testSender, testMintFee);
-        StoryUSD.approve(address(spgNftContract), testMintFee);
-
-        (address ipId, ) = registrationWorkflows.mintAndRegisterIp({
-            spgNftContract: address(spgNftContract),
-            recipient: testSender,
-            ipMetadata: testIpMetadata,
-            allowDuplicates: true
-        });
-
-        uint256 deadline = block.timestamp + 1000;
-        (bytes memory signature, ) = _getSigForExecuteWithSig({
-            ipId: ipId,
-            to: licensingModuleAddr,
-            deadline: deadline,
-            state: IIPAccount(payable(ipId)).state(),
-            data: abi.encodeWithSelector(
-                ILicensingModule.attachLicenseTerms.selector,
-                ipId,
-                pilTemplateAddr,
-                commUseTermsId
-            ),
-            signerSk: testSenderSk
-        });
-
-        uint256 licenseTermsId = licenseAttachmentWorkflows.registerPILTermsAndAttach({
-            ipId: ipId,
-            terms: commUseTerms,
-            sigAttach: WorkflowStructs.SignatureData({ signer: testSender, deadline: deadline, signature: signature })
-        });
-
-        assertEq(licenseTermsId, commUseTermsId);
     }
 
     function _test_LicenseAttachmentIntegration_mintAndRegisterIpAndAttachPILTerms()
@@ -88,12 +50,12 @@ contract LicenseAttachmentIntegration is BaseIntegration {
                     spgNftContract: address(spgNftContract),
                     recipient: testSender,
                     ipMetadata: testIpMetadata,
-                    terms: commUseTerms,
+                    terms: commRemixTerms,
                     allowDuplicates: true
                 });
             assertTrue(ipAssetRegistry.isRegistered(ipId1));
             assertEq(tokenId1, spgNftContract.totalSupply());
-            assertEq(licenseTermsId1, pilTemplate.getLicenseTermsId(commUseTerms));
+            assertEq(licenseTermsId1, pilTemplate.getLicenseTermsId(commRemixTerms));
             assertEq(spgNftContract.tokenURI(tokenId1), string.concat(testBaseURI, testIpMetadata.nftMetadataURI));
             assertMetadata(ipId1, testIpMetadata);
             (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId1, 0);
@@ -111,12 +73,12 @@ contract LicenseAttachmentIntegration is BaseIntegration {
                     spgNftContract: address(spgNftContract),
                     recipient: testSender,
                     ipMetadata: testIpMetadata,
-                    terms: commUseTerms,
+                    terms: commRemixTerms,
                     allowDuplicates: true
                 });
             assertTrue(ipAssetRegistry.isRegistered(ipId2));
             assertEq(tokenId2, spgNftContract.totalSupply());
-            assertEq(licenseTermsId2, pilTemplate.getLicenseTermsId(commUseTerms));
+            assertEq(licenseTermsId2, pilTemplate.getLicenseTermsId(commRemixTerms));
             assertEq(spgNftContract.tokenURI(tokenId2), string.concat(testBaseURI, testIpMetadata.nftMetadataURI));
             assertMetadata(ipId2, testIpMetadata);
             (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId2, 0);
@@ -125,9 +87,58 @@ contract LicenseAttachmentIntegration is BaseIntegration {
         }
     }
 
-    function _test_LicenseAttachmentIntegration_registerIpAndAttachPILTerms()
+    function _test_LicenseAttachmentIntegration_mintAndRegisterIpAndAttachLicenseTerms()
         private
-        logTest("test_LicenseAttachmentIntegration_registerIpAndAttachPILTerms")
+        logTest("test_LicenseAttachmentIntegration_mintAndRegisterIpAndAttachLicenseTerms")
+    {
+        // IP 1
+        {
+            StoryUSD.mint(testSender, testMintFee);
+            StoryUSD.approve(address(spgNftContract), testMintFee);
+
+            (address ipId1, uint256 tokenId1) = licenseAttachmentWorkflows.mintAndRegisterIpAndAttachLicenseTerms({
+                spgNftContract: address(spgNftContract),
+                recipient: testSender,
+                ipMetadata: testIpMetadata,
+                licenseTemplate: pilTemplateAddr,
+                licenseTermsId: commUseTermsId,
+                allowDuplicates: true
+            });
+            assertTrue(ipAssetRegistry.isRegistered(ipId1));
+            assertEq(tokenId1, spgNftContract.totalSupply());
+            assertEq(spgNftContract.tokenURI(tokenId1), string.concat(testBaseURI, testIpMetadata.nftMetadataURI));
+            assertMetadata(ipId1, testIpMetadata);
+            (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId1, 0);
+            assertEq(licenseTemplate, pilTemplateAddr);
+            assertEq(licenseTermsId, commUseTermsId);
+        }
+
+        // IP 2
+        {
+            StoryUSD.mint(testSender, testMintFee);
+            StoryUSD.approve(address(spgNftContract), testMintFee);
+
+            (address ipId2, uint256 tokenId2) = licenseAttachmentWorkflows.mintAndRegisterIpAndAttachLicenseTerms({
+                spgNftContract: address(spgNftContract),
+                recipient: testSender,
+                ipMetadata: testIpMetadata,
+                licenseTemplate: pilTemplateAddr,
+                licenseTermsId: commUseTermsId,
+                allowDuplicates: true
+            });
+            assertTrue(ipAssetRegistry.isRegistered(ipId2));
+            assertEq(tokenId2, spgNftContract.totalSupply());
+            assertEq(spgNftContract.tokenURI(tokenId2), string.concat(testBaseURI, testIpMetadata.nftMetadataURI));
+            assertMetadata(ipId2, testIpMetadata);
+            (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId2, 0);
+            assertEq(licenseTemplate, pilTemplateAddr);
+            assertEq(licenseTermsId, commUseTermsId);
+        }
+    }
+
+    function _test_LicenseAttachmentIntegration_registerIpAndAttachLicenseTerms()
+        private
+        logTest("test_LicenseAttachmentIntegration_registerIpAndAttachLicenseTerms")
     {
         StoryUSD.mint(testSender, testMintFee);
         StoryUSD.approve(address(spgNftContract), testMintFee);
@@ -171,11 +182,12 @@ contract LicenseAttachmentIntegration is BaseIntegration {
             signerSk: testSenderSk
         });
 
-        (address ipId, uint256 licenseTermsId) = licenseAttachmentWorkflows.registerIpAndAttachPILTerms({
+        address ipId = licenseAttachmentWorkflows.registerIpAndAttachLicenseTerms({
             nftContract: address(spgNftContract),
             tokenId: tokenId,
             ipMetadata: testIpMetadata,
-            terms: commUseTerms,
+            licenseTemplate: pilTemplateAddr,
+            licenseTermsId: commUseTermsId,
             sigMetadata: WorkflowStructs.SignatureData({
                 signer: testSender,
                 deadline: deadline,
@@ -192,7 +204,7 @@ contract LicenseAttachmentIntegration is BaseIntegration {
             0
         );
         assertEq(expectedLicenseTemplate, pilTemplateAddr);
-        assertEq(expectedLicenseTermsId, licenseTermsId);
+        assertEq(expectedLicenseTermsId, commUseTermsId);
     }
 
     function _setUpTest() private {
@@ -214,13 +226,17 @@ contract LicenseAttachmentIntegration is BaseIntegration {
             )
         );
 
-        commUseTerms = PILFlavors.commercialUse({
+        commRemixTerms = PILFlavors.commercialRemix({
+            mintingFee: testMintFee,
+            commercialRevShare: 10 * 10 ** 6, // 10%
+            royaltyPolicy: royaltyPolicyLRPAddr,
+            currencyToken: testMintFeeToken
+        });
+
+        commUseTermsId = pilTemplate.registerLicenseTerms(PILFlavors.commercialUse({
             mintingFee: testMintFee,
             currencyToken: testMintFeeToken,
             royaltyPolicy: royaltyPolicyLRPAddr
-        });
-
-        // TODO: this is a hack to get the license terms id, we should refactor this in the next PR
-        commUseTermsId = pilTemplate.registerLicenseTerms(commUseTerms);
+        }));
     }
 }

--- a/test/workflows/DerivativeWorkflows.t.sol
+++ b/test/workflows/DerivativeWorkflows.t.sol
@@ -61,10 +61,7 @@ contract DerivativeWorkflowsTest is BaseTest {
         withNonCommercialParentIp
     {
         // First, create an derivative with the same NFT metadata hash but with dedup turned off
-        (, uint256 licenseTermsIdParent) = licenseRegistry.getAttachedLicenseTerms(
-            ipIdParent,
-            0
-        );
+        (, uint256 licenseTermsIdParent) = licenseRegistry.getAttachedLicenseTerms(ipIdParent, 0);
 
         address[] memory parentIpIds = new address[](1);
         parentIpIds[0] = ipIdParent;

--- a/test/workflows/DerivativeWorkflows.t.sol
+++ b/test/workflows/DerivativeWorkflows.t.sol
@@ -61,7 +61,7 @@ contract DerivativeWorkflowsTest is BaseTest {
         withNonCommercialParentIp
     {
         // First, create an derivative with the same NFT metadata hash but with dedup turned off
-        (address licenseTemplateParent, uint256 licenseTermsIdParent) = licenseRegistry.getAttachedLicenseTerms(
+        (, uint256 licenseTermsIdParent) = licenseRegistry.getAttachedLicenseTerms(
             ipIdParent,
             0
         );
@@ -72,7 +72,7 @@ contract DerivativeWorkflowsTest is BaseTest {
         uint256[] memory licenseTermsIds = new uint256[](1);
         licenseTermsIds[0] = licenseTermsIdParent;
 
-        (address ipIdChild, ) = derivativeWorkflows.mintAndRegisterIpAndMakeDerivative({
+        derivativeWorkflows.mintAndRegisterIpAndMakeDerivative({
             spgNftContract: address(nftContract),
             derivData: WorkflowStructs.MakeDerivative({
                 parentIpIds: parentIpIds,

--- a/test/workflows/GroupingWorkflows.t.sol
+++ b/test/workflows/GroupingWorkflows.t.sol
@@ -67,7 +67,7 @@ contract GroupingWorkflowsTest is BaseTest {
     function test_GroupingWorkflows_revert_DuplicatedNFTMetadataHash() public {
         uint256 deadline = block.timestamp + 1000;
 
-        (bytes memory sigAddToGroup,) = _getSigForExecuteWithSig({
+        (bytes memory sigAddToGroup, ) = _getSigForExecuteWithSig({
             ipId: groupId,
             to: address(accessController),
             deadline: deadline,

--- a/test/workflows/GroupingWorkflows.t.sol
+++ b/test/workflows/GroupingWorkflows.t.sol
@@ -11,7 +11,6 @@ import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
 import { ILicenseRegistry } from "@storyprotocol/core/interfaces/registries/ILicenseRegistry.sol";
 import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingModule.sol";
 import { IIPAssetRegistry } from "@storyprotocol/core/interfaces/registries/IIPAssetRegistry.sol";
-import { IIpRoyaltyVault } from "@storyprotocol/core/interfaces/modules/royalty/policies/IIpRoyaltyVault.sol";
 import { IGroupingModule } from "@storyprotocol/core/interfaces/modules/grouping/IGroupingModule.sol";
 import { IGroupIPAssetRegistry } from "@storyprotocol/core/interfaces/registries/IGroupIPAssetRegistry.sol";
 import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
@@ -68,7 +67,7 @@ contract GroupingWorkflowsTest is BaseTest {
     function test_GroupingWorkflows_revert_DuplicatedNFTMetadataHash() public {
         uint256 deadline = block.timestamp + 1000;
 
-        (bytes memory sigAddToGroup, bytes32 expectedState) = _getSigForExecuteWithSig({
+        (bytes memory sigAddToGroup,) = _getSigForExecuteWithSig({
             ipId: groupId,
             to: address(accessController),
             deadline: deadline,

--- a/test/workflows/LicenseAttachmentWorkflows.t.sol
+++ b/test/workflows/LicenseAttachmentWorkflows.t.sol
@@ -318,11 +318,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
             licensingModule: address(licensingModule),
             licenseTemplate: address(pilTemplate),
             licenseTermsId: commRemixTermsId,
-            sigAttach: WorkflowStructs.SignatureData({
-                signer: u.alice,
-                deadline: deadline,
-                signature: signature
-            })
+            sigAttach: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: signature })
         });
     }
 }

--- a/test/workflows/LicenseAttachmentWorkflows.t.sol
+++ b/test/workflows/LicenseAttachmentWorkflows.t.sol
@@ -4,7 +4,6 @@ pragma solidity 0.8.26;
 
 // external
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
-import { Errors as CoreErrors } from "@storyprotocol/core/lib/Errors.sol";
 import { ICoreMetadataModule } from "@storyprotocol/core/interfaces/modules/metadata/ICoreMetadataModule.sol";
 import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
 import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingModule.sol";
@@ -13,7 +12,9 @@ import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
 
 // contracts
 import { Errors } from "../../contracts/lib/Errors.sol";
+import { LicensingHelper } from "../../contracts/lib/LicensingHelper.sol";
 import { WorkflowStructs } from "../../contracts/lib/WorkflowStructs.sol";
+
 // test
 import { BaseTest } from "../utils/BaseTest.t.sol";
 
@@ -27,9 +28,18 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
     }
 
     mapping(uint256 index => IPAsset) internal ipAsset;
+    uint256 commRemixTermsId;
 
     function setUp() public override {
         super.setUp();
+        commRemixTermsId = IPILicenseTemplate(pilTemplate).registerLicenseTerms(
+            PILFlavors.commercialRemix({
+                mintingFee: 20,
+                commercialRevShare: 50,
+                royaltyPolicy: address(royaltyPolicyLRP),
+                currencyToken: address(mockToken)
+            })
+        );
     }
 
     modifier withIp(address owner) {
@@ -53,14 +63,17 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
         whenCallerHasMinterRole
         withEnoughTokens(address(licenseAttachmentWorkflows))
     {
-        (address ipId1, uint256 tokenId1, uint256 licenseTermsId1) = licenseAttachmentWorkflows
-            .mintAndRegisterIpAndAttachPILTerms({
-                spgNftContract: address(nftContract),
-                recipient: caller,
-                ipMetadata: ipMetadataDefault,
-                terms: PILFlavors.nonCommercialSocialRemixing(),
-                allowDuplicates: true
-            });
+        licenseAttachmentWorkflows.mintAndRegisterIpAndAttachPILTerms({
+            spgNftContract: address(nftContract),
+            recipient: caller,
+            ipMetadata: ipMetadataDefault,
+            terms: PILFlavors.commercialUse({
+                mintingFee: 20,
+                currencyToken: address(mockToken),
+                royaltyPolicy: address(royaltyPolicyLAP)
+            }),
+            allowDuplicates: true
+        });
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -77,48 +90,23 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
             terms: PILFlavors.nonCommercialSocialRemixing(),
             allowDuplicates: false
         });
-    }
 
-    function test_LicenseAttachmentWorkflows_registerPILTermsAndAttach() public withCollection withIp(u.alice) {
-        address payable ipId = ipAsset[1].ipId;
-        uint256 deadline = block.timestamp + 1000;
-
-        // TODO: this is a hack to get the license terms id, we should refactor this in the next PR
-        uint256 licenseTermsId = IPILicenseTemplate(pilTemplate).registerLicenseTerms(
-            PILFlavors.commercialUse({
-                mintingFee: 100,
-                currencyToken: address(mockToken),
-                royaltyPolicy: address(royaltyPolicyLAP)
-            })
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.SPGNFT__DuplicatedNFTMetadataHash.selector,
+                address(nftContract),
+                1,
+                ipMetadataDefault.nftMetadataHash
+            )
         );
-
-        (bytes memory signature, ) = _getSigForExecuteWithSig({
-            ipId: ipId,
-            to: address(licensingModule),
-            deadline: deadline,
-            state: IIPAccount(ipId).state(),
-            data: abi.encodeWithSelector(
-                ILicensingModule.attachLicenseTerms.selector,
-                ipId,
-                pilTemplate,
-                licenseTermsId
-            ),
-            signerSk: sk.alice
+        licenseAttachmentWorkflows.mintAndRegisterIpAndAttachLicenseTerms({
+            spgNftContract: address(nftContract),
+            recipient: caller,
+            ipMetadata: ipMetadataDefault,
+            licenseTemplate: address(pilTemplate),
+            licenseTermsId: commRemixTermsId,
+            allowDuplicates: false
         });
-
-        uint256 ltAmt = pilTemplate.totalRegisteredLicenseTerms();
-
-        licenseTermsId = licenseAttachmentWorkflows.registerPILTermsAndAttach({
-            ipId: ipId,
-            terms: PILFlavors.commercialUse({
-                mintingFee: 100,
-                currencyToken: address(mockToken),
-                royaltyPolicy: address(royaltyPolicyLAP)
-            }),
-            sigAttach: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: signature })
-        });
-
-        assertEq(licenseTermsId, ltAmt);
     }
 
     function test_LicenseAttachmentWorkflows_mintAndRegisterIpAndAttachPILTerms()
@@ -132,12 +120,16 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
                 spgNftContract: address(nftContract),
                 recipient: caller,
                 ipMetadata: ipMetadataEmpty,
-                terms: PILFlavors.nonCommercialSocialRemixing(),
+                terms: PILFlavors.commercialUse({
+                    mintingFee: 20,
+                    currencyToken: address(mockToken),
+                    royaltyPolicy: address(royaltyPolicyLAP)
+                }),
                 allowDuplicates: true
             });
         assertTrue(ipAssetRegistry.isRegistered(ipId1));
         assertEq(tokenId1, 1);
-        assertEq(licenseTermsId1, 1);
+        assertEq(licenseTermsId1, commRemixTermsId + 1);
         assertEq(nftContract.tokenURI(tokenId1), string.concat(testBaseURI, tokenId1.toString()));
         assertMetadata(ipId1, ipMetadataEmpty);
         (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId1, 0);
@@ -149,17 +141,63 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
                 spgNftContract: address(nftContract),
                 recipient: caller,
                 ipMetadata: ipMetadataDefault,
-                terms: PILFlavors.nonCommercialSocialRemixing(),
+                terms: PILFlavors.commercialUse({
+                    mintingFee: 20,
+                    currencyToken: address(mockToken),
+                    royaltyPolicy: address(royaltyPolicyLAP)
+                }),
                 allowDuplicates: true
             });
         assertTrue(ipAssetRegistry.isRegistered(ipId2));
         assertEq(tokenId2, 2);
-        assertEq(licenseTermsId1, licenseTermsId2);
         assertEq(nftContract.tokenURI(tokenId2), string.concat(testBaseURI, ipMetadataDefault.nftMetadataURI));
         assertMetadata(ipId2, ipMetadataDefault);
+        (licenseTemplate, licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId2, 0);
+        assertEq(licenseTemplate, address(pilTemplate));
+        assertEq(licenseTermsId, licenseTermsId2);
+        assertEq(licenseTermsId2, licenseTermsId1);
     }
 
-    function test_LicenseAttachmentWorkflows_registerIpAndAttachPILTerms()
+    function test_LicenseAttachmentWorkflows_mintAndRegisterIpAndAttachLicenseTerms()
+        public
+        withCollection
+        whenCallerHasMinterRole
+        withEnoughTokens(address(licenseAttachmentWorkflows))
+    {
+        (address ipId1, uint256 tokenId1) = licenseAttachmentWorkflows.mintAndRegisterIpAndAttachLicenseTerms({
+            spgNftContract: address(nftContract),
+            recipient: caller,
+            ipMetadata: ipMetadataEmpty,
+            licenseTemplate: address(pilTemplate),
+            licenseTermsId: commRemixTermsId,
+            allowDuplicates: true
+        });
+        assertTrue(ipAssetRegistry.isRegistered(ipId1));
+        assertEq(tokenId1, 1);
+        assertEq(nftContract.tokenURI(tokenId1), string.concat(testBaseURI, tokenId1.toString()));
+        assertMetadata(ipId1, ipMetadataEmpty);
+        (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId1, 0);
+        assertEq(licenseTemplate, address(pilTemplate));
+        assertEq(licenseTermsId, commRemixTermsId);
+
+        (address ipId2, uint256 tokenId2) = licenseAttachmentWorkflows.mintAndRegisterIpAndAttachLicenseTerms({
+            spgNftContract: address(nftContract),
+            recipient: caller,
+            ipMetadata: ipMetadataDefault,
+            licenseTemplate: address(pilTemplate),
+            licenseTermsId: commRemixTermsId,
+            allowDuplicates: true
+        });
+        assertTrue(ipAssetRegistry.isRegistered(ipId2));
+        assertEq(tokenId2, 2);
+        assertEq(nftContract.tokenURI(tokenId2), string.concat(testBaseURI, ipMetadataDefault.nftMetadataURI));
+        assertMetadata(ipId2, ipMetadataDefault);
+        (licenseTemplate, licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId2, 0);
+        assertEq(licenseTemplate, address(pilTemplate));
+        assertEq(licenseTermsId, commRemixTermsId);
+    }
+
+    function test_LicenseAttachmentWorkflows_registerIpAndAttachLicenseTerms()
         public
         withCollection
         whenCallerHasMinterRole
@@ -199,88 +237,25 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
                 ILicensingModule.attachLicenseTerms.selector,
                 ipId,
                 pilTemplate,
-                IPILicenseTemplate(pilTemplate).getLicenseTermsId(PILFlavors.nonCommercialSocialRemixing())
+                commRemixTermsId
             ),
             signerSk: sk.alice
         });
 
-        licenseAttachmentWorkflows.registerIpAndAttachPILTerms({
+        licenseAttachmentWorkflows.registerIpAndAttachLicenseTerms({
             nftContract: address(nftContract),
             tokenId: tokenId,
             ipMetadata: ipMetadataDefault,
-            terms: PILFlavors.nonCommercialSocialRemixing(),
+            licenseTemplate: address(pilTemplate),
+            licenseTermsId: commRemixTermsId,
             sigMetadata: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: sigMetadata }),
             sigAttach: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: sigAttach })
         });
-    }
 
-    function test_LicenseAttachmentWorkflows_registerPILTermsAndAttach_idempotency()
-        public
-        withCollection
-        withIp(u.alice)
-    {
-        address payable ipId = ipAsset[1].ipId;
-        uint256 deadline = block.timestamp + 1000;
-
-        // TODO: this is a hack to get the license terms id, we should refactor this in the next PR
-        uint256 licenseTermsId = IPILicenseTemplate(pilTemplate).registerLicenseTerms(
-            PILFlavors.commercialUse({
-                mintingFee: 100,
-                currencyToken: address(mockToken),
-                royaltyPolicy: address(royaltyPolicyLAP)
-            })
-        );
-
-        (bytes memory signature1, ) = _getSigForExecuteWithSig({
-            ipId: ipId,
-            to: address(licensingModule),
-            deadline: deadline,
-            state: IIPAccount(ipId).state(),
-            data: abi.encodeWithSelector(
-                ILicensingModule.attachLicenseTerms.selector,
-                ipId,
-                pilTemplate,
-                licenseTermsId
-            ),
-            signerSk: sk.alice
-        });
-
-        uint256 licenseTermsId1 = licenseAttachmentWorkflows.registerPILTermsAndAttach({
-            ipId: ipId,
-            terms: PILFlavors.commercialUse({
-                mintingFee: 100,
-                currencyToken: address(mockToken),
-                royaltyPolicy: address(royaltyPolicyLAP)
-            }),
-            sigAttach: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: signature1 })
-        });
-
-        (bytes memory signature2, ) = _getSigForExecuteWithSig({
-            ipId: ipId,
-            to: address(licensingModule),
-            deadline: deadline,
-            state: IIPAccount(ipId).state(),
-            data: abi.encodeWithSelector(
-                ILicensingModule.attachLicenseTerms.selector,
-                ipId,
-                pilTemplate,
-                licenseTermsId1
-            ),
-            signerSk: sk.alice
-        });
-
-        // attach the same license terms to the IP again, but it shouldn't revert
-        uint256 licenseTermsId2 = licenseAttachmentWorkflows.registerPILTermsAndAttach({
-            ipId: ipId,
-            terms: PILFlavors.commercialUse({
-                mintingFee: 100,
-                currencyToken: address(mockToken),
-                royaltyPolicy: address(royaltyPolicyLAP)
-            }),
-            sigAttach: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: signature2 })
-        });
-
-        assertEq(licenseTermsId1, licenseTermsId2);
+        assertMetadata(ipId, ipMetadataDefault);
+        (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId, 0);
+        assertEq(licenseTemplate, address(pilTemplate));
+        assertEq(licenseTermsId, commRemixTermsId);
     }
 
     function test_revert_registerPILTermsAndAttach_DerivativesCannotAddLicenseTerms()
@@ -289,20 +264,24 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
         whenCallerHasMinterRole
         withEnoughTokens(address(licenseAttachmentWorkflows))
     {
-        (address ipIdParent, , uint256 licenseTermsIdParent) = licenseAttachmentWorkflows
-            .mintAndRegisterIpAndAttachPILTerms({
-                spgNftContract: address(nftContract),
-                recipient: caller,
-                ipMetadata: ipMetadataDefault,
-                terms: PILFlavors.nonCommercialSocialRemixing(),
-                allowDuplicates: true
-            });
+        (address ipIdParent, ) = licenseAttachmentWorkflows.mintAndRegisterIpAndAttachLicenseTerms({
+            spgNftContract: address(nftContract),
+            recipient: caller,
+            ipMetadata: ipMetadataDefault,
+            licenseTemplate: address(pilTemplate),
+            licenseTermsId: commRemixTermsId,
+            allowDuplicates: true
+        });
 
         address[] memory parentIpIds = new address[](1);
         parentIpIds[0] = ipIdParent;
 
         uint256[] memory licenseTermsIds = new uint256[](1);
-        licenseTermsIds[0] = licenseTermsIdParent;
+        licenseTermsIds[0] = commRemixTermsId;
+
+        vm.startPrank(caller);
+        mockToken.mint(address(caller), 20 * 10 ** mockToken.decimals());
+        mockToken.approve(address(derivativeWorkflows), 10 * 10 ** mockToken.decimals());
 
         (address ipIdChild, ) = derivativeWorkflows.mintAndRegisterIpAndMakeDerivative({
             spgNftContract: address(nftContract),
@@ -320,15 +299,6 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
 
         uint256 deadline = block.timestamp + 1000;
 
-        // TODO: this is a hack to get the license terms id, we should refactor this in the next PR
-        uint256 licenseTermsId = IPILicenseTemplate(pilTemplate).registerLicenseTerms(
-            PILFlavors.commercialUse({
-                mintingFee: 100,
-                currencyToken: address(mockToken),
-                royaltyPolicy: address(royaltyPolicyLAP)
-            })
-        );
-
         (bytes memory signature, ) = _getSigForExecuteWithSig({
             ipId: ipIdChild,
             to: address(licensingModule),
@@ -338,21 +308,21 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
                 ILicensingModule.attachLicenseTerms.selector,
                 ipIdChild,
                 pilTemplate,
-                licenseTermsId
+                commRemixTermsId
             ),
             signerSk: sk.alice
         });
 
-        // attach a different license terms to the child ip, should revert with the correct error
-        vm.expectRevert(CoreErrors.LicensingModule__DerivativesCannotAddLicenseTerms.selector);
-        licenseAttachmentWorkflows.registerPILTermsAndAttach({
+        LicensingHelper.attachLicenseTermsWithSig({
             ipId: ipIdChild,
-            terms: PILFlavors.commercialUse({
-                mintingFee: 100,
-                currencyToken: address(mockToken),
-                royaltyPolicy: address(royaltyPolicyLAP)
-            }),
-            sigAttach: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: signature })
+            licensingModule: address(licensingModule),
+            licenseTemplate: address(pilTemplate),
+            licenseTermsId: commRemixTermsId,
+            sigAttach: WorkflowStructs.SignatureData({
+                signer: u.alice,
+                deadline: deadline,
+                signature: signature
+            })
         });
     }
 }

--- a/test/workflows/RoyaltyWorkflows.t.sol
+++ b/test/workflows/RoyaltyWorkflows.t.sol
@@ -10,6 +10,7 @@ import { IPILicenseTemplate } from "@storyprotocol/core/interfaces/modules/licen
 import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
 
 // contracts
+import { LicensingHelper } from "../../contracts/lib/LicensingHelper.sol";
 import { WorkflowStructs } from "../../contracts/lib/WorkflowStructs.sol";
 
 // test
@@ -229,8 +230,7 @@ contract RoyaltyWorkflowsTest is BaseTest {
 
         // get the signature for executing `attachLicenseTerms` function in `LicensingModule` on behalf of the IP owner
         {
-            // TODO: this is a hack to get the license terms id, we should refactor this in the next PR
-            uint256 licenseTermsId = IPILicenseTemplate(pilTemplate).registerLicenseTerms(
+            commRemixTermsIdA = IPILicenseTemplate(pilTemplate).registerLicenseTerms(
                 PILFlavors.commercialRemix({
                     mintingFee: defaultMintingFeeA,
                     commercialRevShare: defaultCommRevShareA,
@@ -247,27 +247,23 @@ contract RoyaltyWorkflowsTest is BaseTest {
                     ILicensingModule.attachLicenseTerms.selector,
                     ancestorIpId,
                     pilTemplate,
-                    licenseTermsId
+                    commRemixTermsIdA
                 ),
                 signerSk: sk.admin
             });
 
             // register and attach Terms A and C to ancestor IP
-            commRemixTermsIdA = licenseAttachmentWorkflows.registerPILTermsAndAttach({
+            LicensingHelper.attachLicenseTermsWithSig({
                 ipId: ancestorIpId,
-                terms: PILFlavors.commercialRemix({
-                    mintingFee: defaultMintingFeeA,
-                    commercialRevShare: defaultCommRevShareA,
-                    royaltyPolicy: address(royaltyPolicyLRP),
-                    currencyToken: address(mockTokenA)
-                }),
+                licensingModule: address(licensingModule),
+                licenseTemplate: address(pilTemplate),
+                licenseTermsId: commRemixTermsIdA,
                 sigAttach: WorkflowStructs.SignatureData({ signer: u.admin, deadline: deadline, signature: signatureA })
             });
         }
 
         {
-            // TODO: this is a hack to get the license terms id, we should refactor this in the next PR
-            uint256 licenseTermsId = IPILicenseTemplate(pilTemplate).registerLicenseTerms(
+            commRemixTermsIdC = IPILicenseTemplate(pilTemplate).registerLicenseTerms(
                 PILFlavors.commercialRemix({
                     mintingFee: defaultMintingFeeC,
                     commercialRevShare: defaultCommRevShareC,
@@ -284,19 +280,16 @@ contract RoyaltyWorkflowsTest is BaseTest {
                     ILicensingModule.attachLicenseTerms.selector,
                     ancestorIpId,
                     pilTemplate,
-                    licenseTermsId
+                    commRemixTermsIdC
                 ),
                 signerSk: sk.admin
             });
 
-            commRemixTermsIdC = licenseAttachmentWorkflows.registerPILTermsAndAttach({
+            LicensingHelper.attachLicenseTermsWithSig({
                 ipId: ancestorIpId,
-                terms: PILFlavors.commercialRemix({
-                    mintingFee: defaultMintingFeeC,
-                    commercialRevShare: defaultCommRevShareC,
-                    royaltyPolicy: address(royaltyPolicyLAP),
-                    currencyToken: address(mockTokenC)
-                }),
+                licensingModule: address(licensingModule),
+                licenseTemplate: address(pilTemplate),
+                licenseTermsId: commRemixTermsIdC,
                 sigAttach: WorkflowStructs.SignatureData({ signer: u.admin, deadline: deadline, signature: signatureC })
             });
         }


### PR DESCRIPTION
## Description
<!-- Add a description of the changes that this PR introduces -->
This PR introduces support for custom license templates in `LicenseAttachmentWorkflows`. It removes the needs for license term IDs prediction during signature generation by decoupling license term registration from the `registerIpAndAttachPILTerms` function.

#### Key Changes
- Removed the `registerPILTermsAndAttach` function from `LicenseAttachmentWorkflows`.  
- Renamed and refactored:  
  - `registerIpAndAttachPILTerms` is now `registerIpAndAttachLicenseTerms`.  
  - It now accepts a license template and an already registered license term ID, instead of registering new terms internally.  
- Added `mintAndRegisterIpAndAttachLicenseTerms` to support IP registration for an existing NFT and attaching pre-registered license terms.  
- Updated documentation to reflect these changes.


## Test Plan 
<!-- The test plan section indicates detailed steps on how to verify and test code changes. 
You can list the test cases or test steps that need to be performed.-->
Refactored tests to align with the updated functionality. All tests pass locally.

## Related Issue
<!-- The related Issue section can indicate which issue or task the Pull Request is related with -->
- closes #54 
- closes #120

## Notes
<!-- The Important Matters section can alert others to special requirements or matters that need extra attention -->

This PR include API changes, and requires updates to downstream integrations.