### PR TITLE
feat: introduce `RoyaltyTokenDistributionWorkflows` for distributing royalty tokens among IP co-creators

### DIFF
--- a/contracts/SPGNFT.sol
+++ b/contracts/SPGNFT.sol
@@ -39,16 +39,24 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
     bytes32 private constant SPGNFTStorageLocation = 0x66c08f80d8d0ae818983b725b864514cf274647be6eb06de58ff94d1defb6d00;
 
     /// @dev The address of the DerivativeWorkflows contract.
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     address public immutable DERIVATIVE_WORKFLOWS_ADDRESS;
 
     /// @dev The address of the GroupingWorkflows contract.
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     address public immutable GROUPING_WORKFLOWS_ADDRESS;
 
     /// @dev The address of the LicenseAttachmentWorkflows contract.
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     address public immutable LICENSE_ATTACHMENT_WORKFLOWS_ADDRESS;
 
     /// @dev The address of the RegistrationWorkflows contract.
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     address public immutable REGISTRATION_WORKFLOWS_ADDRESS;
+
+    /// @dev The address of the RoyaltyTokenDistributionWorkflows contract.
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
+    address public immutable ROYALTY_TOKEN_DISTRIBUTION_WORKFLOWS_ADDRESS;
 
     /// @notice Modifier to restrict access to workflow contracts.
     modifier onlyPeriphery() {
@@ -56,7 +64,8 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
             msg.sender != DERIVATIVE_WORKFLOWS_ADDRESS &&
             msg.sender != GROUPING_WORKFLOWS_ADDRESS &&
             msg.sender != LICENSE_ATTACHMENT_WORKFLOWS_ADDRESS &&
-            msg.sender != REGISTRATION_WORKFLOWS_ADDRESS
+            msg.sender != REGISTRATION_WORKFLOWS_ADDRESS &&
+            msg.sender != ROYALTY_TOKEN_DISTRIBUTION_WORKFLOWS_ADDRESS
         ) revert Errors.SPGNFT__CallerNotPeripheryContract();
         _;
     }
@@ -66,19 +75,22 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
         address derivativeWorkflows,
         address groupingWorkflows,
         address licenseAttachmentWorkflows,
-        address registrationWorkflows
+        address registrationWorkflows,
+        address royaltyTokenDistributionWorkflows
     ) {
         if (
             derivativeWorkflows == address(0) ||
             groupingWorkflows == address(0) ||
             licenseAttachmentWorkflows == address(0) ||
-            registrationWorkflows == address(0)
+            registrationWorkflows == address(0) ||
+            royaltyTokenDistributionWorkflows == address(0)
         ) revert Errors.SPGNFT__ZeroAddressParam();
 
         DERIVATIVE_WORKFLOWS_ADDRESS = derivativeWorkflows;
         GROUPING_WORKFLOWS_ADDRESS = groupingWorkflows;
         LICENSE_ATTACHMENT_WORKFLOWS_ADDRESS = licenseAttachmentWorkflows;
         REGISTRATION_WORKFLOWS_ADDRESS = registrationWorkflows;
+        ROYALTY_TOKEN_DISTRIBUTION_WORKFLOWS_ADDRESS = royaltyTokenDistributionWorkflows;
 
         _disableInitializers();
     }
@@ -286,6 +298,8 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
         _grantRole(SPGNFTLib.MINTER_ROLE, LICENSE_ATTACHMENT_WORKFLOWS_ADDRESS);
         _grantRole(SPGNFTLib.ADMIN_ROLE, REGISTRATION_WORKFLOWS_ADDRESS);
         _grantRole(SPGNFTLib.MINTER_ROLE, REGISTRATION_WORKFLOWS_ADDRESS);
+        _grantRole(SPGNFTLib.ADMIN_ROLE, ROYALTY_TOKEN_DISTRIBUTION_WORKFLOWS_ADDRESS);
+        _grantRole(SPGNFTLib.MINTER_ROLE, ROYALTY_TOKEN_DISTRIBUTION_WORKFLOWS_ADDRESS);
     }
 
     //

