### PR TITLE
feat(licensing): enable multi-license attachment in `LicenseAttachmentWorkflows`

### DIFF
--- a/.github/workflows/foundry_ci.yml
+++ b/.github/workflows/foundry_ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+      - release-v1.2.4
 
 jobs:
 

--- a/contracts/interfaces/workflows/ILicenseAttachmentWorkflows.sol
+++ b/contracts/interfaces/workflows/ILicenseAttachmentWorkflows.sol
@@ -12,12 +12,12 @@ interface ILicenseAttachmentWorkflows {
     /// @param ipId The ID of the IP.
     /// @param terms The PIL terms to be registered.
     /// @param sigAttach Signature data for attachLicenseTerms to the IP via the Licensing Module.
-    /// @return licenseTermsId The ID of the newly registered PIL terms.
+    /// @return licenseTermsIds The IDs of the newly registered PIL terms.
     function registerPILTermsAndAttach(
         address ipId,
-        PILTerms calldata terms,
+        PILTerms[] calldata terms,
         WorkflowStructs.SignatureData calldata sigAttach
-    ) external returns (uint256 licenseTermsId);
+    ) external returns (uint256[] memory licenseTermsIds);
 
     /// @notice Mint an NFT from a SPGNFT collection, register it with metadata as an IP,
     /// register Programmable IPLicense
@@ -29,13 +29,13 @@ interface ILicenseAttachmentWorkflows {
     /// @param terms The PIL terms to be registered.
     /// @return ipId The ID of the newly registered IP.
     /// @return tokenId The ID of the newly minted NFT.
-    /// @return licenseTermsId The ID of the newly registered PIL terms.
+    /// @return licenseTermsIds The IDs of the newly registered PIL terms.
     function mintAndRegisterIpAndAttachPILTerms(
         address spgNftContract,
         address recipient,
         WorkflowStructs.IPMetadata calldata ipMetadata,
-        PILTerms calldata terms
-    ) external returns (address ipId, uint256 tokenId, uint256 licenseTermsId);
+        PILTerms[] calldata terms
+    ) external returns (address ipId, uint256 tokenId, uint256[] memory licenseTermsIds);
 
     /// @notice Register a given NFT as an IP and attach Programmable IP License Terms.
     /// @dev Because IP Account is created in this function, we need to set the permission via signature to allow this
@@ -47,13 +47,13 @@ interface ILicenseAttachmentWorkflows {
     /// @param sigMetadata OPTIONAL. Signature data for setAll (metadata) for the IP via the Core Metadata Module.
     /// @param sigAttach Signature data for attachLicenseTerms to the IP via the Licensing Module.
     /// @return ipId The ID of the newly registered IP.
-    /// @return licenseTermsId The ID of the newly registered PIL terms.
+    /// @return licenseTermsIds The IDs of the newly registered PIL terms.
     function registerIpAndAttachPILTerms(
         address nftContract,
         uint256 tokenId,
         WorkflowStructs.IPMetadata calldata ipMetadata,
-        PILTerms calldata terms,
+        PILTerms[] calldata terms,
         WorkflowStructs.SignatureData calldata sigMetadata,
         WorkflowStructs.SignatureData calldata sigAttach
-    ) external returns (address ipId, uint256 licenseTermsId);
+    ) external returns (address ipId, uint256[] memory licenseTermsIds);
 }