--- a/contracts/interfaces/workflows/IRoyaltyTokenDistributionWorkflows.sol
+++ b/contracts/interfaces/workflows/IRoyaltyTokenDistributionWorkflows.sol
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { PILTerms } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
+
+import { WorkflowStructs } from "../../lib/WorkflowStructs.sol";
+
+/// @title Royalty Token Distribution Workflows Interface
+/// @notice Interface for IP royalty token distribution workflows.
+interface IRoyaltyTokenDistributionWorkflows {
+    /// @notice Mint an NFT and register the IP, attach PIL terms, and distribute royalty tokens.
+    /// @dev In order to successfully distribute royalty tokens, the license terms attached to the IP must be
+    /// a commercial license.
+    /// @param spgNftContract The address of the SPG NFT contract.
+    /// @param recipient The address to receive the NFT.
+    /// @param ipMetadata The metadata for the IP.
+    /// @param terms The PIL terms to attach to the IP (must be a commercial license).
+    /// @param royaltyShares Authors of the IP and their shares of the royalty tokens, see {WorkflowStructs.RoyaltyShare}.
+    /// @return ipId The ID of the registered IP.
+    /// @return tokenId The ID of the minted NFT.
+    /// @return licenseTermsId The ID of the attached PIL terms.
+    function mintAndRegisterIpAndAttachPILTermsAndDistributeRoyaltyTokens(
+        address spgNftContract,
+        address recipient,
+        WorkflowStructs.IPMetadata calldata ipMetadata,
+        PILTerms calldata terms,
+        WorkflowStructs.RoyaltyShare[] calldata royaltyShares
+    ) external returns (address ipId, uint256 tokenId, uint256 licenseTermsId);
+
+    /// @notice Mint an NFT and register the IP, make a derivative, and distribute royalty tokens.
+    /// @dev In order to successfully distribute royalty tokens, the license terms attached to the IP must be
+    /// a commercial license.
+    /// @param spgNftContract The address of the SPG NFT contract.
+    /// @param recipient The address to receive the NFT.
+    /// @param ipMetadata The metadata for the IP.
+    /// @param derivData The data for the derivative, see {WorkflowStructs.MakeDerivative}.
+    /// @param royaltyShares Authors of the IP and their shares of the royalty tokens, see {WorkflowStructs.RoyaltyShare}.
+    /// @return ipId The ID of the registered IP.
+    /// @return tokenId The ID of the minted NFT.
+    function mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens(
+        address spgNftContract,
+        address recipient,
+        WorkflowStructs.IPMetadata calldata ipMetadata,
+        WorkflowStructs.MakeDerivative calldata derivData,
+        WorkflowStructs.RoyaltyShare[] calldata royaltyShares
+    ) external returns (address ipId, uint256 tokenId);
+
+    /// @notice Register an IP, attach PIL terms, and deploy a royalty vault.
+    /// @dev In order to successfully deploy a royalty vault, the license terms attached to the IP must be
+    /// a commercial license.
+    /// @param nftContract The address of the NFT contract.
+    /// @param tokenId The ID of the NFT.
+    /// @param ipMetadata The metadata for the IP.
+    /// @param terms The PIL terms to attach to the IP (must be a commercial license).
+    /// @param sigMetadata The signature data for the IP metadata.
+    /// @param sigAttach The signature data for attaching the PIL terms.
+    /// @return ipId The ID of the registered IP.
+    /// @return licenseTermsId The ID of the attached PIL terms.
+    /// @return ipRoyaltyVault The address of the deployed royalty vault.
+    function registerIpAndAttachPILTermsAndDeployRoyaltyVault(
+        address nftContract,
+        uint256 tokenId,
+        WorkflowStructs.IPMetadata calldata ipMetadata,
+        PILTerms calldata terms,
+        WorkflowStructs.SignatureData calldata sigMetadata,
+        WorkflowStructs.SignatureData calldata sigAttach
+    ) external returns (address ipId, uint256 licenseTermsId, address ipRoyaltyVault);
+
+    /// @notice Register an IP, make a derivative, and deploy a royalty vault.
+    /// @dev In order to successfully deploy a royalty vault, the license terms attached to the IP must be
+    /// a commercial license.
+    /// @param nftContract The address of the NFT contract.
+    /// @param tokenId The ID of the NFT.
+    /// @param ipMetadata The metadata for the IP.
+    /// @param derivData The data for the derivative, see {WorkflowStructs.MakeDerivative}.
+    /// @param sigMetadata The signature data for the IP metadata.
+    /// @param sigRegister The signature data for registering the derivative.
+    /// @return ipId The ID of the registered IP.
+    /// @return ipRoyaltyVault The address of the deployed royalty vault.
+    function registerIpAndMakeDerivativeAndDeployRoyaltyVault(
+        address nftContract,
+        uint256 tokenId,
+        WorkflowStructs.IPMetadata calldata ipMetadata,
+        WorkflowStructs.MakeDerivative calldata derivData,
+        WorkflowStructs.SignatureData calldata sigMetadata,
+        WorkflowStructs.SignatureData calldata sigRegister
+    ) external returns (address ipId, address ipRoyaltyVault);
+
+    /// @notice Distribute royalty tokens to the authors of the IP.
+    /// @param ipId The ID of the IP.
+    /// @param ipRoyaltyVault The address of the royalty vault.
+    /// @param royaltyShares Authors of the IP and their shares of the royalty tokens, see {WorkflowStructs.RoyaltyShare}.
+    /// @param sigApproveRoyaltyTokens The signature data for approving the royalty tokens.
+    function distributeRoyaltyTokens(
+        address ipId,
+        address ipRoyaltyVault,
+        WorkflowStructs.RoyaltyShare[] calldata royaltyShares,
+        WorkflowStructs.SignatureData calldata sigApproveRoyaltyTokens
+    ) external;
+}

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -44,8 +44,20 @@ library Errors {
     ////////////////////////////////////////////////////////////////////////////
     //                              Royalty Workflows                         //
     ////////////////////////////////////////////////////////////////////////////
-    /// @notice Zero address provided as a param to the GroupingWorkflows.
+    /// @notice Zero address provided as a param to the RoyaltyWorkflows.
     error RoyaltyWorkflows__ZeroAddressParam();
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                   Royalty Token Distribution Workflows                 //
+    ////////////////////////////////////////////////////////////////////////////
+    /// @notice Zero address provided as a param to the RoyaltyTokenDistributionWorkflows.
+    error RoyaltyTokenDistributionWorkflows__ZeroAddressParam();
+
+    /// @notice Total percentages exceed 100%.
+    error RoyaltyTokenDistributionWorkflows__TotalPercentagesExceeds100Percent();
+
+    /// @notice Royalty vault not deployed.
+    error RoyaltyTokenDistributionWorkflows__RoyaltyVaultNotDeployed();
 
     ////////////////////////////////////////////////////////////////////////////
     //                               SPGNFT                                   //

--- a/contracts/lib/LicensingHelper.sol
+++ b/contracts/lib/LicensingHelper.sol
@@ -1,14 +1,19 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { Errors as CoreErrors } from "@storyprotocol/core/lib/Errors.sol";
+import { ILicenseTemplate } from "@storyprotocol/core/interfaces/modules/licensing/ILicenseTemplate.sol";
 import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingModule.sol";
 import { IPILicenseTemplate, PILTerms } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
 
 /// @title Periphery Licensing Helper Library
 /// @notice Library for all licensing related helper functions for Periphery contracts.
 library LicensingHelper {
-    /// @dev Registers PIL License Terms and attaches them to the given IP.
+    using SafeERC20 for IERC20;
+
+    /// @dev Registers multiple PIL License Terms and attaches them to the given IP.
     /// @param ipId The ID of the IP.
     /// @param pilTemplate The address of the PIL License Template.
     /// @param licensingModule The address of the Licensing Module.
@@ -24,9 +29,32 @@ library LicensingHelper {
     ) internal returns (uint256[] memory licenseTermsIds) {
         licenseTermsIds = new uint256[](terms.length);
         for (uint256 i = 0; i < terms.length; i++) {
-            licenseTermsIds[i] = IPILicenseTemplate(pilTemplate).registerLicenseTerms(terms[i]);
-            attachLicenseTerms(ipId, licensingModule, licenseRegistry, pilTemplate, licenseTermsIds[i]);
+            licenseTermsIds[i] = registerPILTermsAndAttach(
+                ipId,
+                pilTemplate,
+                licensingModule,
+                licenseRegistry,
+                terms[i]
+            );
         }
+    }
+
+    /// @dev Registers a single PIL License and attaches it to the given IP.
+    /// @param ipId The ID of the IP.
+    /// @param pilTemplate The address of the PIL License Template.
+    /// @param licensingModule The address of the Licensing Module.
+    /// @param licenseRegistry The address of the License Registry.
+    /// @param terms The PIL terms to be registered.
+    /// @return licenseTermsId The ID of the registered PIL terms.
+    function registerPILTermsAndAttach(
+        address ipId,
+        address pilTemplate,
+        address licensingModule,
+        address licenseRegistry,
+        PILTerms calldata terms
+    ) internal returns (uint256 licenseTermsId) {
+        licenseTermsId = IPILicenseTemplate(pilTemplate).registerLicenseTerms(terms);
+        attachLicenseTerms(ipId, licensingModule, licenseRegistry, pilTemplate, licenseTermsId);
     }
 
     /// @dev Attaches license terms to the given IP.
@@ -51,6 +79,73 @@ library LicensingHelper {
                     revert(add(reason, 32), mload(reason))
                 }
             }
+        }
+    }
+
+    /// @dev Collect mint fees for all parent IPs from the payer and set approval for Royalty Module to spend mint fees.
+    /// @param payerAddress The address of the payer for the license mint fees.
+    /// @param royaltyModule The address of the Royalty Module.
+    /// @param licensingModule The address of the Licensing Module.
+    /// @param licenseTemplate The address of the license template.
+    /// @param parentIpIds The IDs of all the parent IPs.
+    /// @param licenseTermsIds The IDs of the license terms for each corresponding parent IP.
+    function collectMintFeesAndSetApproval(
+        address payerAddress,
+        address royaltyModule,
+        address licensingModule,
+        address licenseTemplate,
+        address[] memory parentIpIds,
+        uint256[] memory licenseTermsIds
+    ) internal {
+        ILicenseTemplate lct = ILicenseTemplate(licenseTemplate);
+        (address royaltyPolicy, , , address mintFeeCurrencyToken) = lct.getRoyaltyPolicy(licenseTermsIds[0]);
+
+        if (royaltyPolicy != address(0)) {
+            // Get total mint fee for all parent IPs
+            uint256 totalMintFee = aggregateMintFees({
+                payerAddress: payerAddress,
+                licensingModule: licensingModule,
+                licenseTemplate: licenseTemplate,
+                parentIpIds: parentIpIds,
+                licenseTermsIds: licenseTermsIds
+            });
+
+            if (totalMintFee != 0) {
+                // Transfer mint fee from payer to this contract
+                IERC20(mintFeeCurrencyToken).safeTransferFrom(payerAddress, address(this), totalMintFee);
+
+                // Approve Royalty Policy to spend mint fee
+                IERC20(mintFeeCurrencyToken).forceApprove(royaltyModule, totalMintFee);
+            }
+        }
+    }
+
+    /// @dev Aggregate license mint fees for all parent IPs.
+    /// @param payerAddress The address of the payer for the license mint fees.
+    /// @param licensingModule The address of the Licensing Module.
+    /// @param licenseTemplate The address of the license template.
+    /// @param parentIpIds The IDs of all the parent IPs.
+    /// @param licenseTermsIds The IDs of the license terms for each corresponding parent IP.
+    /// @return totalMintFee The sum of license mint fees across all parent IPs.
+    function aggregateMintFees(
+        address payerAddress,
+        address licensingModule,
+        address licenseTemplate,
+        address[] memory parentIpIds,
+        uint256[] memory licenseTermsIds
+    ) internal view returns (uint256 totalMintFee) {
+        uint256 mintFee;
+
+        for (uint256 i = 0; i < parentIpIds.length; i++) {
+            (, mintFee) = ILicensingModule(licensingModule).predictMintingLicenseFee({
+                licensorIpId: parentIpIds[i],
+                licenseTemplate: licenseTemplate,
+                licenseTermsId: licenseTermsIds[i],
+                amount: 1,
+                receiver: payerAddress,
+                royaltyContext: ""
+            });
+            totalMintFee += mintFee;
         }
     }
 }

--- a/contracts/lib/WorkflowStructs.sol
+++ b/contracts/lib/WorkflowStructs.sol
@@ -38,4 +38,12 @@ library WorkflowStructs {
         uint256[] licenseTermsIds;
         bytes royaltyContext;
     }
+
+    /// @notice Struct for royalty shares information for royalty token distribution.
+    /// @param author The address of the author.
+    /// @param percentage The percentage of the royalty share, 100_000_000 represents 100%.
+    struct RoyaltyShare {
+        address author;
+        uint32 percentage;
+    }
 }

--- a/contracts/workflows/DerivativeWorkflows.sol
+++ b/contracts/workflows/DerivativeWorkflows.sol
@@ -10,7 +10,6 @@ import { MulticallUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
-import { ILicenseTemplate } from "@storyprotocol/core/interfaces/modules/licensing/ILicenseTemplate.sol";
 import { ILicenseToken } from "@storyprotocol/core/interfaces/ILicenseToken.sol";
 import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingModule.sol";
 import { IRoyaltyModule } from "@storyprotocol/core/interfaces/modules/royalty/IRoyaltyModule.sol";
@@ -19,6 +18,7 @@ import { BaseWorkflow } from "../BaseWorkflow.sol";
 import { Errors } from "../lib/Errors.sol";
 import { IDerivativeWorkflows } from "../interfaces/workflows/IDerivativeWorkflows.sol";
 import { ISPGNFT } from "../interfaces/ISPGNFT.sol";
+import { LicensingHelper } from "../lib/LicensingHelper.sol";
 import { MetadataHelper } from "../lib/MetadataHelper.sol";
 import { PermissionHelper } from "../lib/PermissionHelper.sol";
 import { WorkflowStructs } from "../lib/WorkflowStructs.sol";
@@ -131,7 +131,7 @@ contract DerivativeWorkflows is
 
         MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);
 
-        _collectMintFeesAndSetApproval(
+        LicensingHelper.collectMintFeesAndSetApproval(
             msg.sender,
             address(ROYALTY_MODULE),
             address(LICENSING_MODULE),
@@ -184,7 +184,7 @@ contract DerivativeWorkflows is
             sigRegister
         );
 
-        _collectMintFeesAndSetApproval(
+        LicensingHelper.collectMintFeesAndSetApproval(
             msg.sender,
             address(ROYALTY_MODULE),
             address(LICENSING_MODULE),
@@ -288,73 +288,6 @@ contract DerivativeWorkflows is
                 revert Errors.DerivativeWorkflows__CallerAndNotTokenOwner(licenseTokenIds[i], msg.sender, tokenOwner);
 
             ILicenseToken(licenseToken).safeTransferFrom(msg.sender, address(this), licenseTokenIds[i]);
-        }
-    }
-
-    /// @dev Collect mint fees for all parent IPs from the payer and set approval for Royalty Module to spend mint fees.
-    /// @param payerAddress The address of the payer for the license mint fees.
-    /// @param royaltyModule The address of the Royalty Module.
-    /// @param licensingModule The address of the Licensing Module.
-    /// @param licenseTemplate The address of the license template.
-    /// @param parentIpIds The IDs of all the parent IPs.
-    /// @param licenseTermsIds The IDs of the license terms for each corresponding parent IP.
-    function _collectMintFeesAndSetApproval(
-        address payerAddress,
-        address royaltyModule,
-        address licensingModule,
-        address licenseTemplate,
-        address[] calldata parentIpIds,
-        uint256[] calldata licenseTermsIds
-    ) private {
-        ILicenseTemplate lct = ILicenseTemplate(licenseTemplate);
-        (address royaltyPolicy, , , address mintFeeCurrencyToken) = lct.getRoyaltyPolicy(licenseTermsIds[0]);
-
-        if (royaltyPolicy != address(0)) {
-            // Get total mint fee for all parent IPs
-            uint256 totalMintFee = _aggregateMintFees({
-                payerAddress: payerAddress,
-                licensingModule: licensingModule,
-                licenseTemplate: licenseTemplate,
-                parentIpIds: parentIpIds,
-                licenseTermsIds: licenseTermsIds
-            });
-
-            if (totalMintFee != 0) {
-                // Transfer mint fee from payer to this contract
-                IERC20(mintFeeCurrencyToken).safeTransferFrom(payerAddress, address(this), totalMintFee);
-
-                // Approve Royalty Policy to spend mint fee
-                IERC20(mintFeeCurrencyToken).forceApprove(royaltyModule, totalMintFee);
-            }
-        }
-    }
-
-    /// @dev Aggregate license mint fees for all parent IPs.
-    /// @param payerAddress The address of the payer for the license mint fees.
-    /// @param licensingModule The address of the Licensing Module.
-    /// @param licenseTemplate The address of the license template.
-    /// @param parentIpIds The IDs of all the parent IPs.
-    /// @param licenseTermsIds The IDs of the license terms for each corresponding parent IP.
-    /// @return totalMintFee The sum of license mint fees across all parent IPs.
-    function _aggregateMintFees(
-        address payerAddress,
-        address licensingModule,
-        address licenseTemplate,
-        address[] calldata parentIpIds,
-        uint256[] calldata licenseTermsIds
-    ) private view returns (uint256 totalMintFee) {
-        uint256 mintFee;
-
-        for (uint256 i = 0; i < parentIpIds.length; i++) {
-            (, mintFee) = ILicensingModule(licensingModule).predictMintingLicenseFee({
-                licensorIpId: parentIpIds[i],
-                licenseTemplate: licenseTemplate,
-                licenseTermsId: licenseTermsIds[i],
-                amount: 1,
-                receiver: payerAddress,
-                royaltyContext: ""
-            });
-            totalMintFee += mintFee;
         }
     }
 

--- a/contracts/workflows/RoyaltyTokenDistributionWorkflows.sol
+++ b/contracts/workflows/RoyaltyTokenDistributionWorkflows.sol
@@ -1,0 +1,435 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+// solhint-disable-next-line max-line-length
+import { AccessManagedUpgradeable } from "@openzeppelin/contracts-upgradeable/access/manager/AccessManagedUpgradeable.sol";
+import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { MulticallUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/MulticallUpgradeable.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
+import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
+import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingModule.sol";
+import { IRoyaltyModule } from "@storyprotocol/core/interfaces/modules/royalty/IRoyaltyModule.sol";
+import { PILTerms } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
+
+import { BaseWorkflow } from "../BaseWorkflow.sol";
+import { Errors } from "../lib/Errors.sol";
+import { IRoyaltyTokenDistributionWorkflows } from "../interfaces/workflows/IRoyaltyTokenDistributionWorkflows.sol";
+import { ISPGNFT } from "../interfaces/ISPGNFT.sol";
+import { LicensingHelper } from "../lib/LicensingHelper.sol";
+import { MetadataHelper } from "../lib/MetadataHelper.sol";
+import { PermissionHelper } from "../lib/PermissionHelper.sol";
+import { WorkflowStructs } from "../lib/WorkflowStructs.sol";
+
+/// @title Royalty Token Distribution Workflows
+/// @notice Each workflow bundles multiple core protocol operations into a single function to enable
+/// royalty token distribution upon IP registration in the Story Proof-of-Creativity Protocol.
+contract RoyaltyTokenDistributionWorkflows is
+    IRoyaltyTokenDistributionWorkflows,
+    BaseWorkflow,
+    MulticallUpgradeable,
+    AccessManagedUpgradeable,
+    UUPSUpgradeable
+{
+    using ERC165Checker for address;
+    using SafeERC20 for IERC20;
+
+    /// @dev Storage structure for the RoyaltyTokenDistributionWorkflows
+    /// @param nftContractBeacon The address of the NFT contract beacon.
+    /// @custom:storage-location erc7201:story-protocol-periphery.RoyaltyTokenDistributionWorkflows
+    struct RoyaltyTokenDistributionWorkflowsStorage {
+        address nftContractBeacon;
+    }
+
+    // solhint-disable-next-line max-line-length
+    // keccak256(abi.encode(uint256(keccak256("story-protocol-periphery.RoyaltyTokenDistributionWorkflows")) - 1)) & ~bytes32(uint256(0xff));
+    bytes32 private constant RoyaltyTokenDistributionWorkflowsStorageLocation =
+        0x49f5a60a01a4171ac277a9cd523bb469bbf7cf89b7349fb34e8335e241d25600;
+
+    /// @notice The address of the Royalty Module.
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
+    IRoyaltyModule public immutable ROYALTY_MODULE;
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor(
+        address accessController,
+        address coreMetadataModule,
+        address ipAssetRegistry,
+        address licenseRegistry,
+        address licensingModule,
+        address pilTemplate,
+        address royaltyModule
+    )
+        BaseWorkflow(
+            accessController,
+            coreMetadataModule,
+            ipAssetRegistry,
+            licenseRegistry,
+            licensingModule,
+            pilTemplate
+        )
+    {
+        if (
+            accessController == address(0) ||
+            coreMetadataModule == address(0) ||
+            ipAssetRegistry == address(0) ||
+            licenseRegistry == address(0) ||
+            licensingModule == address(0) ||
+            pilTemplate == address(0) ||
+            royaltyModule == address(0)
+        ) revert Errors.RoyaltyTokenDistributionWorkflows__ZeroAddressParam();
+
+        ROYALTY_MODULE = IRoyaltyModule(royaltyModule);
+
+        _disableInitializers();
+    }
+
+    /// @dev Initializes the contract.
+    /// @param accessManager The address of the protocol access manager.
+    function initialize(address accessManager) external initializer {
+        if (accessManager == address(0)) revert Errors.RoyaltyTokenDistributionWorkflows__ZeroAddressParam();
+        __AccessManaged_init(accessManager);
+        __UUPSUpgradeable_init();
+    }
+
+    /// @dev Sets the NFT contract beacon address.
+    /// @param newNftContractBeacon The address of the new NFT contract beacon.
+    function setNftContractBeacon(address newNftContractBeacon) external restricted {
+        if (newNftContractBeacon == address(0)) revert Errors.RoyaltyTokenDistributionWorkflows__ZeroAddressParam();
+        RoyaltyTokenDistributionWorkflowsStorage storage $ = _getRoyaltyTokenDistributionWorkflowsStorage();
+        $.nftContractBeacon = newNftContractBeacon;
+    }
+
+    /// @notice Mint an NFT and register the IP, attach PIL terms, and distribute royalty tokens.
+    /// @dev In order to successfully distribute royalty tokens, the license terms attached to the IP must be
+    /// a commercial license.
+    /// @param spgNftContract The address of the SPG NFT contract.
+    /// @param recipient The address to receive the NFT.
+    /// @param ipMetadata The metadata for the IP.
+    /// @param terms The PIL terms to attach to the IP (must be a commercial license).
+    /// @param royaltyShares Authors of the IP and their shares of the royalty tokens, see {WorkflowStructs.RoyaltyShare}.
+    /// @return ipId The ID of the registered IP.
+    /// @return tokenId The ID of the minted NFT.
+    /// @return licenseTermsId The ID of the attached PIL terms.
+    function mintAndRegisterIpAndAttachPILTermsAndDistributeRoyaltyTokens(
+        address spgNftContract,
+        address recipient,
+        WorkflowStructs.IPMetadata calldata ipMetadata,
+        PILTerms calldata terms,
+        WorkflowStructs.RoyaltyShare[] calldata royaltyShares
+    ) external onlyMintAuthorized(spgNftContract) returns (address ipId, uint256 tokenId, uint256 licenseTermsId) {
+        tokenId = ISPGNFT(spgNftContract).mintByPeriphery({
+            to: address(this),
+            payer: msg.sender,
+            nftMetadataURI: ipMetadata.nftMetadataURI
+        });
+        ipId = IP_ASSET_REGISTRY.register(block.chainid, spgNftContract, tokenId);
+        MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);
+
+        licenseTermsId = LicensingHelper.registerPILTermsAndAttach(
+            ipId,
+            address(PIL_TEMPLATE),
+            address(LICENSING_MODULE),
+            address(LICENSE_REGISTRY),
+            terms
+        );
+
+        _distributeRoyaltyTokens(
+            ipId,
+            _deployRoyaltyVault(ipId, address(PIL_TEMPLATE), licenseTermsId),
+            royaltyShares,
+            WorkflowStructs.SignatureData(address(0), 0, "") // no signature required.
+        );
+
+        ISPGNFT(spgNftContract).safeTransferFrom(address(this), recipient, tokenId, "");
+    }
+
+    /// @notice Mint an NFT and register the IP, make a derivative, and distribute royalty tokens.
+    /// @dev In order to successfully distribute royalty tokens, the license terms attached to the IP must be
+    /// a commercial license.
+    /// @param spgNftContract The address of the SPG NFT contract.
+    /// @param recipient The address to receive the NFT.
+    /// @param ipMetadata The metadata for the IP.
+    /// @param derivData The data for the derivative, see {WorkflowStructs.MakeDerivative}.
+    /// @param royaltyShares Authors of the IP and their shares of the royalty tokens, see {WorkflowStructs.RoyaltyShare}.
+    /// @return ipId The ID of the registered IP.
+    /// @return tokenId The ID of the minted NFT.
+    function mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens(
+        address spgNftContract,
+        address recipient,
+        WorkflowStructs.IPMetadata calldata ipMetadata,
+        WorkflowStructs.MakeDerivative calldata derivData,
+        WorkflowStructs.RoyaltyShare[] calldata royaltyShares
+    ) external onlyMintAuthorized(spgNftContract) returns (address ipId, uint256 tokenId) {
+        tokenId = ISPGNFT(spgNftContract).mintByPeriphery({
+            to: address(this),
+            payer: msg.sender,
+            nftMetadataURI: ipMetadata.nftMetadataURI
+        });
+        ipId = IP_ASSET_REGISTRY.register(block.chainid, spgNftContract, tokenId);
+
+        MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);
+
+        LicensingHelper.collectMintFeesAndSetApproval(
+            msg.sender,
+            address(ROYALTY_MODULE),
+            address(LICENSING_MODULE),
+            derivData.licenseTemplate,
+            derivData.parentIpIds,
+            derivData.licenseTermsIds
+        );
+
+        LICENSING_MODULE.registerDerivative({
+            childIpId: ipId,
+            parentIpIds: derivData.parentIpIds,
+            licenseTermsIds: derivData.licenseTermsIds,
+            licenseTemplate: derivData.licenseTemplate,
+            royaltyContext: derivData.royaltyContext
+        });
+
+        _distributeRoyaltyTokens(
+            ipId,
+            _deployRoyaltyVault(ipId, derivData.licenseTemplate, derivData.licenseTermsIds[0]),
+            royaltyShares,
+            WorkflowStructs.SignatureData(address(0), 0, "") // no signature required.
+        );
+
+        ISPGNFT(spgNftContract).safeTransferFrom(address(this), recipient, tokenId, "");
+    }
+
+    /// @notice Register an IP, attach PIL terms, and deploy a royalty vault.
+    /// @dev In order to successfully deploy a royalty vault, the license terms attached to the IP must be
+    /// a commercial license.
+    /// @param nftContract The address of the NFT contract.
+    /// @param tokenId The ID of the NFT.
+    /// @param ipMetadata The metadata for the IP.
+    /// @param terms The PIL terms to attach to the IP (must be a commercial license).
+    /// @param sigMetadata The signature data for the IP metadata.
+    /// @param sigAttach The signature data for attaching the PIL terms.
+    /// @return ipId The ID of the registered IP.
+    /// @return licenseTermsId The ID of the attached PIL terms.
+    /// @return ipRoyaltyVault The address of the deployed royalty vault.
+    function registerIpAndAttachPILTermsAndDeployRoyaltyVault(
+        address nftContract,
+        uint256 tokenId,
+        WorkflowStructs.IPMetadata calldata ipMetadata,
+        PILTerms calldata terms,
+        WorkflowStructs.SignatureData calldata sigMetadata,
+        WorkflowStructs.SignatureData calldata sigAttach
+    ) external returns (address ipId, uint256 licenseTermsId, address ipRoyaltyVault) {
+        ipId = IP_ASSET_REGISTRY.register(block.chainid, nftContract, tokenId);
+        MetadataHelper.setMetadataWithSig(
+            ipId,
+            address(CORE_METADATA_MODULE),
+            address(ACCESS_CONTROLLER),
+            ipMetadata,
+            sigMetadata
+        );
+
+        PermissionHelper.setPermissionForModule(
+            ipId,
+            address(LICENSING_MODULE),
+            address(ACCESS_CONTROLLER),
+            ILicensingModule.attachLicenseTerms.selector,
+            sigAttach
+        );
+
+        licenseTermsId = LicensingHelper.registerPILTermsAndAttach(
+            ipId,
+            address(PIL_TEMPLATE),
+            address(LICENSING_MODULE),
+            address(LICENSE_REGISTRY),
+            terms
+        );
+
+        ipRoyaltyVault = _deployRoyaltyVault(ipId, address(PIL_TEMPLATE), licenseTermsId);
+    }
+
+    /// @notice Register an IP, make a derivative, and deploy a royalty vault.
+    /// @dev In order to successfully deploy a royalty vault, the license terms attached to the IP must be
+    /// a commercial license.
+    /// @param nftContract The address of the NFT contract.
+    /// @param tokenId The ID of the NFT.
+    /// @param ipMetadata The metadata for the IP.
+    /// @param derivData The data for the derivative, see {WorkflowStructs.MakeDerivative}.
+    /// @param sigMetadata The signature data for the IP metadata.
+    /// @param sigRegister The signature data for registering the derivative.
+    /// @return ipId The ID of the registered IP.
+    /// @return ipRoyaltyVault The address of the deployed royalty vault.
+    function registerIpAndMakeDerivativeAndDeployRoyaltyVault(
+        address nftContract,
+        uint256 tokenId,
+        WorkflowStructs.IPMetadata calldata ipMetadata,
+        WorkflowStructs.MakeDerivative calldata derivData,
+        WorkflowStructs.SignatureData calldata sigMetadata,
+        WorkflowStructs.SignatureData calldata sigRegister
+    ) external returns (address ipId, address ipRoyaltyVault) {
+        ipId = IP_ASSET_REGISTRY.register(block.chainid, nftContract, tokenId);
+        MetadataHelper.setMetadataWithSig(
+            ipId,
+            address(CORE_METADATA_MODULE),
+            address(ACCESS_CONTROLLER),
+            ipMetadata,
+            sigMetadata
+        );
+
+        PermissionHelper.setPermissionForModule(
+            ipId,
+            address(LICENSING_MODULE),
+            address(ACCESS_CONTROLLER),
+            ILicensingModule.registerDerivative.selector,
+            sigRegister
+        );
+
+        LicensingHelper.collectMintFeesAndSetApproval(
+            msg.sender,
+            address(ROYALTY_MODULE),
+            address(LICENSING_MODULE),
+            derivData.licenseTemplate,
+            derivData.parentIpIds,
+            derivData.licenseTermsIds
+        );
+
+        LICENSING_MODULE.registerDerivative({
+            childIpId: ipId,
+            parentIpIds: derivData.parentIpIds,
+            licenseTermsIds: derivData.licenseTermsIds,
+            licenseTemplate: derivData.licenseTemplate,
+            royaltyContext: derivData.royaltyContext
+        });
+
+        ipRoyaltyVault = _deployRoyaltyVault(ipId, derivData.licenseTemplate, derivData.licenseTermsIds[0]);
+    }
+
+    /// @notice Distribute royalty tokens to the authors of the IP.
+    /// @param ipId The ID of the IP.
+    /// @param ipRoyaltyVault The address of the royalty vault.
+    /// @param royaltyShares Authors of the IP and their shares of the royalty tokens, see {WorkflowStructs.RoyaltyShare}.
+    /// @param sigApproveRoyaltyTokens The signature data for approving the royalty tokens.
+    function distributeRoyaltyTokens(
+        address ipId,
+        address ipRoyaltyVault,
+        WorkflowStructs.RoyaltyShare[] calldata royaltyShares,
+        WorkflowStructs.SignatureData calldata sigApproveRoyaltyTokens
+    ) external {
+        _distributeRoyaltyTokens(ipId, ipRoyaltyVault, royaltyShares, sigApproveRoyaltyTokens);
+    }
+
+    /// @dev Distributes royalty tokens to the authors of the IP.
+    /// @param ipId The ID of the IP.
+    /// @param ipRoyaltyVault The address of the royalty vault.
+    /// @param royaltyShares Authors of the IP and their shares of the royalty tokens, see {WorkflowStructs.RoyaltyShare}.
+    /// @param sigApproveRoyaltyTokens The signature data for approving the royalty tokens.
+    function _distributeRoyaltyTokens(
+        address ipId,
+        address ipRoyaltyVault,
+        WorkflowStructs.RoyaltyShare[] memory royaltyShares,
+        WorkflowStructs.SignatureData memory sigApproveRoyaltyTokens
+    ) internal {
+        if (ipRoyaltyVault == address(0)) revert Errors.RoyaltyTokenDistributionWorkflows__RoyaltyVaultNotDeployed();
+
+        uint32 totalPercentages = _validateRoyaltyShares(royaltyShares);
+
+        if (sigApproveRoyaltyTokens.signature.length > 0) {
+            IIPAccount(payable(ipId)).executeWithSig({
+                to: ipRoyaltyVault,
+                value: 0,
+                data: abi.encodeWithSelector(IERC20.approve.selector, address(this), uint256(totalPercentages)),
+                signer: sigApproveRoyaltyTokens.signer,
+                deadline: sigApproveRoyaltyTokens.deadline,
+                signature: sigApproveRoyaltyTokens.signature
+            });
+        } else {
+            IIPAccount(payable(ipId)).execute({
+                to: ipRoyaltyVault,
+                value: 0,
+                data: abi.encodeWithSelector(IERC20.approve.selector, address(this), uint256(totalPercentages))
+            });
+        }
+
+        // distribute the royalty tokens
+        for (uint256 i; i < royaltyShares.length; i++) {
+            IERC20(ipRoyaltyVault).transferFrom({
+                from: ipId,
+                to: royaltyShares[i].author,
+                value: royaltyShares[i].percentage
+            });
+        }
+    }
+
+    /// @dev Validates the royalty shares.
+    /// @param royaltyShares Authors of the IP and their shares of the royalty tokens, see {WorkflowStructs.RoyaltyShare}.
+    /// @return totalPercentages The total percentages of the royalty shares.
+    function _validateRoyaltyShares(
+        WorkflowStructs.RoyaltyShare[] memory royaltyShares
+    ) internal returns (uint32 totalPercentages) {
+        for (uint256 i; i < royaltyShares.length; i++) {
+            totalPercentages += royaltyShares[i].percentage;
+            if (totalPercentages > 100_000_000)
+                revert Errors.RoyaltyTokenDistributionWorkflows__TotalPercentagesExceeds100Percent();
+        }
+
+        return totalPercentages;
+    }
+
+    /// @dev Deploys a royalty vault for the IP.
+    /// @param ipId The ID of the IP.
+    /// @param licenseTemplate The address of the license template.
+    /// @param licenseTermsId The ID of the license terms.
+    /// @return ipRoyaltyVault The address of the deployed royalty vault.
+    function _deployRoyaltyVault(
+        address ipId,
+        address licenseTemplate,
+        uint256 licenseTermsId
+    ) internal returns (address ipRoyaltyVault) {
+        // if no royalty vault, mint a license token to trigger the vault deployment
+        if (ROYALTY_MODULE.ipRoyaltyVaults(ipId) == address(0)) {
+            address[] memory parentIpIds = new address[](1);
+            uint256[] memory licenseTermsIds = new uint256[](1);
+            parentIpIds[0] = ipId;
+            licenseTermsIds[0] = licenseTermsId;
+
+            LicensingHelper.collectMintFeesAndSetApproval({
+                payerAddress: msg.sender,
+                royaltyModule: address(ROYALTY_MODULE),
+                licensingModule: address(LICENSING_MODULE),
+                licenseTemplate: licenseTemplate,
+                parentIpIds: parentIpIds,
+                licenseTermsIds: licenseTermsIds
+            });
+
+            LICENSING_MODULE.mintLicenseTokens({
+                licensorIpId: ipId,
+                licenseTemplate: licenseTemplate,
+                licenseTermsId: licenseTermsId,
+                amount: 1,
+                receiver: msg.sender,
+                royaltyContext: ""
+            });
+        }
+
+        ipRoyaltyVault = ROYALTY_MODULE.ipRoyaltyVaults(ipId);
+        if (ipRoyaltyVault == address(0)) revert Errors.RoyaltyTokenDistributionWorkflows__RoyaltyVaultNotDeployed();
+    }
+
+    //
+    // Upgrade
+    //
+
+    /// @dev Returns the storage struct of RoyaltyTokenDistributionWorkflows.
+    function _getRoyaltyTokenDistributionWorkflowsStorage()
+        private
+        pure
+        returns (RoyaltyTokenDistributionWorkflowsStorage storage $)
+    {
+        assembly {
+            $.slot := RoyaltyTokenDistributionWorkflowsStorageLocation
+        }
+    }
+
+    /// @dev Hook to authorize the upgrade according to UUPSUpgradeable
+    /// @param newImplementation The address of the new implementation
+    function _authorizeUpgrade(address newImplementation) internal override restricted {}
+}