--- a/contracts/lib/LicensingHelper.sol
+++ b/contracts/lib/LicensingHelper.sol
@@ -14,17 +14,19 @@ library LicensingHelper {
     /// @param licensingModule The address of the Licensing Module.
     /// @param licenseRegistry The address of the License Registry.
     /// @param terms The PIL terms to be registered.
-    /// @return licenseTermsId The ID of the registered PIL terms.
+    /// @return licenseTermsIds The IDs of the registered PIL terms.
     function registerPILTermsAndAttach(
         address ipId,
         address pilTemplate,
         address licensingModule,
         address licenseRegistry,
-        PILTerms calldata terms
-    ) internal returns (uint256 licenseTermsId) {
-        licenseTermsId = IPILicenseTemplate(pilTemplate).registerLicenseTerms(terms);
-
-        attachLicenseTerms(ipId, licensingModule, licenseRegistry, pilTemplate, licenseTermsId);
+        PILTerms[] calldata terms
+    ) internal returns (uint256[] memory licenseTermsIds) {
+        licenseTermsIds = new uint256[](terms.length);
+        for (uint256 i = 0; i < terms.length; i++) {
+            licenseTermsIds[i] = IPILicenseTemplate(pilTemplate).registerLicenseTerms(terms[i]);
+            attachLicenseTerms(ipId, licensingModule, licenseRegistry, pilTemplate, licenseTermsIds[i]);
+        }
     }
 
     /// @dev Attaches license terms to the given IP.

--- a/contracts/workflows/LicenseAttachmentWorkflows.sol
+++ b/contracts/workflows/LicenseAttachmentWorkflows.sol
@@ -93,12 +93,12 @@ contract LicenseAttachmentWorkflows is
     /// @param ipId The ID of the IP.
     /// @param terms The PIL terms to be registered.
     /// @param sigAttach Signature data for attachLicenseTerms to the IP via the Licensing Module.
-    /// @return licenseTermsId The ID of the newly registered PIL terms.
+    /// @return licenseTermsIds The IDs of the newly registered PIL terms.
     function registerPILTermsAndAttach(
         address ipId,
-        PILTerms calldata terms,
+        PILTerms[] calldata terms,
         WorkflowStructs.SignatureData calldata sigAttach
-    ) external returns (uint256 licenseTermsId) {
+    ) external returns (uint256[] memory licenseTermsIds) {
         PermissionHelper.setPermissionForModule(
             ipId,
             address(LICENSING_MODULE),
@@ -107,7 +107,7 @@ contract LicenseAttachmentWorkflows is
             sigAttach
         );
 
-        licenseTermsId = LicensingHelper.registerPILTermsAndAttach(
+        licenseTermsIds = LicensingHelper.registerPILTermsAndAttach(
             ipId,
             address(PIL_TEMPLATE),
             address(LICENSING_MODULE),
@@ -125,13 +125,17 @@ contract LicenseAttachmentWorkflows is
     /// @param terms The PIL terms to be registered.
     /// @return ipId The ID of the newly registered IP.
     /// @return tokenId The ID of the newly minted NFT.
-    /// @return licenseTermsId The ID of the newly registered PIL terms.
+    /// @return licenseTermsIds The IDs of the newly registered PIL terms.
     function mintAndRegisterIpAndAttachPILTerms(
         address spgNftContract,
         address recipient,
         WorkflowStructs.IPMetadata calldata ipMetadata,
-        PILTerms calldata terms
-    ) external onlyMintAuthorized(spgNftContract) returns (address ipId, uint256 tokenId, uint256 licenseTermsId) {
+        PILTerms[] calldata terms
+    )
+        external
+        onlyMintAuthorized(spgNftContract)
+        returns (address ipId, uint256 tokenId, uint256[] memory licenseTermsIds)
+    {
         tokenId = ISPGNFT(spgNftContract).mintByPeriphery({
             to: address(this),
             payer: msg.sender,
@@ -140,7 +144,7 @@ contract LicenseAttachmentWorkflows is
         ipId = IP_ASSET_REGISTRY.register(block.chainid, spgNftContract, tokenId);
         MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);
 
-        licenseTermsId = LicensingHelper.registerPILTermsAndAttach(
+        licenseTermsIds = LicensingHelper.registerPILTermsAndAttach(
             ipId,
             address(PIL_TEMPLATE),
             address(LICENSING_MODULE),
@@ -161,15 +165,15 @@ contract LicenseAttachmentWorkflows is
     /// @param sigMetadata OPTIONAL. Signature data for setAll (metadata) for the IP via the Core Metadata Module.
     /// @param sigAttach Signature data for attachLicenseTerms to the IP via the Licensing Module.
     /// @return ipId The ID of the newly registered IP.
-    /// @return licenseTermsId The ID of the newly registered PIL terms.
+    /// @return licenseTermsIds The IDs of the newly registered PIL terms.
     function registerIpAndAttachPILTerms(
         address nftContract,
         uint256 tokenId,
         WorkflowStructs.IPMetadata calldata ipMetadata,
-        PILTerms calldata terms,
+        PILTerms[] calldata terms,
         WorkflowStructs.SignatureData calldata sigMetadata,
         WorkflowStructs.SignatureData calldata sigAttach
-    ) external returns (address ipId, uint256 licenseTermsId) {
+    ) external returns (address ipId, uint256[] memory licenseTermsIds) {
         ipId = IP_ASSET_REGISTRY.register(block.chainid, nftContract, tokenId);
         MetadataHelper.setMetadataWithSig(
             ipId,
@@ -187,7 +191,7 @@ contract LicenseAttachmentWorkflows is
             sigAttach
         );
 
-        licenseTermsId = LicensingHelper.registerPILTermsAndAttach(
+        licenseTermsIds = LicensingHelper.registerPILTermsAndAttach(
             ipId,
             address(PIL_TEMPLATE),
             address(LICENSING_MODULE),

--- a/test/integration/workflows/DerivativeIntegration.t.sol
+++ b/test/integration/workflows/DerivativeIntegration.t.sol
@@ -7,6 +7,7 @@ import { ICoreMetadataModule } from "@storyprotocol/core/interfaces/modules/meta
 import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
 import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingModule.sol";
 import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
+import { IPILicenseTemplate, PILTerms } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
 
 // contracts
 import { ISPGNFT } from "../../../contracts/interfaces/ISPGNFT.sol";
@@ -353,25 +354,28 @@ contract DerivativeIntegration is BaseIntegration {
             )
         );
 
+        PILTerms[] memory commTerms = new PILTerms[](1);
+        commTerms[0] = PILFlavors.commercialUse({
+            mintingFee: testMintFee,
+            currencyToken: testMintFeeToken,
+            royaltyPolicy: royaltyPolicyLRPAddr
+        });
+
         StoryUSD.mint(testSender, testMintFee);
         StoryUSD.approve(address(spgNftContract), testMintFee);
-        (address parentIpId, , uint256 licenseTermsIdParent) = licenseAttachmentWorkflows
+        (address parentIpId, , uint256[] memory licenseTermsIdParent) = licenseAttachmentWorkflows
             .mintAndRegisterIpAndAttachPILTerms({
                 spgNftContract: address(spgNftContract),
                 recipient: testSender,
                 ipMetadata: testIpMetadata,
-                terms: PILFlavors.commercialUse({
-                    mintingFee: testMintFee,
-                    currencyToken: testMintFeeToken,
-                    royaltyPolicy: royaltyPolicyLRPAddr
-                })
+                terms: commTerms
             });
 
         parentIpIds = new address[](1);
         parentIpIds[0] = parentIpId;
 
         parentLicenseTermIds = new uint256[](1);
-        parentLicenseTermIds[0] = licenseTermsIdParent;
+        parentLicenseTermIds[0] = licenseTermsIdParent[0];
         parentLicenseTemplate = pilTemplateAddr;
     }
 

--- a/test/integration/workflows/LicenseAttachmentIntegration.t.sol
+++ b/test/integration/workflows/LicenseAttachmentIntegration.t.sol
@@ -20,7 +20,7 @@ contract LicenseAttachmentIntegration is BaseIntegration {
     using Strings for uint256;
 
     ISPGNFT private spgNftContract;
-    PILTerms private commUseTerms;
+    PILTerms[] private commTerms;
 
     /// @dev To use, run the following command:
     /// forge script test/integration/workflows/LicenseAttachmentIntegration.t.sol:LicenseAttachmentIntegration \
@@ -59,13 +59,17 @@ contract LicenseAttachmentIntegration is BaseIntegration {
             signerSk: testSenderSk
         });
 
-        uint256 licenseTermsId = licenseAttachmentWorkflows.registerPILTermsAndAttach({
+        uint256[] memory licenseTermsIds = licenseAttachmentWorkflows.registerPILTermsAndAttach({
             ipId: ipId,
-            terms: commUseTerms,
+            terms: commTerms,
             sigAttach: WorkflowStructs.SignatureData({ signer: testSender, deadline: deadline, signature: signature })
         });
 
-        assertEq(licenseTermsId, pilTemplate.getLicenseTermsId(commUseTerms));
+        assertEq(licenseTermsIds[0], pilTemplate.getLicenseTermsId(commTerms[0]));
+        assertEq(licenseTermsIds[1], pilTemplate.getLicenseTermsId(commTerms[1]));
+        assertEq(licenseTermsIds[2], pilTemplate.getLicenseTermsId(commTerms[2]));
+        assertEq(licenseTermsIds[3], pilTemplate.getLicenseTermsId(commTerms[3]));
+        assertEq(licenseTermsIds[4], pilTemplate.getLicenseTermsId(commTerms[4]));
     }
 
     function _test_LicenseAttachmentIntegration_mintAndRegisterIpAndAttachPILTerms()
@@ -77,21 +81,37 @@ contract LicenseAttachmentIntegration is BaseIntegration {
             StoryUSD.mint(testSender, testMintFee);
             StoryUSD.approve(address(spgNftContract), testMintFee);
 
-            (address ipId1, uint256 tokenId1, uint256 licenseTermsId1) = licenseAttachmentWorkflows
+            (address ipId1, uint256 tokenId1, uint256[] memory licenseTermsIds1) = licenseAttachmentWorkflows
                 .mintAndRegisterIpAndAttachPILTerms({
                     spgNftContract: address(spgNftContract),
                     recipient: testSender,
                     ipMetadata: testIpMetadata,
-                    terms: commUseTerms
+                    terms: commTerms
                 });
             assertTrue(ipAssetRegistry.isRegistered(ipId1));
             assertEq(tokenId1, spgNftContract.totalSupply());
-            assertEq(licenseTermsId1, pilTemplate.getLicenseTermsId(commUseTerms));
+            assertEq(licenseTermsIds1[0], pilTemplate.getLicenseTermsId(commTerms[0]));
+            assertEq(licenseTermsIds1[1], pilTemplate.getLicenseTermsId(commTerms[1]));
+            assertEq(licenseTermsIds1[2], pilTemplate.getLicenseTermsId(commTerms[2]));
+            assertEq(licenseTermsIds1[3], pilTemplate.getLicenseTermsId(commTerms[3]));
+            assertEq(licenseTermsIds1[4], pilTemplate.getLicenseTermsId(commTerms[4]));
             assertEq(spgNftContract.tokenURI(tokenId1), string.concat(testBaseURI, testIpMetadata.nftMetadataURI));
             assertMetadata(ipId1, testIpMetadata);
             (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId1, 0);
             assertEq(licenseTemplate, pilTemplateAddr);
-            assertEq(licenseTermsId, licenseTermsId1);
+            assertEq(licenseTermsId, licenseTermsIds1[0]);
+            (licenseTemplate, licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId1, 1);
+            assertEq(licenseTemplate, pilTemplateAddr);
+            assertEq(licenseTermsId, licenseTermsIds1[1]);
+            (licenseTemplate, licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId1, 2);
+            assertEq(licenseTemplate, pilTemplateAddr);
+            assertEq(licenseTermsId, licenseTermsIds1[2]);
+            (licenseTemplate, licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId1, 3);
+            assertEq(licenseTemplate, pilTemplateAddr);
+            assertEq(licenseTermsId, licenseTermsIds1[3]);
+            (licenseTemplate, licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId1, 4);
+            assertEq(licenseTemplate, pilTemplateAddr);
+            assertEq(licenseTermsId, licenseTermsIds1[4]);
         }
 
         // IP 2
@@ -99,21 +119,37 @@ contract LicenseAttachmentIntegration is BaseIntegration {
             StoryUSD.mint(testSender, testMintFee);
             StoryUSD.approve(address(spgNftContract), testMintFee);
 
-            (address ipId2, uint256 tokenId2, uint256 licenseTermsId2) = licenseAttachmentWorkflows
+            (address ipId2, uint256 tokenId2, uint256[] memory licenseTermsIds2) = licenseAttachmentWorkflows
                 .mintAndRegisterIpAndAttachPILTerms({
                     spgNftContract: address(spgNftContract),
                     recipient: testSender,
                     ipMetadata: testIpMetadata,
-                    terms: commUseTerms
+                    terms: commTerms
                 });
             assertTrue(ipAssetRegistry.isRegistered(ipId2));
             assertEq(tokenId2, spgNftContract.totalSupply());
-            assertEq(licenseTermsId2, pilTemplate.getLicenseTermsId(commUseTerms));
+            assertEq(licenseTermsIds2[0], pilTemplate.getLicenseTermsId(commTerms[0]));
+            assertEq(licenseTermsIds2[1], pilTemplate.getLicenseTermsId(commTerms[1]));
+            assertEq(licenseTermsIds2[2], pilTemplate.getLicenseTermsId(commTerms[2]));
+            assertEq(licenseTermsIds2[3], pilTemplate.getLicenseTermsId(commTerms[3]));
+            assertEq(licenseTermsIds2[4], pilTemplate.getLicenseTermsId(commTerms[4]));
             assertEq(spgNftContract.tokenURI(tokenId2), string.concat(testBaseURI, testIpMetadata.nftMetadataURI));
             assertMetadata(ipId2, testIpMetadata);
             (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId2, 0);
             assertEq(licenseTemplate, pilTemplateAddr);
-            assertEq(licenseTermsId, licenseTermsId2);
+            assertEq(licenseTermsId, licenseTermsIds2[0]);
+            (licenseTemplate, licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId2, 1);
+            assertEq(licenseTemplate, pilTemplateAddr);
+            assertEq(licenseTermsId, licenseTermsIds2[1]);
+            (licenseTemplate, licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId2, 2);
+            assertEq(licenseTemplate, pilTemplateAddr);
+            assertEq(licenseTermsId, licenseTermsIds2[2]);
+            (licenseTemplate, licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId2, 3);
+            assertEq(licenseTemplate, pilTemplateAddr);
+            assertEq(licenseTermsId, licenseTermsIds2[3]);
+            (licenseTemplate, licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId2, 4);
+            assertEq(licenseTemplate, pilTemplateAddr);
+            assertEq(licenseTermsId, licenseTermsIds2[4]);
         }
     }
 
@@ -149,11 +185,11 @@ contract LicenseAttachmentIntegration is BaseIntegration {
             signerSk: testSenderSk
         });
 
-        (address ipId, uint256 licenseTermsId) = licenseAttachmentWorkflows.registerIpAndAttachPILTerms({
+        (address ipId, uint256[] memory licenseTermsIds) = licenseAttachmentWorkflows.registerIpAndAttachPILTerms({
             nftContract: address(spgNftContract),
             tokenId: tokenId,
             ipMetadata: testIpMetadata,
-            terms: commUseTerms,
+            terms: commTerms,
             sigMetadata: WorkflowStructs.SignatureData({
                 signer: testSender,
                 deadline: deadline,
@@ -165,12 +201,29 @@ contract LicenseAttachmentIntegration is BaseIntegration {
         assertEq(ipId, expectedIpId);
         assertTrue(ipAssetRegistry.isRegistered(ipId));
         assertEq(IIPAccount(payable(ipId)).state(), expectedState);
+        assertEq(licenseTermsIds[0], pilTemplate.getLicenseTermsId(commTerms[0]));
+        assertEq(licenseTermsIds[1], pilTemplate.getLicenseTermsId(commTerms[1]));
+        assertEq(licenseTermsIds[2], pilTemplate.getLicenseTermsId(commTerms[2]));
+        assertEq(licenseTermsIds[3], pilTemplate.getLicenseTermsId(commTerms[3]));
+        assertEq(licenseTermsIds[4], pilTemplate.getLicenseTermsId(commTerms[4]));
         (address expectedLicenseTemplate, uint256 expectedLicenseTermsId) = licenseRegistry.getAttachedLicenseTerms(
             expectedIpId,
             0
         );
         assertEq(expectedLicenseTemplate, pilTemplateAddr);
-        assertEq(expectedLicenseTermsId, licenseTermsId);
+        assertEq(expectedLicenseTermsId, licenseTermsIds[0]);
+        (expectedLicenseTemplate, expectedLicenseTermsId) = licenseRegistry.getAttachedLicenseTerms(expectedIpId, 1);
+        assertEq(expectedLicenseTemplate, pilTemplateAddr);
+        assertEq(expectedLicenseTermsId, licenseTermsIds[1]);
+        (expectedLicenseTemplate, expectedLicenseTermsId) = licenseRegistry.getAttachedLicenseTerms(expectedIpId, 2);
+        assertEq(expectedLicenseTemplate, pilTemplateAddr);
+        assertEq(expectedLicenseTermsId, licenseTermsIds[2]);
+        (expectedLicenseTemplate, expectedLicenseTermsId) = licenseRegistry.getAttachedLicenseTerms(expectedIpId, 3);
+        assertEq(expectedLicenseTemplate, pilTemplateAddr);
+        assertEq(expectedLicenseTermsId, licenseTermsIds[3]);
+        (expectedLicenseTemplate, expectedLicenseTermsId) = licenseRegistry.getAttachedLicenseTerms(expectedIpId, 4);
+        assertEq(expectedLicenseTemplate, pilTemplateAddr);
+        assertEq(expectedLicenseTermsId, licenseTermsIds[4]);
     }
 
     function _setUpTest() private {
@@ -192,10 +245,45 @@ contract LicenseAttachmentIntegration is BaseIntegration {
             )
         );
 
-        commUseTerms = PILFlavors.commercialUse({
-            mintingFee: testMintFee,
-            currencyToken: testMintFeeToken,
-            royaltyPolicy: royaltyPolicyLRPAddr
-        });
+        uint32 testCommRevShare = 5 * 10 ** 6; // 5%
+
+        commTerms.push(
+            PILFlavors.commercialRemix({
+                mintingFee: testMintFee,
+                commercialRevShare: testCommRevShare,
+                royaltyPolicy: royaltyPolicyLAPAddr,
+                currencyToken: testMintFeeToken
+            })
+        );
+        commTerms.push(
+            PILFlavors.commercialUse({
+                mintingFee: testMintFee,
+                currencyToken: testMintFeeToken,
+                royaltyPolicy: royaltyPolicyLRPAddr
+            })
+        );
+        commTerms.push(
+            PILFlavors.commercialRemix({
+                mintingFee: testMintFee,
+                commercialRevShare: testCommRevShare,
+                royaltyPolicy: royaltyPolicyLRPAddr,
+                currencyToken: testMintFeeToken
+            })
+        );
+        commTerms.push(
+            PILFlavors.commercialUse({
+                mintingFee: testMintFee,
+                currencyToken: testMintFeeToken,
+                royaltyPolicy: royaltyPolicyLRPAddr
+            })
+        );
+        commTerms.push(
+            PILFlavors.commercialRemix({
+                mintingFee: 0,
+                commercialRevShare: testCommRevShare,
+                royaltyPolicy: royaltyPolicyLAPAddr,
+                currencyToken: testMintFeeToken
+            })
+        );
     }
 }

--- a/test/integration/workflows/RoyaltyIntegration.t.sol
+++ b/test/integration/workflows/RoyaltyIntegration.t.sol
@@ -312,57 +312,70 @@ contract RoyaltyIntegration is BaseIntegration {
         vm.label(ancestorIpId, "AncestorIp");
 
         uint256 deadline = block.timestamp + 1000;
-        PILTerms[] memory commRemixTerms = new PILTerms[](1);
-        uint256[] memory commRemixTermsIds = new uint256[](1);
 
-        // set permission for licensing module to attach license terms to ancestor IP
-        (bytes memory signatureA, , ) = _getSetPermissionSigForPeriphery({
-            ipId: ancestorIpId,
-            to: licenseAttachmentWorkflowsAddr,
-            module: licensingModuleAddr,
-            selector: licensingModule.attachLicenseTerms.selector,
-            deadline: deadline,
-            state: IIPAccount(payable(ancestorIpId)).state(),
-            signerSk: testSenderSk
-        });
+        bytes memory signatureA;
+        bytes memory signatureC;
 
-        // register and attach Terms A and C to ancestor IP
-        commRemixTerms[0] = PILFlavors.commercialRemix({
-            mintingFee: defaultMintingFeeA,
-            commercialRevShare: defaultCommRevShareA,
-            royaltyPolicy: royaltyPolicyLRPAddr,
-            currencyToken: address(StoryUSD)
-        });
-        commRemixTermsIds = licenseAttachmentWorkflows.registerPILTermsAndAttach({
-            ipId: ancestorIpId,
-            terms: commRemixTerms,
-            sigAttach: WorkflowStructs.SignatureData({ signer: testSender, deadline: deadline, signature: signatureA })
-        });
-        commRemixTermsIdA = commRemixTermsIds[0];
+        {
+            PILTerms[] memory commRemixTerms = new PILTerms[](1);
+            uint256[] memory commRemixTermsIds = new uint256[](1);
+            // set permission for licensing module to attach license terms to ancestor IP
+            (signatureA, , ) = _getSetPermissionSigForPeriphery({
+                ipId: ancestorIpId,
+                to: licenseAttachmentWorkflowsAddr,
+                module: licensingModuleAddr,
+                selector: licensingModule.attachLicenseTerms.selector,
+                deadline: deadline,
+                state: IIPAccount(payable(ancestorIpId)).state(),
+                signerSk: testSenderSk
+            });
 
-        // set permission for licensing module to attach license terms to ancestor IP
-        (bytes memory signatureC, , ) = _getSetPermissionSigForPeriphery({
-            ipId: ancestorIpId,
-            to: licenseAttachmentWorkflowsAddr,
-            module: licensingModuleAddr,
-            selector: licensingModule.attachLicenseTerms.selector,
-            deadline: deadline,
-            state: IIPAccount(payable(ancestorIpId)).state(),
-            signerSk: testSenderSk
-        });
+            // register and attach Terms A and C to ancestor IP
+            commRemixTerms[0] = PILFlavors.commercialRemix({
+                mintingFee: defaultMintingFeeA,
+                commercialRevShare: defaultCommRevShareA,
+                royaltyPolicy: royaltyPolicyLRPAddr,
+                currencyToken: address(StoryUSD)
+            });
+            commRemixTermsIds = licenseAttachmentWorkflows.registerPILTermsAndAttach({
+                ipId: ancestorIpId,
+                terms: commRemixTerms,
+                sigAttach: WorkflowStructs.SignatureData({
+                    signer: testSender,
+                    deadline: deadline,
+                    signature: signatureA
+                })
+            });
+            commRemixTermsIdA = commRemixTermsIds[0];
 
-        commRemixTerms[0] = PILFlavors.commercialRemix({
-            mintingFee: defaultMintingFeeC,
-            commercialRevShare: defaultCommRevShareC,
-            royaltyPolicy: royaltyPolicyLAPAddr,
-            currencyToken: address(StoryUSD)
-        });
-        commRemixTermsIds = licenseAttachmentWorkflows.registerPILTermsAndAttach({
-            ipId: ancestorIpId,
-            terms: commRemixTerms,
-            sigAttach: WorkflowStructs.SignatureData({ signer: testSender, deadline: deadline, signature: signatureC })
-        });
-        commRemixTermsIdC = commRemixTermsIds[0];
+            // set permission for licensing module to attach license terms to ancestor IP
+            (signatureC, , ) = _getSetPermissionSigForPeriphery({
+                ipId: ancestorIpId,
+                to: licenseAttachmentWorkflowsAddr,
+                module: licensingModuleAddr,
+                selector: licensingModule.attachLicenseTerms.selector,
+                deadline: deadline,
+                state: IIPAccount(payable(ancestorIpId)).state(),
+                signerSk: testSenderSk
+            });
+
+            commRemixTerms[0] = PILFlavors.commercialRemix({
+                mintingFee: defaultMintingFeeC,
+                commercialRevShare: defaultCommRevShareC,
+                royaltyPolicy: royaltyPolicyLAPAddr,
+                currencyToken: address(StoryUSD)
+            });
+            commRemixTermsIds = licenseAttachmentWorkflows.registerPILTermsAndAttach({
+                ipId: ancestorIpId,
+                terms: commRemixTerms,
+                sigAttach: WorkflowStructs.SignatureData({
+                    signer: testSender,
+                    deadline: deadline,
+                    signature: signatureC
+                })
+            });
+            commRemixTermsIdC = commRemixTermsIds[0];
+        }
 
         // register childIpA as derivative of ancestorIp under Terms A
         {

--- a/test/workflows/DerivativeWorkflows.t.sol
+++ b/test/workflows/DerivativeWorkflows.t.sol
@@ -8,6 +8,7 @@ import { ICoreMetadataModule } from "@storyprotocol/core/interfaces/modules/meta
 import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
 import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingModule.sol";
 import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
+import { PILTerms } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
 
 // contracts
 import { WorkflowStructs } from "../../contracts/lib/WorkflowStructs.sol";
@@ -25,25 +26,29 @@ contract DerivativeWorkflowsTest is BaseTest {
     }
 
     modifier withNonCommercialParentIp() {
+        PILTerms[] memory terms = new PILTerms[](1);
+        terms[0] = PILFlavors.nonCommercialSocialRemixing();
         (ipIdParent, , ) = licenseAttachmentWorkflows.mintAndRegisterIpAndAttachPILTerms({
             spgNftContract: address(nftContract),
             recipient: caller,
             ipMetadata: ipMetadataDefault,
-            terms: PILFlavors.nonCommercialSocialRemixing()
+            terms: terms
         });
         _;
     }
 
     modifier withCommercialParentIp() {
+        PILTerms[] memory terms = new PILTerms[](1);
+        terms[0] = PILFlavors.commercialUse({
+            mintingFee: 100 * 10 ** mockToken.decimals(),
+            currencyToken: address(mockToken),
+            royaltyPolicy: address(royaltyPolicyLAP)
+        });
         (ipIdParent, , ) = licenseAttachmentWorkflows.mintAndRegisterIpAndAttachPILTerms({
             spgNftContract: address(nftContract),
             recipient: caller,
             ipMetadata: ipMetadataDefault,
-            terms: PILFlavors.commercialUse({
-                mintingFee: 100 * 10 ** mockToken.decimals(),
-                currencyToken: address(mockToken),
-                royaltyPolicy: address(royaltyPolicyLAP)
-            })
+            terms: terms
         });
         _;
     }

--- a/test/workflows/LicenseAttachmentWorkflows.t.sol
+++ b/test/workflows/LicenseAttachmentWorkflows.t.sol
@@ -9,6 +9,7 @@ import { ICoreMetadataModule } from "@storyprotocol/core/interfaces/modules/meta
 import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
 import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingModule.sol";
 import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
+import { PILTerms } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
 
 // contracts
 import { WorkflowStructs } from "../../contracts/lib/WorkflowStructs.sol";
@@ -26,9 +27,49 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
     }
 
     mapping(uint256 index => IPAsset) internal ipAsset;
+    PILTerms[] private terms;
 
     function setUp() public override {
         super.setUp();
+
+        terms.push(
+            PILFlavors.commercialUse({
+                mintingFee: 0,
+                currencyToken: address(mockToken),
+                royaltyPolicy: address(royaltyPolicyLAP)
+            })
+        );
+        terms.push(
+            PILFlavors.commercialRemix({
+                mintingFee: 0,
+                commercialRevShare: 5 * 10 ** 6, // 5%
+                royaltyPolicy: address(royaltyPolicyLAP),
+                currencyToken: address(mockToken)
+            })
+        );
+        terms.push(
+            PILFlavors.commercialUse({
+                mintingFee: 0,
+                currencyToken: address(mockToken),
+                royaltyPolicy: address(royaltyPolicyLRP)
+            })
+        );
+        terms.push(
+            PILFlavors.commercialRemix({
+                mintingFee: 0,
+                commercialRevShare: 5 * 10 ** 6, // 5%
+                royaltyPolicy: address(royaltyPolicyLRP),
+                currencyToken: address(mockToken)
+            })
+        );
+        terms.push(
+            PILFlavors.commercialRemix({
+                mintingFee: 100 * 10 ** mockToken.decimals(),
+                commercialRevShare: 10 * 10 ** 6, // 10%
+                royaltyPolicy: address(royaltyPolicyLRP),
+                currencyToken: address(mockToken)
+            })
+        );
     }
 
     modifier withIp(address owner) {
@@ -61,17 +102,17 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
 
         uint256 ltAmt = pilTemplate.totalRegisteredLicenseTerms();
 
-        uint256 licenseTermsId = licenseAttachmentWorkflows.registerPILTermsAndAttach({
+        uint256[] memory licenseTermsIds = licenseAttachmentWorkflows.registerPILTermsAndAttach({
             ipId: ipId,
-            terms: PILFlavors.commercialUse({
-                mintingFee: 100,
-                currencyToken: address(mockToken),
-                royaltyPolicy: address(royaltyPolicyLAP)
-            }),
+            terms: terms,
             sigAttach: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: signature })
         });
 
-        assertEq(licenseTermsId, ltAmt + 1);
+        assertEq(licenseTermsIds[0], ltAmt + 1);
+        assertEq(licenseTermsIds[1], ltAmt + 2);
+        assertEq(licenseTermsIds[2], ltAmt + 3);
+        assertEq(licenseTermsIds[3], ltAmt + 4);
+        assertEq(licenseTermsIds[4], ltAmt + 5);
     }
 
     function test_LicenseAttachmentWorkflows_mintAndRegisterIpAndAttachPILTerms()
@@ -80,32 +121,52 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
         whenCallerHasMinterRole
         withEnoughTokens(address(licenseAttachmentWorkflows))
     {
-        (address ipId1, uint256 tokenId1, uint256 licenseTermsId1) = licenseAttachmentWorkflows
+        (address ipId1, uint256 tokenId1, uint256[] memory licenseTermsIds1) = licenseAttachmentWorkflows
             .mintAndRegisterIpAndAttachPILTerms({
                 spgNftContract: address(nftContract),
                 recipient: caller,
                 ipMetadata: ipMetadataEmpty,
-                terms: PILFlavors.nonCommercialSocialRemixing()
+                terms: terms
             });
         assertTrue(ipAssetRegistry.isRegistered(ipId1));
         assertEq(tokenId1, 1);
-        assertEq(licenseTermsId1, 1);
+        assertEq(licenseTermsIds1[0], 2);
+        assertEq(licenseTermsIds1[1], 3);
+        assertEq(licenseTermsIds1[2], 4);
+        assertEq(licenseTermsIds1[3], 5);
+        assertEq(licenseTermsIds1[4], 6);
         assertEq(nftContract.tokenURI(tokenId1), string.concat(testBaseURI, tokenId1.toString()));
         assertMetadata(ipId1, ipMetadataEmpty);
         (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId1, 0);
         assertEq(licenseTemplate, address(pilTemplate));
-        assertEq(licenseTermsId, licenseTermsId1);
+        assertEq(licenseTermsId, licenseTermsIds1[0]);
+        (licenseTemplate, licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId1, 1);
+        assertEq(licenseTemplate, address(pilTemplate));
+        assertEq(licenseTermsId, licenseTermsIds1[1]);
+        (licenseTemplate, licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId1, 2);
+        assertEq(licenseTemplate, address(pilTemplate));
+        assertEq(licenseTermsId, licenseTermsIds1[2]);
+        (licenseTemplate, licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId1, 3);
+        assertEq(licenseTemplate, address(pilTemplate));
+        assertEq(licenseTermsId, licenseTermsIds1[3]);
+        (licenseTemplate, licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId1, 4);
+        assertEq(licenseTemplate, address(pilTemplate));
+        assertEq(licenseTermsId, licenseTermsIds1[4]);
 
-        (address ipId2, uint256 tokenId2, uint256 licenseTermsId2) = licenseAttachmentWorkflows
+        (address ipId2, uint256 tokenId2, uint256[] memory licenseTermsIds2) = licenseAttachmentWorkflows
             .mintAndRegisterIpAndAttachPILTerms({
                 spgNftContract: address(nftContract),
                 recipient: caller,
                 ipMetadata: ipMetadataDefault,
-                terms: PILFlavors.nonCommercialSocialRemixing()
+                terms: terms
             });
         assertTrue(ipAssetRegistry.isRegistered(ipId2));
         assertEq(tokenId2, 2);
-        assertEq(licenseTermsId1, licenseTermsId2);
+        assertEq(licenseTermsIds1[0], licenseTermsIds2[0]);
+        assertEq(licenseTermsIds1[1], licenseTermsIds2[1]);
+        assertEq(licenseTermsIds1[2], licenseTermsIds2[2]);
+        assertEq(licenseTermsIds1[3], licenseTermsIds2[3]);
+        assertEq(licenseTermsIds1[4], licenseTermsIds2[4]);
         assertEq(nftContract.tokenURI(tokenId2), string.concat(testBaseURI, ipMetadataDefault.nftMetadataURI));
         assertMetadata(ipId2, ipMetadataDefault);
     }
@@ -145,10 +206,28 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
             nftContract: address(nftContract),
             tokenId: tokenId,
             ipMetadata: ipMetadataDefault,
-            terms: PILFlavors.nonCommercialSocialRemixing(),
+            terms: terms,
             sigMetadata: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: sigMetadata }),
             sigAttach: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: sigAttach })
         });
+
+        assertTrue(ipAssetRegistry.isRegistered(ipId));
+        assertMetadata(ipId, ipMetadataDefault);
+        (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId, 0);
+        assertEq(licenseTemplate, address(pilTemplate));
+        assertEq(licenseTermsId, pilTemplate.getLicenseTermsId(terms[0]));
+        (licenseTemplate, licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId, 1);
+        assertEq(licenseTemplate, address(pilTemplate));
+        assertEq(licenseTermsId, pilTemplate.getLicenseTermsId(terms[1]));
+        (licenseTemplate, licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId, 2);
+        assertEq(licenseTemplate, address(pilTemplate));
+        assertEq(licenseTermsId, pilTemplate.getLicenseTermsId(terms[2]));
+        (licenseTemplate, licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId, 3);
+        assertEq(licenseTemplate, address(pilTemplate));
+        assertEq(licenseTermsId, pilTemplate.getLicenseTermsId(terms[3]));
+        (licenseTemplate, licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId, 4);
+        assertEq(licenseTemplate, address(pilTemplate));
+        assertEq(licenseTermsId, pilTemplate.getLicenseTermsId(terms[4]));
     }
 
     function test_LicenseAttachmentWorkflows_registerPILTermsAndAttach_idempotency()
@@ -169,13 +248,9 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
             signerSk: sk.alice
         });
 
-        uint256 licenseTermsId1 = licenseAttachmentWorkflows.registerPILTermsAndAttach({
+        uint256[] memory licenseTermsIds1 = licenseAttachmentWorkflows.registerPILTermsAndAttach({
             ipId: ipId,
-            terms: PILFlavors.commercialUse({
-                mintingFee: 100,
-                currencyToken: address(mockToken),
-                royaltyPolicy: address(royaltyPolicyLAP)
-            }),
+            terms: terms,
             sigAttach: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: signature1 })
         });
 
@@ -189,18 +264,18 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
             signerSk: sk.alice
         });
 
-        // attach the same license terms to the IP again, but it shouldn't revert
-        uint256 licenseTermsId2 = licenseAttachmentWorkflows.registerPILTermsAndAttach({
+        /// attach the same license terms to the IP again, but it shouldn't revert
+        uint256[] memory licenseTermsIds2 = licenseAttachmentWorkflows.registerPILTermsAndAttach({
             ipId: ipId,
-            terms: PILFlavors.commercialUse({
-                mintingFee: 100,
-                currencyToken: address(mockToken),
-                royaltyPolicy: address(royaltyPolicyLAP)
-            }),
+            terms: terms,
             sigAttach: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: signature2 })
         });
 
-        assertEq(licenseTermsId1, licenseTermsId2);
+        assertEq(licenseTermsIds1[0], licenseTermsIds2[0]);
+        assertEq(licenseTermsIds1[1], licenseTermsIds2[1]);
+        assertEq(licenseTermsIds1[2], licenseTermsIds2[2]);
+        assertEq(licenseTermsIds1[3], licenseTermsIds2[3]);
+        assertEq(licenseTermsIds1[4], licenseTermsIds2[4]);
     }
 
     function test_revert_registerPILTermsAndAttach_DerivativesCannotAddLicenseTerms()
@@ -209,19 +284,19 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
         whenCallerHasMinterRole
         withEnoughTokens(address(licenseAttachmentWorkflows))
     {
-        (address ipIdParent, , uint256 licenseTermsIdParent) = licenseAttachmentWorkflows
+        (address ipIdParent, , uint256[] memory licenseTermsIdsParent) = licenseAttachmentWorkflows
             .mintAndRegisterIpAndAttachPILTerms({
                 spgNftContract: address(nftContract),
                 recipient: caller,
                 ipMetadata: ipMetadataDefault,
-                terms: PILFlavors.nonCommercialSocialRemixing()
+                terms: terms
             });
 
         address[] memory parentIpIds = new address[](1);
         parentIpIds[0] = ipIdParent;
 
         uint256[] memory licenseTermsIds = new uint256[](1);
-        licenseTermsIds[0] = licenseTermsIdParent;
+        licenseTermsIds[0] = licenseTermsIdsParent[0];
 
         (address ipIdChild, ) = derivativeWorkflows.mintAndRegisterIpAndMakeDerivative({
             spgNftContract: address(nftContract),
@@ -247,15 +322,11 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
             signerSk: sk.alice
         });
 
-        // attach a different license terms to the child ip, should revert with the correct error
+        /// attach license terms to the child ip, should revert with the correct error
         vm.expectRevert(CoreErrors.LicensingModule__DerivativesCannotAddLicenseTerms.selector);
         licenseAttachmentWorkflows.registerPILTermsAndAttach({
             ipId: ipIdChild,
-            terms: PILFlavors.commercialUse({
-                mintingFee: 100,
-                currencyToken: address(mockToken),
-                royaltyPolicy: address(royaltyPolicyLAP)
-            }),
+            terms: terms,
             sigAttach: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: signature })
         });
     }