--- a/script/upgrade/UpgradeSPGNFT.s.sol
+++ b/script/upgrade/UpgradeSPGNFT.s.sol
@@ -36,7 +36,8 @@ contract UpgradeSPGNFT is UpgradeHelper {
             address(derivativeWorkflows),
             address(groupingWorkflows),
             address(licenseAttachmentWorkflows),
-            address(registrationWorkflows)
+            address(registrationWorkflows),
+            address(royaltyTokenDistributionWorkflows)
         );
         spgNftImplAddr = address(spgNftImpl);
         console2.log("SPGNFTImpl deployed to: ", spgNftImplAddr);

--- a/script/utils/DeployHelper.sol
+++ b/script/utils/DeployHelper.sol
@@ -40,6 +40,7 @@ import { LicenseAttachmentWorkflows } from "../../contracts/workflows/LicenseAtt
 import { OrgNFT } from "../../contracts/story-nft/OrgNFT.sol";
 import { RegistrationWorkflows } from "../../contracts/workflows/RegistrationWorkflows.sol";
 import { RoyaltyWorkflows } from "../../contracts/workflows/RoyaltyWorkflows.sol";
+import { RoyaltyTokenDistributionWorkflows } from "../../contracts/workflows/RoyaltyTokenDistributionWorkflows.sol";
 import { StoryBadgeNFT } from "../../contracts/story-nft/StoryBadgeNFT.sol";
 import { StoryNFTFactory } from "../../contracts/story-nft/StoryNFTFactory.sol";
 