--- a/test/workflows/RoyaltyWorkflows.t.sol
+++ b/test/workflows/RoyaltyWorkflows.t.sol
@@ -7,6 +7,7 @@ import { Errors as CoreErrors } from "@storyprotocol/core/lib/Errors.sol";
 import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
 import { IpRoyaltyVault } from "@storyprotocol/core/modules/royalty/policies/IpRoyaltyVault.sol";
 import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
+import { PILTerms } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
 
 // contracts
 import { IRoyaltyWorkflows } from "../../contracts/interfaces/workflows/IRoyaltyWorkflows.sol";
@@ -391,6 +392,8 @@ contract RoyaltyWorkflowsTest is BaseTest {
         vm.label(ancestorIpId, "AncestorIp");
 
         uint256 deadline = block.timestamp + 1000;
+        PILTerms[] memory commRemixTerms = new PILTerms[](1);
+        uint256[] memory commRemixTermsIds;
 
         // set permission for licensing module to attach license terms to ancestor IP
         {
@@ -405,16 +408,20 @@ contract RoyaltyWorkflowsTest is BaseTest {
             });
 
             // register and attach Terms A and C to ancestor IP
-            commRemixTermsIdA = licenseAttachmentWorkflows.registerPILTermsAndAttach({
+            commRemixTerms[0] = PILFlavors.commercialRemix({
+                mintingFee: defaultMintingFeeA,
+                commercialRevShare: defaultCommRevShareA,
+                royaltyPolicy: address(royaltyPolicyLRP),
+                currencyToken: address(mockTokenA)
+            });
+
+            commRemixTermsIds = licenseAttachmentWorkflows.registerPILTermsAndAttach({
                 ipId: ancestorIpId,
-                terms: PILFlavors.commercialRemix({
-                    mintingFee: defaultMintingFeeA,
-                    commercialRevShare: defaultCommRevShareA,
-                    royaltyPolicy: address(royaltyPolicyLRP),
-                    currencyToken: address(mockTokenA)
-                }),
+                terms: commRemixTerms,
                 sigAttach: WorkflowStructs.SignatureData({ signer: u.admin, deadline: deadline, signature: signatureA })
             });
+
+            commRemixTermsIdA = commRemixTermsIds[0];
         }
 
         {
@@ -428,16 +435,20 @@ contract RoyaltyWorkflowsTest is BaseTest {
                 signerSk: sk.admin
             });
 
-            commRemixTermsIdC = licenseAttachmentWorkflows.registerPILTermsAndAttach({
+            commRemixTerms[0] = PILFlavors.commercialRemix({
+                mintingFee: defaultMintingFeeC,
+                commercialRevShare: defaultCommRevShareC,
+                royaltyPolicy: address(royaltyPolicyLAP),
+                currencyToken: address(mockTokenC)
+            });
+
+            commRemixTermsIds = licenseAttachmentWorkflows.registerPILTermsAndAttach({
                 ipId: ancestorIpId,
-                terms: PILFlavors.commercialRemix({
-                    mintingFee: defaultMintingFeeC,
-                    commercialRevShare: defaultCommRevShareC,
-                    royaltyPolicy: address(royaltyPolicyLAP),
-                    currencyToken: address(mockTokenC)
-                }),
+                terms: commRemixTerms,
                 sigAttach: WorkflowStructs.SignatureData({ signer: u.admin, deadline: deadline, signature: signatureC })
             });
+
+            commRemixTermsIdC = commRemixTermsIds[0];
         }
 
         // register childIpA as derivative of ancestorIp under Terms A


### PR DESCRIPTION
## Description
<!-- Add a description of the changes that this PR introduces -->
This PR introduces support for attaching multiple licenses in all `LicenseAttachmentWorkflows` functions.

#### Key Changes
- Updated `registerPILTermsAndAttach`, `mintAndRegisterIpAndAttachPILTerms`, and `registerIpAndAttachPILTerms` to accept an array of PIL terms for registration and attachment.
- Updated `LicensingHelper` to handle the registration and attachment of multiple licenses.


## Test Plan 
<!-- The test plan section indicates detailed steps on how to verify and test code changes. 
You can list the test cases or test steps that need to be performed.-->
- Modified existing tests for `LicenseAttachmentWorkflows` to validate the attachment of 5 licenses per function call instead of one.
- Refactored tests to align with the updated functionality.

## Related Issue
<!-- The related Issue section can indicate which issue or task the Pull Request is related with -->
- Issue #124 