@@ -84,6 +85,7 @@ contract DeployHelper is
     LicenseAttachmentWorkflows internal licenseAttachmentWorkflows;
     RegistrationWorkflows internal registrationWorkflows;
     RoyaltyWorkflows internal royaltyWorkflows;
+    RoyaltyTokenDistributionWorkflows internal royaltyTokenDistributionWorkflows;
 
     // StoryNFT
     StoryNFTFactory internal storyNftFactory;
@@ -374,6 +376,27 @@ contract DeployHelper is
         impl = address(0);
         _postdeploy("RoyaltyWorkflows", address(royaltyWorkflows));
 
+        _predeploy("RoyaltyTokenDistributionWorkflows");
+        impl = address(new RoyaltyTokenDistributionWorkflows(
+            accessControllerAddr,
+            coreMetadataModuleAddr,
+            ipAssetRegistryAddr,
+            licenseRegistryAddr,
+            licensingModuleAddr,
+            pilTemplateAddr,
+            royaltyModuleAddr
+        ));
+        royaltyTokenDistributionWorkflows = RoyaltyTokenDistributionWorkflows(
+            TestProxyHelper.deployUUPSProxy(
+                create3Deployer,
+                _getSalt(type(RoyaltyTokenDistributionWorkflows).name),
+                impl,
+                abi.encodeCall(RoyaltyTokenDistributionWorkflows.initialize, address(protocolAccessManagerAddr))
+            )
+        );
+        impl = address(0);
+        _postdeploy("RoyaltyTokenDistributionWorkflows", address(royaltyTokenDistributionWorkflows));
+
         // SPGNFT contracts
         _predeploy("SPGNFTImpl");
         spgNftImpl = SPGNFT(
@@ -384,7 +407,8 @@ contract DeployHelper is
                         address(derivativeWorkflows),
                         address(groupingWorkflows),
                         address(licenseAttachmentWorkflows),
-                        address(registrationWorkflows)
+                        address(registrationWorkflows),
+                        address(royaltyTokenDistributionWorkflows)
                     )
                 )
             )

--- a/script/utils/StoryProtocolPeripheryAddressManager.sol
+++ b/script/utils/StoryProtocolPeripheryAddressManager.sol
@@ -12,6 +12,7 @@ contract StoryProtocolPeripheryAddressManager is Script {
     address internal licenseAttachmentWorkflowsAddr;
     address internal registrationWorkflowsAddr;
     address internal royaltyWorkflowsAddr;
+    address internal royaltyTokenDistributionWorkflowsAddr;
     address internal spgNftBeaconAddr;
     address internal spgNftImplAddr;
     address internal defaultStoryNftTemplateAddr;
@@ -30,6 +31,7 @@ contract StoryProtocolPeripheryAddressManager is Script {
         licenseAttachmentWorkflowsAddr = json.readAddress(".main.LicenseAttachmentWorkflows");
         registrationWorkflowsAddr = json.readAddress(".main.RegistrationWorkflows");
         royaltyWorkflowsAddr = json.readAddress(".main.RoyaltyWorkflows");
+        royaltyTokenDistributionWorkflowsAddr = json.readAddress(".main.RoyaltyTokenDistributionWorkflows");
         spgNftBeaconAddr = json.readAddress(".main.SPGNFTBeacon");
         spgNftImplAddr = json.readAddress(".main.SPGNFTImpl");
         defaultStoryNftTemplateAddr = json.readAddress(".main.DefaultStoryNftTemplate");

--- a/script/utils/upgrades/ERC7201Helper.s.sol
+++ b/script/utils/upgrades/ERC7201Helper.s.sol
@@ -12,7 +12,7 @@ import { console2 } from "forge-std/console2.sol";
 /// https://stackoverflow.com/questions/67893318/solidity-how-to-represent-bytes32-as-string
 contract ERC7201HelperScript is Script {
     string constant NAMESPACE = "story-protocol-periphery";
-    string constant CONTRACT_NAME = "RegistrationWorkflows";
+    string constant CONTRACT_NAME = "RoyaltyTokenDistributionWorkflows";
 
     function run() external pure {
         bytes memory erc7201Key = abi.encodePacked(NAMESPACE, ".", CONTRACT_NAME);

--- a/script/utils/upgrades/UpgradeHelper.s.sol
+++ b/script/utils/upgrades/UpgradeHelper.s.sol
@@ -13,6 +13,7 @@ import { GroupingWorkflows } from "../../../contracts/workflows/GroupingWorkflow
 import { LicenseAttachmentWorkflows } from "../../../contracts/workflows/LicenseAttachmentWorkflows.sol";
 import { RegistrationWorkflows } from "../../../contracts/workflows/RegistrationWorkflows.sol";
 import { RoyaltyWorkflows } from "../../../contracts/workflows/RoyaltyWorkflows.sol";
+import { RoyaltyTokenDistributionWorkflows } from "../../../contracts/workflows/RoyaltyTokenDistributionWorkflows.sol";
 import { SPGNFT } from "../../../contracts/SPGNFT.sol";
 
 // script
@@ -37,6 +38,7 @@ contract UpgradeHelper is
     LicenseAttachmentWorkflows internal licenseAttachmentWorkflows;
     RegistrationWorkflows internal registrationWorkflows;
     RoyaltyWorkflows internal royaltyWorkflows;
+    RoyaltyTokenDistributionWorkflows internal royaltyTokenDistributionWorkflows;
 
     /// @dev SPGNFT contracts
     SPGNFT internal spgNftImpl;
@@ -53,6 +55,7 @@ contract UpgradeHelper is
         licenseAttachmentWorkflows = LicenseAttachmentWorkflows(licenseAttachmentWorkflowsAddr);
         registrationWorkflows = RegistrationWorkflows(registrationWorkflowsAddr);
         royaltyWorkflows = RoyaltyWorkflows(royaltyWorkflowsAddr);
+        royaltyTokenDistributionWorkflows = RoyaltyTokenDistributionWorkflows(royaltyTokenDistributionWorkflowsAddr);
 
         spgNftImpl = SPGNFT(spgNftImplAddr);
         spgNftBeacon = UpgradeableBeacon(spgNftBeaconAddr);

--- a/test/SPGNFT.t.sol
+++ b/test/SPGNFT.t.sol
@@ -47,7 +47,8 @@ contract SPGNFTTest is BaseTest {
                 address(derivativeWorkflows),
                 address(groupingWorkflows),
                 address(licenseAttachmentWorkflows),
-                address(registrationWorkflows)
+                address(registrationWorkflows),
+                address(royaltyTokenDistributionWorkflows)
             )
         );
         address NFT_CONTRACT_BEACON = address(new UpgradeableBeacon(testSpgNftImpl, deployer));
@@ -88,7 +89,8 @@ contract SPGNFTTest is BaseTest {
                 address(derivativeWorkflows),
                 address(groupingWorkflows),
                 address(licenseAttachmentWorkflows),
-                address(registrationWorkflows)
+                address(registrationWorkflows),
+                address(royaltyTokenDistributionWorkflows)
             )
         );
         address NFT_CONTRACT_BEACON = address(new UpgradeableBeacon(testSpgNftImpl, deployer));

--- a/test/utils/BaseTest.t.sol
+++ b/test/utils/BaseTest.t.sol
@@ -118,6 +118,7 @@ contract BaseTest is Test, DeployHelper {
         groupingWorkflows.setNftContractBeacon(address(spgNftBeacon));
         licenseAttachmentWorkflows.setNftContractBeacon(address(spgNftBeacon));
         registrationWorkflows.setNftContractBeacon(address(spgNftBeacon));
+        royaltyTokenDistributionWorkflows.setNftContractBeacon(address(spgNftBeacon));
         vm.stopPrank();
     }
 

--- a/test/workflows/RoyaltyTokenDistributionWorkflows.t.sol
+++ b/test/workflows/RoyaltyTokenDistributionWorkflows.t.sol
@@ -1,0 +1,481 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+// external
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
+import { ICoreMetadataModule } from "@storyprotocol/core/interfaces/modules/metadata/ICoreMetadataModule.sol";
+import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
+import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingModule.sol";
+import { MetaTx } from "@storyprotocol/core/lib/MetaTx.sol";
+import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
+import { PILTerms } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
+
+// contracts
+import { Errors } from "../../contracts/lib/Errors.sol";
+import { ISPGNFT } from "../../contracts/interfaces/ISPGNFT.sol";
+import { WorkflowStructs } from "../../contracts/lib/WorkflowStructs.sol";
+
+// test
+import { BaseTest } from "../utils/BaseTest.t.sol";
+
+contract RoyaltyTokenDistributionWorkflowsTest is BaseTest {
+    using Strings for uint256;
+    using MessageHashUtils for bytes32;
+
+    uint256 private nftMintingFee;
+    uint256 private licenseMintingFee;
+
+    PILTerms private commRemixTerms;
+
+    WorkflowStructs.RoyaltyShare[] private royaltyShares;
+    WorkflowStructs.MakeDerivative private derivativeData;
+
+    function setUp() public override {
+        super.setUp();
+        _setUpTest();
+    }
+
+    function test_RoyaltyTokenDistributionWorkflows_mintAndRegisterIpAndAttachPILTermsAndDistributeRoyaltyTokens()
+        public
+    {
+        vm.startPrank(u.alice);
+        mockToken.mint(u.alice, nftMintingFee + licenseMintingFee);
+        mockToken.approve(address(spgNftPublic), nftMintingFee);
+        mockToken.approve(address(royaltyTokenDistributionWorkflows), licenseMintingFee);
+
+        (address ipId, uint256 tokenId, uint256 licenseTermsId) = royaltyTokenDistributionWorkflows
+            .mintAndRegisterIpAndAttachPILTermsAndDistributeRoyaltyTokens({
+                spgNftContract: address(spgNftPublic),
+                recipient: u.alice,
+                ipMetadata: ipMetadataDefault,
+                terms: commRemixTerms,
+                royaltyShares: royaltyShares
+            });
+        vm.stopPrank();
+
+        assertTrue(ipAssetRegistry.isRegistered(ipId));
+        assertEq(tokenId, 2);
+        assertEq(spgNftPublic.tokenURI(tokenId), string.concat(testBaseURI, ipMetadataDefault.nftMetadataURI));
+        assertMetadata(ipId, ipMetadataDefault);
+        assertEq(licenseTermsId, pilTemplate.getLicenseTermsId(commRemixTerms));
+        (address licenseTemplateAttached, uint256 licenseTermsIdAttached) = licenseRegistry.getAttachedLicenseTerms(
+            ipId,
+            0
+        );
+        assertEq(licenseTemplateAttached, address(pilTemplate));
+        assertEq(licenseTermsIdAttached, pilTemplate.getLicenseTermsId(commRemixTerms));
+        _assertRoyaltyTokenDistribution(ipId);
+    }
+
+    function test_RoyaltyTokenDistributionWorkflows_mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens()
+        public
+    {
+        vm.startPrank(u.alice);
+        mockToken.mint(u.alice, nftMintingFee + licenseMintingFee);
+        mockToken.approve(address(spgNftPublic), nftMintingFee);
+        mockToken.approve(address(royaltyTokenDistributionWorkflows), licenseMintingFee);
+
+        (address ipId, uint256 tokenId) = royaltyTokenDistributionWorkflows
+            .mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens({
+                spgNftContract: address(spgNftPublic),
+                recipient: u.alice,
+                ipMetadata: ipMetadataDefault,
+                derivData: derivativeData,
+                royaltyShares: royaltyShares
+            });
+        vm.stopPrank();
+
+        assertEq(tokenId, 2);
+        assertEq(spgNftPublic.tokenURI(tokenId), string.concat(testBaseURI, ipMetadataDefault.nftMetadataURI));
+        assertEq(ipAssetRegistry.ipId(block.chainid, address(spgNftPublic), tokenId), ipId);
+        assertMetadata(ipId, ipMetadataDefault);
+        assertParentChild({
+            parentIpId: derivativeData.parentIpIds[0],
+            childIpId: ipId,
+            expectedParentCount: 1,
+            expectedParentIndex: 0
+        });
+        (address licenseTemplateAttached, uint256 licenseTermsIdAttached) = licenseRegistry.getAttachedLicenseTerms(
+            ipId,
+            0
+        );
+        assertEq(licenseTemplateAttached, address(pilTemplate));
+        assertEq(licenseTermsIdAttached, derivativeData.licenseTermsIds[0]);
+        _assertRoyaltyTokenDistribution(ipId);
+    }
+
+    function test_RoyaltyTokenDistributionWorkflows_registerIpAndAttachPILTermsAndDistributeRoyaltyTokens() public {
+        uint256 tokenId = mockNft.mint(u.alice);
+        address expectedIpId = ipAssetRegistry.ipId(block.chainid, address(mockNft), tokenId);
+
+        uint256 deadline = block.timestamp + 1000;
+
+        WorkflowStructs.SignatureData memory sigMetadata;
+        WorkflowStructs.SignatureData memory sigAttach;
+        WorkflowStructs.SignatureData memory sigApproveRoyaltyTokens;
+        bytes32 expectedStateAttach;
+
+        {
+            (bytes memory signatureMetadata, bytes32 expectedStateMetadata, ) = _getSetPermissionSigForPeriphery({
+                ipId: expectedIpId,
+                to: address(royaltyTokenDistributionWorkflows),
+                module: address(coreMetadataModule),
+                selector: ICoreMetadataModule.setAll.selector,
+                deadline: deadline,
+                state: bytes32(0),
+                signerSk: sk.alice
+            });
+
+            bytes memory signatureAttach;
+            (signatureAttach, expectedStateAttach, ) = _getSetPermissionSigForPeriphery({
+                ipId: expectedIpId,
+                to: address(royaltyTokenDistributionWorkflows),
+                module: address(licensingModule),
+                selector: ILicensingModule.attachLicenseTerms.selector,
+                deadline: deadline,
+                state: expectedStateMetadata,
+                signerSk: sk.alice
+            });
+
+            sigMetadata = WorkflowStructs.SignatureData({
+                signer: u.alice,
+                deadline: deadline,
+                signature: signatureMetadata
+            });
+
+            sigAttach = WorkflowStructs.SignatureData({
+                signer: u.alice,
+                deadline: deadline,
+                signature: signatureAttach
+            });
+        }
+
+        // register IP, attach PIL terms, and deploy royalty vault
+        vm.startPrank(u.alice);
+        mockToken.mint(u.alice, licenseMintingFee);
+        mockToken.approve(address(royaltyTokenDistributionWorkflows), licenseMintingFee);
+        (address ipId, uint256 licenseTermsId, address ipRoyaltyVault) = royaltyTokenDistributionWorkflows
+            .registerIpAndAttachPILTermsAndDeployRoyaltyVault({
+                nftContract: address(mockNft),
+                tokenId: tokenId,
+                ipMetadata: ipMetadataDefault,
+                terms: commRemixTerms,
+                sigMetadata: sigMetadata,
+                sigAttach: sigAttach
+            });
+        vm.stopPrank();
+
+        {
+            (bytes memory signatureApproveRoyaltyTokens, ) = _getSigForExecuteWithSig({
+                ipId: expectedIpId,
+                to: ipRoyaltyVault,
+                deadline: deadline,
+                state: expectedStateAttach,
+                data: abi.encodeWithSelector(
+                    IERC20.approve.selector,
+                    address(royaltyTokenDistributionWorkflows),
+                    100_000_000 // 100%
+                ),
+                signerSk: sk.alice
+            });
+            sigApproveRoyaltyTokens = WorkflowStructs.SignatureData({
+                signer: u.alice,
+                deadline: deadline,
+                signature: signatureApproveRoyaltyTokens
+            });
+        }
+
+        vm.startPrank(u.alice);
+        // distribute royalty tokens
+        royaltyTokenDistributionWorkflows.distributeRoyaltyTokens({
+            ipId: ipId,
+            ipRoyaltyVault: ipRoyaltyVault,
+            royaltyShares: royaltyShares,
+            sigApproveRoyaltyTokens: sigApproveRoyaltyTokens
+        });
+        vm.stopPrank();
+
+        assertTrue(ipAssetRegistry.isRegistered(ipId));
+        assertMetadata(ipId, ipMetadataDefault);
+        assertEq(licenseTermsId, pilTemplate.getLicenseTermsId(commRemixTerms));
+        (address licenseTemplateAttached, uint256 licenseTermsIdAttached) = licenseRegistry.getAttachedLicenseTerms(
+            ipId,
+            0
+        );
+        assertEq(licenseTemplateAttached, address(pilTemplate));
+        assertEq(licenseTermsIdAttached, pilTemplate.getLicenseTermsId(commRemixTerms));
+        _assertRoyaltyTokenDistribution(ipId);
+    }
+
+    function test_RoyaltyTokenDistributionWorkflows_registerIpAndMakeDerivativeAndDistributeRoyaltyTokens() public {
+        uint256 tokenId = mockNft.mint(u.alice);
+        address expectedIpId = ipAssetRegistry.ipId(block.chainid, address(mockNft), tokenId);
+
+        uint256 deadline = block.timestamp + 1000;
+
+        WorkflowStructs.SignatureData memory sigMetadata;
+        WorkflowStructs.SignatureData memory sigRegister;
+        WorkflowStructs.SignatureData memory sigApproveRoyaltyTokens;
+        bytes32 expectedStateRegister;
+
+        {
+            (bytes memory signatureMetadata, bytes32 expectedStateMetadata, ) = _getSetPermissionSigForPeriphery({
+                ipId: expectedIpId,
+                to: address(royaltyTokenDistributionWorkflows),
+                module: address(coreMetadataModule),
+                selector: ICoreMetadataModule.setAll.selector,
+                deadline: deadline,
+                state: bytes32(0),
+                signerSk: sk.alice
+            });
+
+            bytes memory signatureRegister;
+            (signatureRegister, expectedStateRegister, ) = _getSetPermissionSigForPeriphery({
+                ipId: expectedIpId,
+                to: address(royaltyTokenDistributionWorkflows),
+                module: address(licensingModule),
+                selector: ILicensingModule.registerDerivative.selector,
+                deadline: deadline,
+                state: expectedStateMetadata,
+                signerSk: sk.alice
+            });
+
+            sigMetadata = WorkflowStructs.SignatureData({
+                signer: u.alice,
+                deadline: deadline,
+                signature: signatureMetadata
+            });
+
+            sigRegister = WorkflowStructs.SignatureData({
+                signer: u.alice,
+                deadline: deadline,
+                signature: signatureRegister
+            });
+        }
+
+        // register IP, make derivative, and deploy royalty vault
+        vm.startPrank(u.alice);
+        mockToken.mint(u.alice, licenseMintingFee);
+        mockToken.approve(address(royaltyTokenDistributionWorkflows), licenseMintingFee);
+        (address ipId, address ipRoyaltyVault) = royaltyTokenDistributionWorkflows
+            .registerIpAndMakeDerivativeAndDeployRoyaltyVault({
+                nftContract: address(mockNft),
+                tokenId: tokenId,
+                ipMetadata: ipMetadataDefault,
+                derivData: derivativeData,
+                sigMetadata: sigMetadata,
+                sigRegister: sigRegister
+            });
+        vm.stopPrank();
+
+        {
+            // get signature for approving royalty tokens
+            (bytes memory signatureApproveRoyaltyTokens, ) = _getSigForExecuteWithSig({
+                ipId: expectedIpId,
+                to: ipRoyaltyVault,
+                deadline: deadline,
+                state: expectedStateRegister,
+                data: abi.encodeWithSelector(
+                    IERC20.approve.selector,
+                    address(royaltyTokenDistributionWorkflows),
+                    100_000_000 // 100%
+                ),
+                signerSk: sk.alice
+            });
+            sigApproveRoyaltyTokens = WorkflowStructs.SignatureData({
+                signer: u.alice,
+                deadline: deadline,
+                signature: signatureApproveRoyaltyTokens
+            });
+        }
+
+        vm.startPrank(u.alice);
+        // distribute royalty tokens
+        royaltyTokenDistributionWorkflows.distributeRoyaltyTokens({
+            ipId: ipId,
+            ipRoyaltyVault: ipRoyaltyVault,
+            royaltyShares: royaltyShares,
+            sigApproveRoyaltyTokens: sigApproveRoyaltyTokens
+        });
+        vm.stopPrank();
+
+        assertEq(ipAssetRegistry.ipId(block.chainid, address(mockNft), tokenId), ipId);
+        assertMetadata(ipId, ipMetadataDefault);
+        assertParentChild({
+            parentIpId: derivativeData.parentIpIds[0],
+            childIpId: ipId,
+            expectedParentCount: 1,
+            expectedParentIndex: 0
+        });
+        (address licenseTemplateAttached, uint256 licenseTermsIdAttached) = licenseRegistry.getAttachedLicenseTerms(
+            ipId,
+            0
+        );
+        assertEq(licenseTemplateAttached, address(pilTemplate));
+        assertEq(licenseTermsIdAttached, derivativeData.licenseTermsIds[0]);
+        _assertRoyaltyTokenDistribution(ipId);
+    }
+
+    function test_RoyaltyTokenDistributionWorkflows_revert_TotalPercentagesExceeds100Percent() public {
+        royaltyShares.push(
+            WorkflowStructs.RoyaltyShare({
+                author: u.dan,
+                percentage: 10_000_000 // 10%
+            })
+        );
+
+        vm.startPrank(u.alice);
+        mockToken.mint(u.alice, nftMintingFee + licenseMintingFee);
+        mockToken.approve(address(spgNftPublic), nftMintingFee);
+        mockToken.approve(address(royaltyTokenDistributionWorkflows), licenseMintingFee);
+
+        vm.expectRevert(Errors.RoyaltyTokenDistributionWorkflows__TotalPercentagesExceeds100Percent.selector);
+        royaltyTokenDistributionWorkflows.mintAndRegisterIpAndAttachPILTermsAndDistributeRoyaltyTokens({
+            spgNftContract: address(spgNftPublic),
+            recipient: u.alice,
+            ipMetadata: ipMetadataDefault,
+            terms: commRemixTerms,
+            royaltyShares: royaltyShares
+        });
+        vm.stopPrank();
+    }
+
+    function test_RoyaltyTokenDistributionWorkflows_revert_RoyaltyVaultNotDeployed() public {
+        vm.startPrank(u.alice);
+        mockToken.mint(u.alice, licenseMintingFee);
+        mockToken.approve(address(spgNftPublic), licenseMintingFee);
+
+        vm.expectRevert(Errors.RoyaltyTokenDistributionWorkflows__RoyaltyVaultNotDeployed.selector);
+        royaltyTokenDistributionWorkflows.mintAndRegisterIpAndAttachPILTermsAndDistributeRoyaltyTokens({
+            spgNftContract: address(spgNftPublic),
+            recipient: u.alice,
+            ipMetadata: ipMetadataDefault,
+            terms: PILFlavors.nonCommercialSocialRemixing(),
+            royaltyShares: royaltyShares
+        });
+        vm.stopPrank();
+    }
+
+    function _setUpTest() private {
+        nftMintingFee = 1 * 10 ** mockToken.decimals();
+        licenseMintingFee = 1 * 10 ** mockToken.decimals();
+
+        uint32 testCommRevShare = 5 * 10 ** 6; // 5%
+
+        commRemixTerms = PILFlavors.commercialRemix({
+            mintingFee: licenseMintingFee,
+            commercialRevShare: testCommRevShare,
+            royaltyPolicy: address(royaltyPolicyLAP),
+            currencyToken: address(mockToken)
+        });
+
+        PILTerms[] memory commRemixTermsParent = new PILTerms[](1);
+        commRemixTermsParent[0] = PILFlavors.commercialRemix({
+            mintingFee: licenseMintingFee,
+            commercialRevShare: testCommRevShare,
+            royaltyPolicy: address(royaltyPolicyLRP),
+            currencyToken: address(mockToken)
+        });
+
+        address[] memory ipIdParent = new address[](1);
+        uint256[] memory licenseTermsIdsParent;
+        vm.startPrank(u.alice);
+        mockToken.mint(u.alice, licenseMintingFee);
+        mockToken.approve(address(spgNftPublic), licenseMintingFee);
+        (ipIdParent[0], , licenseTermsIdsParent) = licenseAttachmentWorkflows.mintAndRegisterIpAndAttachPILTerms({
+            spgNftContract: address(spgNftPublic),
+            recipient: u.alice,
+            ipMetadata: ipMetadataDefault,
+            terms: commRemixTermsParent
+        });
+        vm.stopPrank();
+
+        derivativeData = WorkflowStructs.MakeDerivative({
+            parentIpIds: ipIdParent,
+            licenseTemplate: address(pilTemplate),
+            licenseTermsIds: licenseTermsIdsParent,
+            royaltyContext: ""
+        });
+
+        royaltyShares.push(
+            WorkflowStructs.RoyaltyShare({
+                author: u.admin,
+                percentage: 50_000_000 // 50%
+            })
+        );
+
+        royaltyShares.push(
+            WorkflowStructs.RoyaltyShare({
+                author: u.alice,
+                percentage: 20_000_000 // 20%
+            })
+        );
+
+        royaltyShares.push(
+            WorkflowStructs.RoyaltyShare({
+                author: u.bob,
+                percentage: 20_000_000 // 20%
+            })
+        );
+
+        royaltyShares.push(
+            WorkflowStructs.RoyaltyShare({
+                author: u.carl,
+                percentage: 10_000_000 // 10%
+            })
+        );
+    }
+
+    /// @dev Assert that the royalty tokens have been distributed correctly.
+    /// @param ipId The ID of the IP whose royalty tokens to check.
+    function _assertRoyaltyTokenDistribution(address ipId) private {
+        address royaltyVault = royaltyModule.ipRoyaltyVaults(ipId);
+        IERC20 royaltyToken = IERC20(royaltyVault);
+
+        for (uint256 i; i < royaltyShares.length; i++) {
+            assertEq(royaltyToken.balanceOf(royaltyShares[i].author), royaltyShares[i].percentage);
+        }
+    }
+
+    /// @dev Get the signature for executing a function on behalf of the IP via {IIPAccount.executeWithSig}.
+    /// @param ipId The ID of the IP whose account will execute the function.
+    /// @param to The address of the contract to execute the function on.
+    /// @param deadline The deadline for the signature.
+    /// @param state IPAccount's internal nonce
+    /// @param data the call data for the function.
+    /// @param signerSk The secret key of the signer.
+    /// @return signature The signature for executing the function.
+    /// @return expectedState The expected IPAccount's state after executing the function.
+    function _getSigForExecuteWithSig(
+        address ipId,
+        address to,
+        uint256 deadline,
+        bytes32 state,
+        bytes memory data,
+        uint256 signerSk
+    ) internal view returns (bytes memory signature, bytes32 expectedState) {
+        expectedState = keccak256(
+            abi.encode(
+                state, // ipAccount.state()
+                abi.encodeWithSelector(
+                    IIPAccount.execute.selector,
+                    to, // to
+                    0, // value
+                    data
+                )
+            )
+        );
+
+        bytes32 digest = MessageHashUtils.toTypedDataHash(
+            MetaTx.calculateDomainSeparator(ipId),
+            MetaTx.getExecuteStructHash(
+                MetaTx.Execute({ to: to, value: 0, data: data, nonce: expectedState, deadline: deadline })
+            )
+        );
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerSk, digest);
+        signature = abi.encodePacked(r, s, v);
+    }
+}


### PR DESCRIPTION
## Description
<!-- Add a description of the changes that this PR introduces -->
This PR introduces `RoyaltyTokenDistributionWorkflows`, enabling royalty tokens to be distributed among the co-creators of IPs during IP and derivative registration.

### Notes: 
- To successfully distribute royalty tokens through this workflow, the license terms used for each function must be commercial license terms.  
- To register and distribute royalty tokens for an existing NFT, two steps are currently required:  
  1. Call `registerIpAndAttachPILTermsAndDeployRoyaltyVault` or `registerIpAndMakeDerivativeAndDeployRoyaltyVault` to deploy a vault for the newly registered IP.  
  2. Call `distributeRoyaltyTokens` to distribute the royalty tokens for the newly registered IP.  


## Test Plan 
<!-- The test plan section indicates detailed steps on how to verify and test code changes. 
You can list the test cases or test steps that need to be performed.-->
New tests have been added for `RoyaltyTokenDistributionWorkflows` to verify:  
- IP registration.  
- License attachment.  
- IP metadata attachment.  
- Derivative registration.  
- Royalty token distribution.  

All tests pass locally.  


## Related Issue
<!-- The related Issue section can indicate which issue or task the Pull Request is related with -->
- Issue #122 