### PR TITLE
feat(licensing): enable multi-license attachment

### DIFF
--- a/contracts/interfaces/workflows/IGroupingWorkflows.sol
+++ b/contracts/interfaces/workflows/IGroupingWorkflows.sol
@@ -12,8 +12,9 @@ interface IGroupingWorkflows {
     /// @param spgNftContract The address of the SPGNFT collection.
     /// @param groupId The ID of the group IP to add the newly registered IP.
     /// @param recipient The address of the recipient of the minted NFT.
-    /// @param licenseTemplate The address of the license template to be attached to the new IP.
-    /// @param licenseTermsId The ID of the registered license terms that will be attached to the new IP.
+    /// @param licenseTemplates The addresses of the license templates to be attached to the new IP.
+    /// @param licenseTermsIds The IDs of the registered license terms that will be attached to the new IP.
+    ///        The i th license terms ID must be a valid license terms that was registered in the i th license template.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
     /// @param sigAddToGroup Signature data for addIp to the group IP via the Grouping Module.
     /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
@@ -23,8 +24,8 @@ interface IGroupingWorkflows {
         address spgNftContract,
         address groupId,
         address recipient,
-        address licenseTemplate,
-        uint256 licenseTermsId,
+        address[] calldata licenseTemplates,
+        uint256[] calldata licenseTermsIds,
         WorkflowStructs.IPMetadata calldata ipMetadata,
         WorkflowStructs.SignatureData calldata sigAddToGroup,
         bool allowDuplicates
@@ -35,22 +36,25 @@ interface IGroupingWorkflows {
     /// @param nftContract The address of the NFT collection.
     /// @param tokenId The ID of the NFT.
     /// @param groupId The ID of the group IP to add the newly registered IP.
-    /// @param licenseTemplate The address of the license template to be attached to the new IP.
-    /// @param licenseTermsId The ID of the registered license terms that will be attached to the new IP.
+    /// @param licenseTemplates The addresses of the license templates to be attached to the new IP.
+    /// @param licenseTermsIds The IDs of the registered license terms that will be attached to the new IP.
+    ///        The i th license terms ID must be a valid license terms that was registered in the i th license template.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
     /// @param sigMetadata OPTIONAL. Signature data for setAll (metadata).
-    /// @param sigAttach Signature data for attachLicenseTerms to the IP via the Licensing Module.
+    /// @param sigsAttach Signature data for attachLicenseTerms to the IP via the Licensing Module.
+    ///        The i th signature data is for attaching the i th license terms registered
+    ///        in the i th license template to the IP.
     /// @param sigAddToGroup Signature data for addIp to the group IP via the Grouping Module.
     /// @return ipId The ID of the newly registered IP.
     function registerIpAndAttachLicenseAndAddToGroup(
         address nftContract,
         uint256 tokenId,
         address groupId,
-        address licenseTemplate,
-        uint256 licenseTermsId,
+        address[] calldata licenseTemplates,
+        uint256[] calldata licenseTermsIds,
         WorkflowStructs.IPMetadata calldata ipMetadata,
         WorkflowStructs.SignatureData calldata sigMetadata,
-        WorkflowStructs.SignatureData calldata sigAttach,
+        WorkflowStructs.SignatureData[] calldata sigsAttach,
         WorkflowStructs.SignatureData calldata sigAddToGroup
     ) external returns (address ipId);
 

--- a/contracts/interfaces/workflows/IGroupingWorkflows.sol
+++ b/contracts/interfaces/workflows/IGroupingWorkflows.sol
@@ -12,9 +12,7 @@ interface IGroupingWorkflows {
     /// @param spgNftContract The address of the SPGNFT collection.
     /// @param groupId The ID of the group IP to add the newly registered IP.
     /// @param recipient The address of the recipient of the minted NFT.
-    /// @param licenseTemplates The addresses of the license templates to be attached to the new IP.
-    /// @param licenseTermsIds The IDs of the registered license terms that will be attached to the new IP.
-    ///        The i th license terms ID must be a valid license terms that was registered in the i th license template.
+    /// @param licenseTermsInfo The information of the license terms that will be attached to the new IP.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
     /// @param sigAddToGroup Signature data for addIp to the group IP via the Grouping Module.
     /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
@@ -24,8 +22,7 @@ interface IGroupingWorkflows {
         address spgNftContract,
         address groupId,
         address recipient,
-        address[] calldata licenseTemplates,
-        uint256[] calldata licenseTermsIds,
+        WorkflowStructs.LicenseTermsInfo[] calldata licenseTermsInfo,
         WorkflowStructs.IPMetadata calldata ipMetadata,
         WorkflowStructs.SignatureData calldata sigAddToGroup,
         bool allowDuplicates
@@ -36,9 +33,7 @@ interface IGroupingWorkflows {
     /// @param nftContract The address of the NFT collection.
     /// @param tokenId The ID of the NFT.
     /// @param groupId The ID of the group IP to add the newly registered IP.
-    /// @param licenseTemplates The addresses of the license templates to be attached to the new IP.
-    /// @param licenseTermsIds The IDs of the registered license terms that will be attached to the new IP.
-    ///        The i th license terms ID must be a valid license terms that was registered in the i th license template.
+    /// @param licenseTermsInfo The information of the license terms that will be attached to the new IP.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
     /// @param sigMetadata OPTIONAL. Signature data for setAll (metadata).
     /// @param sigsAttach Signature data for attachLicenseTerms to the IP via the Licensing Module.
@@ -50,8 +45,7 @@ interface IGroupingWorkflows {
         address nftContract,
         uint256 tokenId,
         address groupId,
-        address[] calldata licenseTemplates,
-        uint256[] calldata licenseTermsIds,
+        WorkflowStructs.LicenseTermsInfo[] calldata licenseTermsInfo,
         WorkflowStructs.IPMetadata calldata ipMetadata,
         WorkflowStructs.SignatureData calldata sigMetadata,
         WorkflowStructs.SignatureData[] calldata sigsAttach,
@@ -60,13 +54,11 @@ interface IGroupingWorkflows {
 
     /// @notice Register a group IP with a group reward pool and attach license terms to the group IP
     /// @param groupPool The address of the group reward pool.
-    /// @param licenseTemplate The address of the license template to be attached to the new group IP.
-    /// @param licenseTermsId The ID of the registered license terms that will be attached to the new group IP.
+    /// @param licenseTermsInfo The information of the license terms that will be attached to the new group IP.
     /// @return groupId The ID of the newly registered group IP.
     function registerGroupAndAttachLicense(
         address groupPool,
-        address licenseTemplate,
-        uint256 licenseTermsId
+        WorkflowStructs.LicenseTermsInfo calldata licenseTermsInfo
     ) external returns (address groupId);
 
     /// @notice Register a group IP with a group reward pool, attach license terms to the group IP,
@@ -74,14 +66,12 @@ interface IGroupingWorkflows {
     /// @dev ipIds must be have the same license terms as the group IP.
     /// @param groupPool The address of the group reward pool.
     /// @param ipIds The IDs of the IPs to add to the newly registered group IP.
-    /// @param licenseTemplate The address of the license template to be attached to the new group IP.
-    /// @param licenseTermsId The ID of the registered license terms that will be attached to the new group IP.
+    /// @param licenseTermsInfo The information of the license terms that will be attached to the new group IP.
     /// @return groupId The ID of the newly registered group IP.
     function registerGroupAndAttachLicenseAndAddIps(
         address groupPool,
         address[] calldata ipIds,
-        address licenseTemplate,
-        uint256 licenseTermsId
+        WorkflowStructs.LicenseTermsInfo calldata licenseTermsInfo
     ) external returns (address groupId);
 
     /// @notice Collect royalties for the entire group and distribute the rewards to each member IP's royalty vault

--- a/contracts/interfaces/workflows/IGroupingWorkflows.sol
+++ b/contracts/interfaces/workflows/IGroupingWorkflows.sol
@@ -12,7 +12,7 @@ interface IGroupingWorkflows {
     /// @param spgNftContract The address of the SPGNFT collection.
     /// @param groupId The ID of the group IP to add the newly registered IP.
     /// @param recipient The address of the recipient of the minted NFT.
-    /// @param licenseTermsInfo The information of the license terms that will be attached to the new IP.
+    /// @param licenseInfo The information of the license terms that will be attached to the new IP.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
     /// @param sigAddToGroup Signature data for addIp to the group IP via the Grouping Module.
     /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
@@ -22,7 +22,7 @@ interface IGroupingWorkflows {
         address spgNftContract,
         address groupId,
         address recipient,
-        WorkflowStructs.LicenseTermsInfo[] calldata licenseTermsInfo,
+        WorkflowStructs.LicenseInfo[] calldata licenseInfo,
         WorkflowStructs.IPMetadata calldata ipMetadata,
         WorkflowStructs.SignatureData calldata sigAddToGroup,
         bool allowDuplicates
@@ -33,7 +33,7 @@ interface IGroupingWorkflows {
     /// @param nftContract The address of the NFT collection.
     /// @param tokenId The ID of the NFT.
     /// @param groupId The ID of the group IP to add the newly registered IP.
-    /// @param licenseTermsInfo The information of the license terms that will be attached to the new IP.
+    /// @param licenseInfo The information of the license terms that will be attached to the new IP.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
     /// @param sigMetadata OPTIONAL. Signature data for setAll (metadata).
     /// @param sigsAttach Signature data for attachLicenseTerms to the IP via the Licensing Module.
@@ -45,7 +45,7 @@ interface IGroupingWorkflows {
         address nftContract,
         uint256 tokenId,
         address groupId,
-        WorkflowStructs.LicenseTermsInfo[] calldata licenseTermsInfo,
+        WorkflowStructs.LicenseInfo[] calldata licenseInfo,
         WorkflowStructs.IPMetadata calldata ipMetadata,
         WorkflowStructs.SignatureData calldata sigMetadata,
         WorkflowStructs.SignatureData[] calldata sigsAttach,
@@ -54,11 +54,11 @@ interface IGroupingWorkflows {
 
     /// @notice Register a group IP with a group reward pool and attach license terms to the group IP
     /// @param groupPool The address of the group reward pool.
-    /// @param licenseTermsInfo The information of the license terms that will be attached to the new group IP.
+    /// @param licenseInfo The information of the license terms that will be attached to the new group IP.
     /// @return groupId The ID of the newly registered group IP.
     function registerGroupAndAttachLicense(
         address groupPool,
-        WorkflowStructs.LicenseTermsInfo calldata licenseTermsInfo
+        WorkflowStructs.LicenseInfo calldata licenseInfo
     ) external returns (address groupId);
 
     /// @notice Register a group IP with a group reward pool, attach license terms to the group IP,
@@ -66,12 +66,12 @@ interface IGroupingWorkflows {
     /// @dev ipIds must be have the same license terms as the group IP.
     /// @param groupPool The address of the group reward pool.
     /// @param ipIds The IDs of the IPs to add to the newly registered group IP.
-    /// @param licenseTermsInfo The information of the license terms that will be attached to the new group IP.
+    /// @param licenseInfo The information of the license terms that will be attached to the new group IP.
     /// @return groupId The ID of the newly registered group IP.
     function registerGroupAndAttachLicenseAndAddIps(
         address groupPool,
         address[] calldata ipIds,
-        WorkflowStructs.LicenseTermsInfo calldata licenseTermsInfo
+        WorkflowStructs.LicenseInfo calldata licenseInfo
     ) external returns (address groupId);
 
     /// @notice Collect royalties for the entire group and distribute the rewards to each member IP's royalty vault

--- a/contracts/interfaces/workflows/ILicenseAttachmentWorkflows.sol
+++ b/contracts/interfaces/workflows/ILicenseAttachmentWorkflows.sol
@@ -18,14 +18,14 @@ interface ILicenseAttachmentWorkflows {
     /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
     /// @return ipId The ID of the newly registered IP.
     /// @return tokenId The ID of the newly minted NFT.
-    /// @return licenseTermsId The ID of the newly registered PIL terms.
+    /// @return licenseTermsIds The IDs of the newly registered PIL terms.
     function mintAndRegisterIpAndAttachPILTerms(
         address spgNftContract,
         address recipient,
         WorkflowStructs.IPMetadata calldata ipMetadata,
-        PILTerms calldata terms,
+        PILTerms[] calldata terms,
         bool allowDuplicates
-    ) external returns (address ipId, uint256 tokenId, uint256 licenseTermsId);
+    ) external returns (address ipId, uint256 tokenId, uint256[] memory licenseTermsIds);
 
     /// @notice Mint an NFT from a SPGNFT collection, register as an IP, attach provided IP metadata,
     /// and attach the provided license terms to the newly registered IP.
@@ -33,9 +33,9 @@ interface ILicenseAttachmentWorkflows {
     /// @param spgNftContract The address of the SPGNFT collection.
     /// @param recipient The address of the recipient of the newly minted NFT.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
-    /// @param licenseTemplate The address of the license template used of the license terms to be attached.
-    /// @param licenseTermsId The ID of the license terms to attach. Must be a valid ID that exists
-    ///        in the specified license template.
+    /// @param licenseTemplates The addresses of the license templates used of the license terms to be attached.
+    /// @param licenseTermsIds The IDs of the license terms to attach. The i th license terms ID must be a valid license
+    ///        terms that was registered in the i th license template.
     /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
     /// @return ipId The ID of the newly registered IP.
     /// @return tokenId The ID of the newly minted NFT.
@@ -43,8 +43,8 @@ interface ILicenseAttachmentWorkflows {
         address spgNftContract,
         address recipient,
         WorkflowStructs.IPMetadata calldata ipMetadata,
-        address licenseTemplate,
-        uint256 licenseTermsId,
+        address[] calldata licenseTemplates,
+        uint256[] calldata licenseTermsIds,
         bool allowDuplicates
     ) external returns (address ipId, uint256 tokenId);
 
@@ -55,19 +55,21 @@ interface ILicenseAttachmentWorkflows {
     /// @param nftContract The address of the NFT collection.
     /// @param tokenId The ID of the NFT.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
-    /// @param licenseTemplate The address of the license template used of the license terms to be attached.
-    /// @param licenseTermsId The ID of the license terms to attach. Must be a valid ID that exists
-    ///        in the specified license template.
+    /// @param licenseTemplates The addresses of the license templates used of the license terms to be attached.
+    /// @param licenseTermsIds The IDs of the license terms to attach. The i th license terms ID must be a valid license
+    ///        terms that was registered in the i th license template.
     /// @param sigMetadata OPTIONAL. Signature data for setAll (metadata) for the IP via the Core Metadata Module.
-    /// @param sigAttach Signature data for attachLicenseTerms to the IP via the Licensing Module.
+    /// @param sigsAttach Signature data for attachLicenseTerms to the IP via the Licensing Module.
+    ///        The i th signature data is for attaching the i th license terms registered in the i th license template
+    ///        to the IP.
     /// @return ipId The ID of the newly registered IP.
     function registerIpAndAttachLicenseTerms(
         address nftContract,
         uint256 tokenId,
         WorkflowStructs.IPMetadata calldata ipMetadata,
-        address licenseTemplate,
-        uint256 licenseTermsId,
+        address[] calldata licenseTemplates,
+        uint256[] calldata licenseTermsIds,
         WorkflowStructs.SignatureData calldata sigMetadata,
-        WorkflowStructs.SignatureData calldata sigAttach
+        WorkflowStructs.SignatureData[] calldata sigsAttach
     ) external returns (address ipId);
 }

--- a/contracts/lib/LicensingHelper.sol
+++ b/contracts/lib/LicensingHelper.sol
@@ -16,15 +16,18 @@ library LicensingHelper {
     /// @param pilTemplate The address of the PIL License Template.
     /// @param licensingModule The address of the Licensing Module.
     /// @param terms The PIL terms to be registered.
-    /// @return licenseTermsId The ID of the registered PIL terms.
+    /// @return licenseTermsIds The IDs of the registered PIL terms.
     function registerPILTermsAndAttach(
         address ipId,
         address pilTemplate,
         address licensingModule,
-        PILTerms memory terms
-    ) internal returns (uint256 licenseTermsId) {
-        licenseTermsId = IPILicenseTemplate(pilTemplate).registerLicenseTerms(terms);
-        attachLicenseTerms(ipId, licensingModule, pilTemplate, licenseTermsId);
+        PILTerms[] memory terms
+    ) internal returns (uint256[] memory licenseTermsIds) {
+        licenseTermsIds = new uint256[](terms.length);
+        for (uint256 i = 0; i < terms.length; i++) {
+            licenseTermsIds[i] = IPILicenseTemplate(pilTemplate).registerLicenseTerms(terms[i]);
+            attachLicenseTerms(ipId, licensingModule, pilTemplate, licenseTermsIds[i]);
+        }
     }
 
     /// @dev Attaches license terms to the given IP.
@@ -48,24 +51,6 @@ library LicensingHelper {
                 }
             }
         }
-    }
-
-    /// @dev Registers PIL License Terms and attaches them to the given IP on behalf of the owner with a signature.
-    /// @param ipId The ID of the IP to which the license terms will be attached.
-    /// @param pilTemplate The address of the PIL License Template.
-    /// @param licensingModule The address of the Licensing Module.
-    /// @param terms The PIL terms to be registered.
-    /// @param sigAttach Signature data for attachLicenseTerms to the IP via the Licensing Module.
-    /// @return licenseTermsId The ID of the registered PIL terms.
-    function registerPILTermsAndAttachWithSig(
-        address ipId,
-        address pilTemplate,
-        address licensingModule,
-        PILTerms calldata terms,
-        WorkflowStructs.SignatureData memory sigAttach
-    ) internal returns (uint256 licenseTermsId) {
-        licenseTermsId = IPILicenseTemplate(pilTemplate).registerLicenseTerms(terms);
-        attachLicenseTermsWithSig(ipId, licensingModule, pilTemplate, licenseTermsId, sigAttach);
     }
 
     /// @dev Attaches license terms to the given IP on behalf of the owner with a signature.

--- a/contracts/lib/WorkflowStructs.sol
+++ b/contracts/lib/WorkflowStructs.sol
@@ -44,7 +44,7 @@ library WorkflowStructs {
     /// @notice Struct for license terms information.
     /// @param licenseTemplate The address of the license template.
     /// @param licenseTermsId The ID of the license terms which was registered in the license template.
-    struct LicenseTermsInfo {
+    struct LicenseInfo {
         address licenseTemplate;
         uint256 licenseTermsId;
     }

--- a/contracts/lib/WorkflowStructs.sol
+++ b/contracts/lib/WorkflowStructs.sol
@@ -40,4 +40,12 @@ library WorkflowStructs {
         bytes royaltyContext;
         uint256 maxMintingFee;
     }
+
+    /// @notice Struct for license terms information.
+    /// @param licenseTemplate The address of the license template.
+    /// @param licenseTermsId The ID of the license terms which was registered in the license template.
+    struct LicenseTermsInfo {
+        address licenseTemplate;
+        uint256 licenseTermsId;
+    }
 }

--- a/contracts/workflows/GroupingWorkflows.sol
+++ b/contracts/workflows/GroupingWorkflows.sol
@@ -118,7 +118,7 @@ contract GroupingWorkflows is
     /// @param spgNftContract The address of the SPGNFT collection.
     /// @param groupId The ID of the group IP to add the newly registered IP.
     /// @param recipient The address of the recipient of the minted NFT.
-    /// @param licenseTermsInfo The information of the license terms that will be attached to the new IP.
+    /// @param licenseInfo The information of the license terms that will be attached to the new IP.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
     /// @param sigAddToGroup Signature data for addIp to the group IP via the Grouping Module.
     /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
@@ -128,7 +128,7 @@ contract GroupingWorkflows is
         address spgNftContract,
         address groupId,
         address recipient,
-        WorkflowStructs.LicenseTermsInfo[] calldata licenseTermsInfo,
+        WorkflowStructs.LicenseInfo[] calldata licenseInfo,
         WorkflowStructs.IPMetadata calldata ipMetadata,
         WorkflowStructs.SignatureData calldata sigAddToGroup,
         bool allowDuplicates
@@ -145,12 +145,12 @@ contract GroupingWorkflows is
         MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);
 
         // attach license terms to the IP, do nothing if already attached
-        for (uint256 i = 0; i < licenseTermsInfo.length; i++) {
+        for (uint256 i = 0; i < licenseInfo.length; i++) {
             LicensingHelper.attachLicenseTerms(
                 ipId,
                 address(LICENSING_MODULE),
-                licenseTermsInfo[i].licenseTemplate,
-                licenseTermsInfo[i].licenseTermsId
+                licenseInfo[i].licenseTemplate,
+                licenseInfo[i].licenseTermsId
             );
         }
 
@@ -186,7 +186,7 @@ contract GroupingWorkflows is
     /// @param nftContract The address of the NFT collection.
     /// @param tokenId The ID of the NFT.
     /// @param groupId The ID of the group IP to add the newly registered IP.
-    /// @param licenseTermsInfo The information of the license terms that will be attached to the new IP.
+    /// @param licenseInfo The information of the license terms that will be attached to the new IP.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
     /// @param sigMetadata OPTIONAL. Signature data for setAll (metadata) for the IP via the Core Metadata Module.
     /// @param sigsAttach Signature data for attachLicenseTerms to the IP via the Licensing Module.
@@ -198,7 +198,7 @@ contract GroupingWorkflows is
         address nftContract,
         uint256 tokenId,
         address groupId,
-        WorkflowStructs.LicenseTermsInfo[] calldata licenseTermsInfo,
+        WorkflowStructs.LicenseInfo[] calldata licenseInfo,
         WorkflowStructs.IPMetadata calldata ipMetadata,
         WorkflowStructs.SignatureData calldata sigMetadata,
         WorkflowStructs.SignatureData[] calldata sigsAttach,
@@ -208,12 +208,12 @@ contract GroupingWorkflows is
         MetadataHelper.setMetadataWithSig(ipId, address(CORE_METADATA_MODULE), ipMetadata, sigMetadata);
 
         // attach license terms to the IP, do nothing if already attached
-        for (uint256 i = 0; i < licenseTermsInfo.length; i++) {
+        for (uint256 i = 0; i < licenseInfo.length; i++) {
             LicensingHelper.attachLicenseTermsWithSig(
                 ipId,
                 address(LICENSING_MODULE),
-                licenseTermsInfo[i].licenseTemplate,
-                licenseTermsInfo[i].licenseTermsId,
+                licenseInfo[i].licenseTemplate,
+                licenseInfo[i].licenseTermsId,
                 sigsAttach[i]
             );
         }
@@ -235,11 +235,11 @@ contract GroupingWorkflows is
 
     /// @notice Register a group IP with a group reward pool and attach license terms to the group IP
     /// @param groupPool The address of the group reward pool.
-    /// @param licenseTermsInfo The information of the license terms that will be attached to the new group IP.
+    /// @param licenseInfo The information of the license terms that will be attached to the new group IP.
     /// @return groupId The ID of the newly registered group IP.
     function registerGroupAndAttachLicense(
         address groupPool,
-        WorkflowStructs.LicenseTermsInfo calldata licenseTermsInfo
+        WorkflowStructs.LicenseInfo calldata licenseInfo
     ) external returns (address groupId) {
         groupId = GROUPING_MODULE.registerGroup(groupPool);
 
@@ -247,8 +247,8 @@ contract GroupingWorkflows is
         LicensingHelper.attachLicenseTerms(
             groupId,
             address(LICENSING_MODULE),
-            licenseTermsInfo.licenseTemplate,
-            licenseTermsInfo.licenseTermsId
+            licenseInfo.licenseTemplate,
+            licenseInfo.licenseTermsId
         );
 
         GROUP_NFT.safeTransferFrom(address(this), msg.sender, GROUP_NFT.totalSupply() - 1);
@@ -259,12 +259,12 @@ contract GroupingWorkflows is
     /// @dev ipIds must have the same PIL terms as the group IP.
     /// @param groupPool The address of the group reward pool.
     /// @param ipIds The IDs of the IPs to add to the newly registered group IP.
-    /// @param licenseTermsInfo The information of the license terms that will be attached to the new group IP.
+    /// @param licenseInfo The information of the license terms that will be attached to the new group IP.
     /// @return groupId The ID of the newly registered group IP.
     function registerGroupAndAttachLicenseAndAddIps(
         address groupPool,
         address[] calldata ipIds,
-        WorkflowStructs.LicenseTermsInfo calldata licenseTermsInfo
+        WorkflowStructs.LicenseInfo calldata licenseInfo
     ) external returns (address groupId) {
         groupId = GROUPING_MODULE.registerGroup(groupPool);
 
@@ -272,8 +272,8 @@ contract GroupingWorkflows is
         LicensingHelper.attachLicenseTerms(
             groupId,
             address(LICENSING_MODULE),
-            licenseTermsInfo.licenseTemplate,
-            licenseTermsInfo.licenseTermsId
+            licenseInfo.licenseTemplate,
+            licenseInfo.licenseTermsId
         );
 
         GROUPING_MODULE.addIp(groupId, ipIds);

--- a/test/integration/workflows/DerivativeIntegration.t.sol
+++ b/test/integration/workflows/DerivativeIntegration.t.sol
@@ -8,6 +8,7 @@ import { ICoreMetadataModule } from "@storyprotocol/core/interfaces/modules/meta
 import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
 import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingModule.sol";
 import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
+import { PILTerms } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
 
 // contracts
 import { ISPGNFT } from "../../../contracts/interfaces/ISPGNFT.sol";
@@ -413,17 +414,19 @@ contract DerivativeIntegration is BaseIntegration {
 
         StoryUSD.mint(testSender, testMintFee);
         StoryUSD.approve(address(spgNftContract), testMintFee);
-        (address parentIpId, , uint256 licenseTermsIdParent) = licenseAttachmentWorkflows
+        PILTerms[] memory terms = new PILTerms[](1);
+        terms[0] = PILFlavors.commercialRemix({
+            mintingFee: testMintFee,
+            commercialRevShare: 10 * 10 ** 6, // 10%
+            royaltyPolicy: royaltyPolicyLRPAddr,
+            currencyToken: testMintFeeToken
+        });
+        (address parentIpId, , uint256[] memory licenseTermsIdParent) = licenseAttachmentWorkflows
             .mintAndRegisterIpAndAttachPILTerms({
                 spgNftContract: address(spgNftContract),
                 recipient: testSender,
                 ipMetadata: testIpMetadata,
-                terms: PILFlavors.commercialRemix({
-                    mintingFee: testMintFee,
-                    commercialRevShare: 10 * 10 ** 6, // 10%
-                    royaltyPolicy: royaltyPolicyLRPAddr,
-                    currencyToken: testMintFeeToken
-                }),
+                terms: terms,
                 allowDuplicates: true
             });
 
@@ -431,7 +434,7 @@ contract DerivativeIntegration is BaseIntegration {
         parentIpIds[0] = parentIpId;
 
         parentLicenseTermIds = new uint256[](1);
-        parentLicenseTermIds[0] = licenseTermsIdParent;
+        parentLicenseTermIds[0] = licenseTermsIdParent[0];
         parentLicenseTemplate = pilTemplateAddr;
     }
 

--- a/test/integration/workflows/GroupingIntegration.t.sol
+++ b/test/integration/workflows/GroupingIntegration.t.sol
@@ -28,7 +28,7 @@ contract GroupingIntegration is BaseIntegration {
 
     ISPGNFT private spgNftContract;
     address private groupId;
-    WorkflowStructs.LicenseTermsInfo[] private testLicenseTermsInfo;
+    WorkflowStructs.LicenseInfo[] private testLicenseInfo;
     uint32 private revShare;
     uint256 private numIps = 10;
     address[] private ipIds;
@@ -80,7 +80,7 @@ contract GroupingIntegration is BaseIntegration {
             groupId: groupId,
             recipient: testSender,
             ipMetadata: testIpMetadata,
-            licenseTermsInfo: testLicenseTermsInfo,
+            licenseInfo: testLicenseInfo,
             sigAddToGroup: WorkflowStructs.SignatureData({
                 signer: testSender,
                 deadline: deadline,
@@ -94,10 +94,10 @@ contract GroupingIntegration is BaseIntegration {
         assertTrue(IGroupIPAssetRegistry(ipAssetRegistryAddr).containsIp(groupId, ipId));
         assertEq(spgNftContract.tokenURI(tokenId), string.concat(testBaseURI, testIpMetadata.nftMetadataURI));
         assertMetadata(ipId, testIpMetadata);
-        for (uint256 i = 0; i < testLicenseTermsInfo.length; i++) {
+        for (uint256 i = 0; i < testLicenseInfo.length; i++) {
             (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId, i);
-            assertEq(licenseTemplate, testLicenseTermsInfo[i].licenseTemplate);
-            assertEq(licenseTermsId, testLicenseTermsInfo[i].licenseTermsId);
+            assertEq(licenseTemplate, testLicenseInfo[i].licenseTemplate);
+            assertEq(licenseTermsId, testLicenseInfo[i].licenseTermsId);
         }
     }
 
@@ -139,8 +139,8 @@ contract GroupingIntegration is BaseIntegration {
                 ),
                 signerSk: testSenderSk
             });
-            bytes[] memory sigsAttach = new bytes[](testLicenseTermsInfo.length);
-            for (uint256 i = 0; i < testLicenseTermsInfo.length; i++) {
+            bytes[] memory sigsAttach = new bytes[](testLicenseInfo.length);
+            for (uint256 i = 0; i < testLicenseInfo.length; i++) {
                 (sigsAttach[i], expectedState) = _getSigForExecuteWithSig({
                     ipId: expectedIpId,
                     to: licensingModuleAddr,
@@ -149,8 +149,8 @@ contract GroupingIntegration is BaseIntegration {
                     data: abi.encodeWithSelector(
                         ILicensingModule.attachLicenseTerms.selector,
                         expectedIpId,
-                        testLicenseTermsInfo[i].licenseTemplate,
-                        testLicenseTermsInfo[i].licenseTermsId
+                        testLicenseInfo[i].licenseTemplate,
+                        testLicenseInfo[i].licenseTermsId
                     ),
                     signerSk: testSenderSk
                 });
@@ -171,8 +171,8 @@ contract GroupingIntegration is BaseIntegration {
                 deadline: deadline,
                 signature: sigMetadata
             });
-            sigsAttachData = new WorkflowStructs.SignatureData[](testLicenseTermsInfo.length);
-            for (uint256 i = 0; i < testLicenseTermsInfo.length; i++) {
+            sigsAttachData = new WorkflowStructs.SignatureData[](testLicenseInfo.length);
+            for (uint256 i = 0; i < testLicenseInfo.length; i++) {
                 sigsAttachData[i] = WorkflowStructs.SignatureData({
                     signer: testSender,
                     deadline: deadline,
@@ -190,7 +190,7 @@ contract GroupingIntegration is BaseIntegration {
             nftContract: address(spgNftContract),
             tokenId: tokenId,
             groupId: groupId,
-            licenseTermsInfo: testLicenseTermsInfo,
+            licenseInfo: testLicenseInfo,
             ipMetadata: testIpMetadata,
             sigMetadata: sigMetadataData,
             sigsAttach: sigsAttachData,
@@ -203,10 +203,10 @@ contract GroupingIntegration is BaseIntegration {
         assertMetadata(ipId, testIpMetadata);
         address licenseTemplate;
         uint256 licenseTermsId;
-        for (uint256 i = 0; i < testLicenseTermsInfo.length; i++) {
+        for (uint256 i = 0; i < testLicenseInfo.length; i++) {
             (licenseTemplate, licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId, i);
-            assertEq(licenseTemplate, testLicenseTermsInfo[i].licenseTemplate);
-            assertEq(licenseTermsId, testLicenseTermsInfo[i].licenseTermsId);
+            assertEq(licenseTemplate, testLicenseInfo[i].licenseTemplate);
+            assertEq(licenseTermsId, testLicenseInfo[i].licenseTermsId);
         }
     }
 
@@ -216,7 +216,7 @@ contract GroupingIntegration is BaseIntegration {
     {
         address newGroupId = groupingWorkflows.registerGroupAndAttachLicense({
             groupPool: evenSplitGroupPoolAddr,
-            licenseTermsInfo: testLicenseTermsInfo[0]
+            licenseInfo: testLicenseInfo[0]
         });
 
         // check the group IPA is registered
@@ -224,8 +224,8 @@ contract GroupingIntegration is BaseIntegration {
 
         // check the license terms is correctly attached to the group IPA
         (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(newGroupId, 0);
-        assertEq(licenseTemplate, testLicenseTermsInfo[0].licenseTemplate);
-        assertEq(licenseTermsId, testLicenseTermsInfo[0].licenseTermsId);
+        assertEq(licenseTemplate, testLicenseInfo[0].licenseTemplate);
+        assertEq(licenseTermsId, testLicenseInfo[0].licenseTermsId);
     }
 
     function _test_GroupingIntegration_registerGroupAndAttachLicenseAndAddIps()
@@ -235,7 +235,7 @@ contract GroupingIntegration is BaseIntegration {
         address newGroupId = groupingWorkflows.registerGroupAndAttachLicenseAndAddIps({
             groupPool: evenSplitGroupPoolAddr,
             ipIds: ipIds,
-            licenseTermsInfo: testLicenseTermsInfo[0]
+            licenseInfo: testLicenseInfo[0]
         });
 
         // check the group IPA is registered
@@ -249,8 +249,8 @@ contract GroupingIntegration is BaseIntegration {
 
         // check the license terms is correctly attached to the group IPA
         (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(newGroupId, 0);
-        assertEq(licenseTemplate, testLicenseTermsInfo[0].licenseTemplate);
-        assertEq(licenseTermsId, testLicenseTermsInfo[0].licenseTermsId);
+        assertEq(licenseTemplate, testLicenseInfo[0].licenseTemplate);
+        assertEq(licenseTermsId, testLicenseInfo[0].licenseTermsId);
     }
 
     function _test_GroupingIntegration_collectRoyaltiesAndClaimReward()
@@ -260,7 +260,7 @@ contract GroupingIntegration is BaseIntegration {
         address newGroupId = groupingWorkflows.registerGroupAndAttachLicenseAndAddIps({
             groupPool: evenSplitGroupPoolAddr,
             ipIds: ipIds,
-            licenseTermsInfo: testLicenseTermsInfo[0]
+            licenseInfo: testLicenseInfo[0]
         });
 
         assertEq(IGroupIPAssetRegistry(ipAssetRegistryAddr).totalMembers(newGroupId), numIps);
@@ -269,7 +269,7 @@ contract GroupingIntegration is BaseIntegration {
         address[] memory parentIpIds = new address[](1);
         parentIpIds[0] = newGroupId;
         uint256[] memory licenseTermsIds = new uint256[](1);
-        licenseTermsIds[0] = testLicenseTermsInfo[0].licenseTermsId;
+        licenseTermsIds[0] = testLicenseInfo[0].licenseTermsId;
 
         StoryUSD.mint(testSender, testMintFee);
         StoryUSD.approve(address(spgNftContract), testMintFee);
@@ -278,7 +278,7 @@ contract GroupingIntegration is BaseIntegration {
             derivData: WorkflowStructs.MakeDerivative({
                 parentIpIds: parentIpIds,
                 licenseTermsIds: licenseTermsIds,
-                licenseTemplate: testLicenseTermsInfo[0].licenseTemplate,
+                licenseTemplate: testLicenseInfo[0].licenseTemplate,
                 royaltyContext: "",
                 maxMintingFee: 0
             }),
@@ -294,7 +294,7 @@ contract GroupingIntegration is BaseIntegration {
             derivData: WorkflowStructs.MakeDerivative({
                 parentIpIds: parentIpIds,
                 licenseTermsIds: licenseTermsIds,
-                licenseTemplate: testLicenseTermsInfo[0].licenseTemplate,
+                licenseTemplate: testLicenseInfo[0].licenseTemplate,
                 royaltyContext: "",
                 maxMintingFee: 0
             }),
@@ -381,7 +381,7 @@ contract GroupingIntegration is BaseIntegration {
                 address(spgNftContract),
                 groupId,
                 testSender,
-                testLicenseTermsInfo,
+                testLicenseInfo,
                 testIpMetadata,
                 WorkflowStructs.SignatureData({ signer: testSender, deadline: deadline, signature: sigsAddToGroup[i] })
             );
@@ -404,10 +404,10 @@ contract GroupingIntegration is BaseIntegration {
             assertMetadata(ipId, testIpMetadata);
             address licenseTemplate;
             uint256 licenseTermsId;
-            for (uint256 j = 0; j < testLicenseTermsInfo.length; j++) {
+            for (uint256 j = 0; j < testLicenseInfo.length; j++) {
                 (licenseTemplate, licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId, j);
-                assertEq(licenseTemplate, testLicenseTermsInfo[j].licenseTemplate);
-                assertEq(licenseTermsId, testLicenseTermsInfo[j].licenseTermsId);
+                assertEq(licenseTemplate, testLicenseInfo[j].licenseTemplate);
+                assertEq(licenseTermsId, testLicenseInfo[j].licenseTermsId);
             }
         }
     }
@@ -470,7 +470,7 @@ contract GroupingIntegration is BaseIntegration {
                 });
 
                 // Get the signature for executing `attachLicenseTerms` function in `LicensingModule` on behalf of the IP owner
-                for (uint256 j = 0; j < testLicenseTermsInfo.length; j++) {
+                for (uint256 j = 0; j < testLicenseInfo.length; j++) {
                     (sigAttach, expectedState) = _getSigForExecuteWithSig({
                         ipId: expectedIpIds[i],
                         to: licensingModuleAddr,
@@ -479,8 +479,8 @@ contract GroupingIntegration is BaseIntegration {
                         data: abi.encodeWithSelector(
                             ILicensingModule.attachLicenseTerms.selector,
                             expectedIpIds[i],
-                            testLicenseTermsInfo[j].licenseTemplate,
-                            testLicenseTermsInfo[j].licenseTermsId
+                            testLicenseInfo[j].licenseTemplate,
+                            testLicenseInfo[j].licenseTermsId
                         ),
                         signerSk: testSenderSk
                     });
@@ -523,7 +523,7 @@ contract GroupingIntegration is BaseIntegration {
                 address(spgNftContract),
                 tokenIds[i],
                 groupId,
-                testLicenseTermsInfo,
+                testLicenseInfo,
                 testIpMetadata,
                 sigMetadataData[i],
                 sigAttachData[i],
@@ -542,10 +542,10 @@ contract GroupingIntegration is BaseIntegration {
             assertTrue(ipAssetRegistry.isRegistered(ipId));
             assertTrue(IGroupIPAssetRegistry(ipAssetRegistryAddr).containsIp(groupId, ipId));
             assertMetadata(ipId, testIpMetadata);
-            for (uint256 j = 0; j < testLicenseTermsInfo.length; j++) {
+            for (uint256 j = 0; j < testLicenseInfo.length; j++) {
                 (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId, j);
-                assertEq(licenseTemplate, testLicenseTermsInfo[j].licenseTemplate);
-                assertEq(licenseTermsId, testLicenseTermsInfo[j].licenseTermsId);
+                assertEq(licenseTemplate, testLicenseInfo[j].licenseTemplate);
+                assertEq(licenseTermsId, testLicenseInfo[j].licenseTermsId);
             }
         }
     }
@@ -553,8 +553,8 @@ contract GroupingIntegration is BaseIntegration {
     function _setUpTest() private {
         revShare = 10 * 10 ** 6; // 10%
 
-        testLicenseTermsInfo.push(
-            WorkflowStructs.LicenseTermsInfo({
+        testLicenseInfo.push(
+            WorkflowStructs.LicenseInfo({
                 licenseTemplate: pilTemplateAddr,
                 licenseTermsId: pilTemplate.registerLicenseTerms(
                     // minting fee is set to 0 beacause currently core protocol requires group IP's minting fee to be 0
@@ -568,8 +568,8 @@ contract GroupingIntegration is BaseIntegration {
             })
         );
 
-        testLicenseTermsInfo.push(
-            WorkflowStructs.LicenseTermsInfo({
+        testLicenseInfo.push(
+            WorkflowStructs.LicenseInfo({
                 licenseTemplate: pilTemplateAddr,
                 licenseTermsId: pilTemplate.registerLicenseTerms(
                     // Another license that will not be associated with the group IP
@@ -589,8 +589,8 @@ contract GroupingIntegration is BaseIntegration {
             LicensingHelper.attachLicenseTerms(
                 groupId,
                 licensingModuleAddr,
-                testLicenseTermsInfo[0].licenseTemplate,
-                testLicenseTermsInfo[0].licenseTermsId
+                testLicenseInfo[0].licenseTemplate,
+                testLicenseInfo[0].licenseTermsId
             );
         }
 
@@ -638,12 +638,12 @@ contract GroupingIntegration is BaseIntegration {
 
             // attach license terms to the IPs
             for (uint256 i = 0; i < numIps; i++) {
-                for (uint256 j = 0; j < testLicenseTermsInfo.length; j++) {
+                for (uint256 j = 0; j < testLicenseInfo.length; j++) {
                     LicensingHelper.attachLicenseTerms(
                         ipIds[i],
                         licensingModuleAddr,
-                        testLicenseTermsInfo[j].licenseTemplate,
-                        testLicenseTermsInfo[j].licenseTermsId
+                        testLicenseInfo[j].licenseTemplate,
+                        testLicenseInfo[j].licenseTermsId
                     );
                 }
             }

--- a/test/integration/workflows/GroupingIntegration.t.sol
+++ b/test/integration/workflows/GroupingIntegration.t.sol
@@ -28,8 +28,8 @@ contract GroupingIntegration is BaseIntegration {
 
     ISPGNFT private spgNftContract;
     address private groupId;
-    address private testLicenseTemplate;
-    uint256 private testLicenseTermsId;
+    address[] private testLicenseTemplates;
+    uint256[] private testLicenseTermsIds;
     uint32 private revShare;
     uint256 private numIps = 10;
     address[] private ipIds;
@@ -81,8 +81,8 @@ contract GroupingIntegration is BaseIntegration {
             groupId: groupId,
             recipient: testSender,
             ipMetadata: testIpMetadata,
-            licenseTemplate: testLicenseTemplate,
-            licenseTermsId: testLicenseTermsId,
+            licenseTemplates: testLicenseTemplates,
+            licenseTermsIds: testLicenseTermsIds,
             sigAddToGroup: WorkflowStructs.SignatureData({
                 signer: testSender,
                 deadline: deadline,
@@ -96,9 +96,11 @@ contract GroupingIntegration is BaseIntegration {
         assertTrue(IGroupIPAssetRegistry(ipAssetRegistryAddr).containsIp(groupId, ipId));
         assertEq(spgNftContract.tokenURI(tokenId), string.concat(testBaseURI, testIpMetadata.nftMetadataURI));
         assertMetadata(ipId, testIpMetadata);
-        (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId, 0);
-        assertEq(licenseTemplate, testLicenseTemplate);
-        assertEq(licenseTermsId, testLicenseTermsId);
+        for (uint256 i = 0; i < testLicenseTermsIds.length; i++) {
+            (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId, i);
+            assertEq(licenseTemplate, testLicenseTemplates[i]);
+            assertEq(licenseTermsId, testLicenseTermsIds[i]);
+        }
     }
 
     function _test_GroupingIntegration_registerIpAndAttachLicenseAndAddToGroup()
@@ -118,7 +120,7 @@ contract GroupingIntegration is BaseIntegration {
         address expectedIpId = ipAssetRegistry.ipId(block.chainid, address(spgNftContract), tokenId);
 
         WorkflowStructs.SignatureData memory sigMetadataData;
-        WorkflowStructs.SignatureData memory sigAttachData;
+        WorkflowStructs.SignatureData[] memory sigsAttachData;
         WorkflowStructs.SignatureData memory sigAddToGroupData;
 
         {
@@ -139,19 +141,22 @@ contract GroupingIntegration is BaseIntegration {
                 ),
                 signerSk: testSenderSk
             });
-            (bytes memory sigAttach, ) = _getSigForExecuteWithSig({
-                ipId: expectedIpId,
-                to: licensingModuleAddr,
-                deadline: deadline,
-                state: expectedState,
-                data: abi.encodeWithSelector(
-                    ILicensingModule.attachLicenseTerms.selector,
-                    expectedIpId,
-                    testLicenseTemplate,
-                    testLicenseTermsId
-                ),
-                signerSk: testSenderSk
-            });
+            bytes[] memory sigsAttach = new bytes[](testLicenseTermsIds.length);
+            for (uint256 i = 0; i < testLicenseTermsIds.length; i++) {
+                (sigsAttach[i], expectedState) = _getSigForExecuteWithSig({
+                    ipId: expectedIpId,
+                    to: licensingModuleAddr,
+                    deadline: deadline,
+                    state: expectedState,
+                    data: abi.encodeWithSelector(
+                        ILicensingModule.attachLicenseTerms.selector,
+                        expectedIpId,
+                        testLicenseTemplates[i],
+                        testLicenseTermsIds[i]
+                    ),
+                    signerSk: testSenderSk
+                });
+            }
 
             // Get the signature for executing `addIp` function in `GroupingModule` on behalf of the Group IP owner
             (bytes memory sigAddToGroup, ) = _getSigForExecuteWithSig({
@@ -168,11 +173,14 @@ contract GroupingIntegration is BaseIntegration {
                 deadline: deadline,
                 signature: sigMetadata
             });
-            sigAttachData = WorkflowStructs.SignatureData({
-                signer: testSender,
-                deadline: deadline,
-                signature: sigAttach
-            });
+            sigsAttachData = new WorkflowStructs.SignatureData[](testLicenseTermsIds.length);
+            for (uint256 i = 0; i < testLicenseTermsIds.length; i++) {
+                sigsAttachData[i] = WorkflowStructs.SignatureData({
+                    signer: testSender,
+                    deadline: deadline,
+                    signature: sigsAttach[i]
+                });
+            }
             sigAddToGroupData = WorkflowStructs.SignatureData({
                 signer: testSender,
                 deadline: deadline,
@@ -184,11 +192,11 @@ contract GroupingIntegration is BaseIntegration {
             nftContract: address(spgNftContract),
             tokenId: tokenId,
             groupId: groupId,
-            licenseTemplate: testLicenseTemplate,
-            licenseTermsId: testLicenseTermsId,
+            licenseTemplates: testLicenseTemplates,
+            licenseTermsIds: testLicenseTermsIds,
             ipMetadata: testIpMetadata,
             sigMetadata: sigMetadataData,
-            sigAttach: sigAttachData,
+            sigsAttach: sigsAttachData,
             sigAddToGroup: sigAddToGroupData
         });
 
@@ -196,9 +204,13 @@ contract GroupingIntegration is BaseIntegration {
         assertTrue(ipAssetRegistry.isRegistered(ipId));
         assertTrue(IGroupIPAssetRegistry(ipAssetRegistryAddr).containsIp(groupId, ipId));
         assertMetadata(ipId, testIpMetadata);
-        (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId, 0);
-        assertEq(licenseTemplate, testLicenseTemplate);
-        assertEq(licenseTermsId, testLicenseTermsId);
+        address licenseTemplate;
+        uint256 licenseTermsId;
+        for (uint256 i = 0; i < testLicenseTermsIds.length; i++) {
+            (licenseTemplate, licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId, i);
+            assertEq(licenseTemplate, testLicenseTemplates[i]);
+            assertEq(licenseTermsId, testLicenseTermsIds[i]);
+        }
     }
 
     function _test_GroupingIntegration_registerGroupAndAttachLicense()
@@ -207,8 +219,8 @@ contract GroupingIntegration is BaseIntegration {
     {
         address newGroupId = groupingWorkflows.registerGroupAndAttachLicense({
             groupPool: evenSplitGroupPoolAddr,
-            licenseTemplate: testLicenseTemplate,
-            licenseTermsId: testLicenseTermsId
+            licenseTemplate: testLicenseTemplates[0],
+            licenseTermsId: testLicenseTermsIds[0]
         });
 
         // check the group IPA is registered
@@ -216,8 +228,8 @@ contract GroupingIntegration is BaseIntegration {
 
         // check the license terms is correctly attached to the group IPA
         (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(newGroupId, 0);
-        assertEq(licenseTemplate, testLicenseTemplate);
-        assertEq(licenseTermsId, testLicenseTermsId);
+        assertEq(licenseTemplate, testLicenseTemplates[0]);
+        assertEq(licenseTermsId, testLicenseTermsIds[0]);
     }
 
     function _test_GroupingIntegration_registerGroupAndAttachLicenseAndAddIps()
@@ -227,8 +239,8 @@ contract GroupingIntegration is BaseIntegration {
         address newGroupId = groupingWorkflows.registerGroupAndAttachLicenseAndAddIps({
             groupPool: evenSplitGroupPoolAddr,
             ipIds: ipIds,
-            licenseTemplate: testLicenseTemplate,
-            licenseTermsId: testLicenseTermsId
+            licenseTemplate: testLicenseTemplates[0],
+            licenseTermsId: testLicenseTermsIds[0]
         });
 
         // check the group IPA is registered
@@ -242,8 +254,8 @@ contract GroupingIntegration is BaseIntegration {
 
         // check the license terms is correctly attached to the group IPA
         (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(newGroupId, 0);
-        assertEq(licenseTemplate, testLicenseTemplate);
-        assertEq(licenseTermsId, testLicenseTermsId);
+        assertEq(licenseTemplate, testLicenseTemplates[0]);
+        assertEq(licenseTermsId, testLicenseTermsIds[0]);
     }
 
     function _test_GroupingIntegration_collectRoyaltiesAndClaimReward()
@@ -253,8 +265,8 @@ contract GroupingIntegration is BaseIntegration {
         address newGroupId = groupingWorkflows.registerGroupAndAttachLicenseAndAddIps({
             groupPool: evenSplitGroupPoolAddr,
             ipIds: ipIds,
-            licenseTemplate: address(pilTemplate),
-            licenseTermsId: testLicenseTermsId
+            licenseTemplate: testLicenseTemplates[0],
+            licenseTermsId: testLicenseTermsIds[0]
         });
 
         assertEq(IGroupIPAssetRegistry(ipAssetRegistryAddr).totalMembers(newGroupId), numIps);
@@ -263,7 +275,7 @@ contract GroupingIntegration is BaseIntegration {
         address[] memory parentIpIds = new address[](1);
         parentIpIds[0] = newGroupId;
         uint256[] memory licenseTermsIds = new uint256[](1);
-        licenseTermsIds[0] = testLicenseTermsId;
+        licenseTermsIds[0] = testLicenseTermsIds[0];
 
         StoryUSD.mint(testSender, testMintFee);
         StoryUSD.approve(address(spgNftContract), testMintFee);
@@ -272,7 +284,7 @@ contract GroupingIntegration is BaseIntegration {
             derivData: WorkflowStructs.MakeDerivative({
                 parentIpIds: parentIpIds,
                 licenseTermsIds: licenseTermsIds,
-                licenseTemplate: address(pilTemplate),
+                licenseTemplate: testLicenseTemplates[0],
                 royaltyContext: "",
                 maxMintingFee: 0
             }),
@@ -288,7 +300,7 @@ contract GroupingIntegration is BaseIntegration {
             derivData: WorkflowStructs.MakeDerivative({
                 parentIpIds: parentIpIds,
                 licenseTermsIds: licenseTermsIds,
-                licenseTemplate: address(pilTemplate),
+                licenseTemplate: testLicenseTemplates[0],
                 royaltyContext: "",
                 maxMintingFee: 0
             }),
@@ -375,8 +387,8 @@ contract GroupingIntegration is BaseIntegration {
                 address(spgNftContract),
                 groupId,
                 testSender,
-                testLicenseTemplate,
-                testLicenseTermsId,
+                testLicenseTemplates,
+                testLicenseTermsIds,
                 testIpMetadata,
                 WorkflowStructs.SignatureData({ signer: testSender, deadline: deadline, signature: sigsAddToGroup[i] })
             );
@@ -397,9 +409,13 @@ contract GroupingIntegration is BaseIntegration {
             assertTrue(IGroupIPAssetRegistry(ipAssetRegistryAddr).containsIp(groupId, ipId));
             assertEq(spgNftContract.tokenURI(tokenId), string.concat(testBaseURI, testIpMetadata.nftMetadataURI));
             assertMetadata(ipId, testIpMetadata);
-            (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId, 0);
-            assertEq(licenseTemplate, testLicenseTemplate);
-            assertEq(licenseTermsId, testLicenseTermsId);
+            address licenseTemplate;
+            uint256 licenseTermsId;
+            for (uint256 j = 0; j < testLicenseTermsIds.length; j++) {
+                (licenseTemplate, licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId, j);
+                assertEq(licenseTemplate, testLicenseTemplates[j]);
+                assertEq(licenseTermsId, testLicenseTermsIds[j]);
+            }
         }
     }
 
@@ -431,7 +447,7 @@ contract GroupingIntegration is BaseIntegration {
         uint256 deadline = block.timestamp + 1000;
 
         WorkflowStructs.SignatureData[] memory sigMetadataData = new WorkflowStructs.SignatureData[](numCalls);
-        WorkflowStructs.SignatureData[] memory sigAttachData = new WorkflowStructs.SignatureData[](numCalls);
+        WorkflowStructs.SignatureData[][] memory sigAttachData = new WorkflowStructs.SignatureData[][](numCalls);
         WorkflowStructs.SignatureData[] memory sigAddToGroupData = new WorkflowStructs.SignatureData[](numCalls);
 
         {
@@ -454,33 +470,33 @@ contract GroupingIntegration is BaseIntegration {
                     ),
                     signerSk: testSenderSk
                 });
-
-                // Get the signature for executing `attachLicenseTerms` function in `LicensingModule` on behalf of the IP owner
-                (sigAttach, ) = _getSigForExecuteWithSig({
-                    ipId: expectedIpIds[i],
-                    to: licensingModuleAddr,
-                    deadline: deadline,
-                    state: bytes32(0),
-                    data: abi.encodeWithSelector(
-                        ILicensingModule.attachLicenseTerms.selector,
-                        expectedIpIds[i],
-                        testLicenseTemplate,
-                        testLicenseTermsId
-                    ),
-                    signerSk: testSenderSk
-                });
-
                 sigMetadataData[i] = WorkflowStructs.SignatureData({
                     signer: testSender,
                     deadline: deadline,
                     signature: sigMetadata
                 });
 
-                sigAttachData[i] = WorkflowStructs.SignatureData({
-                    signer: testSender,
-                    deadline: deadline,
-                    signature: sigAttach
-                });
+                // Get the signature for executing `attachLicenseTerms` function in `LicensingModule` on behalf of the IP owner
+                for (uint256 j = 0; j < testLicenseTermsIds.length; j++) {
+                    (sigAttach, expectedState) = _getSigForExecuteWithSig({
+                        ipId: expectedIpIds[i],
+                        to: licensingModuleAddr,
+                        deadline: deadline,
+                        state: expectedState,
+                        data: abi.encodeWithSelector(
+                            ILicensingModule.attachLicenseTerms.selector,
+                            expectedIpIds[i],
+                            testLicenseTemplates[j],
+                            testLicenseTermsIds[j]
+                        ),
+                        signerSk: testSenderSk
+                    });
+                    sigAttachData[i][j] = WorkflowStructs.SignatureData({
+                        signer: testSender,
+                        deadline: deadline,
+                        signature: sigAttach
+                    });
+                }
             }
 
             // Get the signatures for executing `addIp` function in `GroupingModule` on behalf of the IP owner
@@ -514,8 +530,8 @@ contract GroupingIntegration is BaseIntegration {
                 address(spgNftContract),
                 tokenIds[i],
                 groupId,
-                testLicenseTemplate,
-                testLicenseTermsId,
+                testLicenseTemplates,
+                testLicenseTermsIds,
                 testIpMetadata,
                 sigMetadataData[i],
                 sigAttachData[i],
@@ -535,15 +551,21 @@ contract GroupingIntegration is BaseIntegration {
             assertTrue(IGroupIPAssetRegistry(ipAssetRegistryAddr).containsIp(groupId, ipId));
             assertMetadata(ipId, testIpMetadata);
             (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId, 0);
-            assertEq(licenseTemplate, testLicenseTemplate);
-            assertEq(licenseTermsId, testLicenseTermsId);
+            assertEq(licenseTemplate, testLicenseTemplates[0]);
+            assertEq(licenseTermsId, testLicenseTermsIds[0]);
+            (licenseTemplate, licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId, 1);
+            assertEq(licenseTemplate, testLicenseTemplates[1]);
+            assertEq(licenseTermsId, testLicenseTermsIds[1]);
         }
     }
 
     function _setUpTest() private {
         revShare = 10 * 10 ** 6; // 10%
-        testLicenseTemplate = pilTemplateAddr;
-        testLicenseTermsId = pilTemplate.registerLicenseTerms(
+        testLicenseTemplates = new address[](2);
+        testLicenseTermsIds = new uint256[](2);
+
+        testLicenseTemplates[0] = pilTemplateAddr;
+        testLicenseTermsIds[0] = pilTemplate.registerLicenseTerms(
             // minting fee is set to 0 beacause currently core protocol requires group IP's minting fee to be 0
             PILFlavors.commercialRemix({
                 mintingFee: 0,
@@ -553,10 +575,26 @@ contract GroupingIntegration is BaseIntegration {
             })
         );
 
+        testLicenseTemplates[1] = pilTemplateAddr;
+        testLicenseTermsIds[1] = pilTemplate.registerLicenseTerms(
+            // Another license that will not be associated with the group IP
+            PILFlavors.commercialRemix({
+                mintingFee: testMintFee,
+                commercialRevShare: revShare,
+                royaltyPolicy: royaltyPolicyLAPAddr,
+                currencyToken: address(StoryUSD)
+            })
+        );
+
         // setup a group
         {
             groupId = groupingModule.registerGroup(evenSplitGroupPoolAddr);
-            LicensingHelper.attachLicenseTerms(groupId, licensingModuleAddr, testLicenseTemplate, testLicenseTermsId);
+            LicensingHelper.attachLicenseTerms(
+                groupId,
+                licensingModuleAddr,
+                testLicenseTemplates[0],
+                testLicenseTermsIds[0]
+            );
         }
 
         // setup a collection and IPs
@@ -603,7 +641,14 @@ contract GroupingIntegration is BaseIntegration {
 
             // attach license terms to the IPs
             for (uint256 i = 0; i < numIps; i++) {
-                LicensingHelper.attachLicenseTerms(ipIds[i], licensingModuleAddr, pilTemplateAddr, testLicenseTermsId);
+                for (uint256 j = 0; j < testLicenseTemplates.length; j++) {
+                    LicensingHelper.attachLicenseTerms(
+                        ipIds[i],
+                        licensingModuleAddr,
+                        testLicenseTemplates[j],
+                        testLicenseTermsIds[j]
+                    );
+                }
             }
         }
     }

--- a/test/integration/workflows/LicenseAttachmentIntegration.t.sol
+++ b/test/integration/workflows/LicenseAttachmentIntegration.t.sol
@@ -20,8 +20,9 @@ contract LicenseAttachmentIntegration is BaseIntegration {
     using Strings for uint256;
 
     ISPGNFT private spgNftContract;
-    PILTerms private commRemixTerms;
-    uint256 private commUseTermsId;
+    PILTerms[] private commTerms;
+    address[] private licenseTemplates;
+    uint256[] private commTermsId;
 
     /// @dev To use, run the following command:
     /// forge script test/integration/workflows/LicenseAttachmentIntegration.t.sol:LicenseAttachmentIntegration \
@@ -45,22 +46,24 @@ contract LicenseAttachmentIntegration is BaseIntegration {
             StoryUSD.mint(testSender, testMintFee);
             StoryUSD.approve(address(spgNftContract), testMintFee);
 
-            (address ipId1, uint256 tokenId1, uint256 licenseTermsId1) = licenseAttachmentWorkflows
+            (address ipId1, uint256 tokenId1, uint256[] memory licenseTermsIds1) = licenseAttachmentWorkflows
                 .mintAndRegisterIpAndAttachPILTerms({
                     spgNftContract: address(spgNftContract),
                     recipient: testSender,
                     ipMetadata: testIpMetadata,
-                    terms: commRemixTerms,
+                    terms: commTerms,
                     allowDuplicates: true
                 });
             assertTrue(ipAssetRegistry.isRegistered(ipId1));
             assertEq(tokenId1, spgNftContract.totalSupply());
-            assertEq(licenseTermsId1, pilTemplate.getLicenseTermsId(commRemixTerms));
             assertEq(spgNftContract.tokenURI(tokenId1), string.concat(testBaseURI, testIpMetadata.nftMetadataURI));
             assertMetadata(ipId1, testIpMetadata);
-            (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId1, 0);
-            assertEq(licenseTemplate, pilTemplateAddr);
-            assertEq(licenseTermsId, licenseTermsId1);
+            for (uint256 i = 0; i < licenseTermsIds1.length; i++) {
+                assertEq(licenseTermsIds1[i], commTermsId[i]);
+                (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId1, i);
+                assertEq(licenseTemplate, pilTemplateAddr);
+                assertEq(licenseTermsId, licenseTermsIds1[i]);
+            }
         }
 
         // IP 2
@@ -68,22 +71,24 @@ contract LicenseAttachmentIntegration is BaseIntegration {
             StoryUSD.mint(testSender, testMintFee);
             StoryUSD.approve(address(spgNftContract), testMintFee);
 
-            (address ipId2, uint256 tokenId2, uint256 licenseTermsId2) = licenseAttachmentWorkflows
+            (address ipId2, uint256 tokenId2, uint256[] memory licenseTermsIds2) = licenseAttachmentWorkflows
                 .mintAndRegisterIpAndAttachPILTerms({
                     spgNftContract: address(spgNftContract),
                     recipient: testSender,
                     ipMetadata: testIpMetadata,
-                    terms: commRemixTerms,
+                    terms: commTerms,
                     allowDuplicates: true
                 });
             assertTrue(ipAssetRegistry.isRegistered(ipId2));
             assertEq(tokenId2, spgNftContract.totalSupply());
-            assertEq(licenseTermsId2, pilTemplate.getLicenseTermsId(commRemixTerms));
             assertEq(spgNftContract.tokenURI(tokenId2), string.concat(testBaseURI, testIpMetadata.nftMetadataURI));
             assertMetadata(ipId2, testIpMetadata);
-            (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId2, 0);
-            assertEq(licenseTemplate, pilTemplateAddr);
-            assertEq(licenseTermsId, licenseTermsId2);
+            for (uint256 i = 0; i < licenseTermsIds2.length; i++) {
+                assertEq(licenseTermsIds2[i], commTermsId[i]);
+                (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId2, i);
+                assertEq(licenseTemplate, pilTemplateAddr);
+                assertEq(licenseTermsId, licenseTermsIds2[i]);
+            }
         }
     }
 
@@ -100,17 +105,19 @@ contract LicenseAttachmentIntegration is BaseIntegration {
                 spgNftContract: address(spgNftContract),
                 recipient: testSender,
                 ipMetadata: testIpMetadata,
-                licenseTemplate: pilTemplateAddr,
-                licenseTermsId: commUseTermsId,
+                licenseTemplates: licenseTemplates,
+                licenseTermsIds: commTermsId,
                 allowDuplicates: true
             });
             assertTrue(ipAssetRegistry.isRegistered(ipId1));
             assertEq(tokenId1, spgNftContract.totalSupply());
             assertEq(spgNftContract.tokenURI(tokenId1), string.concat(testBaseURI, testIpMetadata.nftMetadataURI));
             assertMetadata(ipId1, testIpMetadata);
-            (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId1, 0);
-            assertEq(licenseTemplate, pilTemplateAddr);
-            assertEq(licenseTermsId, commUseTermsId);
+            for (uint256 i = 0; i < commTermsId.length; i++) {
+                (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId1, i);
+                assertEq(licenseTemplate, licenseTemplates[i]);
+                assertEq(licenseTermsId, commTermsId[i]);
+            }
         }
 
         // IP 2
@@ -122,17 +129,19 @@ contract LicenseAttachmentIntegration is BaseIntegration {
                 spgNftContract: address(spgNftContract),
                 recipient: testSender,
                 ipMetadata: testIpMetadata,
-                licenseTemplate: pilTemplateAddr,
-                licenseTermsId: commUseTermsId,
+                licenseTemplates: licenseTemplates,
+                licenseTermsIds: commTermsId,
                 allowDuplicates: true
             });
             assertTrue(ipAssetRegistry.isRegistered(ipId2));
             assertEq(tokenId2, spgNftContract.totalSupply());
             assertEq(spgNftContract.tokenURI(tokenId2), string.concat(testBaseURI, testIpMetadata.nftMetadataURI));
             assertMetadata(ipId2, testIpMetadata);
-            (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId2, 0);
-            assertEq(licenseTemplate, pilTemplateAddr);
-            assertEq(licenseTermsId, commUseTermsId);
+            for (uint256 i = 0; i < commTermsId.length; i++) {
+                (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId2, i);
+                assertEq(licenseTemplate, licenseTemplates[i]);
+                assertEq(licenseTermsId, commTermsId[i]);
+            }
         }
     }
 
@@ -168,43 +177,60 @@ contract LicenseAttachmentIntegration is BaseIntegration {
             signerSk: testSenderSk
         });
 
-        (bytes memory sigAttach, bytes32 expectedState) = _getSigForExecuteWithSig({
-            ipId: expectedIpId,
-            to: licensingModuleAddr,
-            deadline: deadline,
-            state: sigAttachState,
-            data: abi.encodeWithSelector(
-                ILicensingModule.attachLicenseTerms.selector,
-                expectedIpId,
-                pilTemplateAddr,
-                commUseTermsId
-            ),
-            signerSk: testSenderSk
-        });
+        bytes[] memory sigsAttach = new bytes[](commTermsId.length);
+        bytes32 expectedState = sigAttachState;
+        for (uint256 i = 0; i < commTermsId.length; i++) {
+            (sigsAttach[i], expectedState) = _getSigForExecuteWithSig({
+                ipId: expectedIpId,
+                to: licensingModuleAddr,
+                deadline: deadline,
+                state: expectedState,
+                data: abi.encodeWithSelector(
+                    ILicensingModule.attachLicenseTerms.selector,
+                    expectedIpId,
+                    licenseTemplates[i],
+                    commTermsId[i]
+                ),
+                signerSk: testSenderSk
+            });
+        }
+
+        WorkflowStructs.SignatureData[] memory sigsAttachData = new WorkflowStructs.SignatureData[](commTermsId.length);
+        for (uint256 i = 0; i < commTermsId.length; i++) {
+            sigsAttachData[i] = WorkflowStructs.SignatureData({
+                signer: testSender,
+                deadline: deadline,
+                signature: sigsAttach[i]
+            });
+        }
 
         address ipId = licenseAttachmentWorkflows.registerIpAndAttachLicenseTerms({
             nftContract: address(spgNftContract),
             tokenId: tokenId,
             ipMetadata: testIpMetadata,
-            licenseTemplate: pilTemplateAddr,
-            licenseTermsId: commUseTermsId,
+            licenseTemplates: licenseTemplates,
+            licenseTermsIds: commTermsId,
             sigMetadata: WorkflowStructs.SignatureData({
                 signer: testSender,
                 deadline: deadline,
                 signature: sigMetadata
             }),
-            sigAttach: WorkflowStructs.SignatureData({ signer: testSender, deadline: deadline, signature: sigAttach })
+            sigsAttach: sigsAttachData
         });
 
         assertEq(ipId, expectedIpId);
         assertTrue(ipAssetRegistry.isRegistered(ipId));
         assertEq(IIPAccount(payable(ipId)).state(), expectedState);
-        (address expectedLicenseTemplate, uint256 expectedLicenseTermsId) = licenseRegistry.getAttachedLicenseTerms(
-            expectedIpId,
-            0
-        );
-        assertEq(expectedLicenseTemplate, pilTemplateAddr);
-        assertEq(expectedLicenseTermsId, commUseTermsId);
+        address expectedLicenseTemplate;
+        uint256 expectedLicenseTermsId;
+        for (uint256 i = 0; i < commTermsId.length; i++) {
+            (expectedLicenseTemplate, expectedLicenseTermsId) = licenseRegistry.getAttachedLicenseTerms(
+                expectedIpId,
+                i
+            );
+            assertEq(expectedLicenseTemplate, licenseTemplates[i]);
+            assertEq(expectedLicenseTermsId, commTermsId[i]);
+        }
     }
 
     function _setUpTest() private {
@@ -226,19 +252,26 @@ contract LicenseAttachmentIntegration is BaseIntegration {
             )
         );
 
-        commRemixTerms = PILFlavors.commercialRemix({
-            mintingFee: testMintFee,
-            commercialRevShare: 10 * 10 ** 6, // 10%
-            royaltyPolicy: royaltyPolicyLRPAddr,
-            currencyToken: testMintFeeToken
-        });
-
-        commUseTermsId = pilTemplate.registerLicenseTerms(
+        commTerms.push(
+            PILFlavors.commercialRemix({
+                mintingFee: testMintFee,
+                commercialRevShare: 10 * 10 ** 6, // 10%
+                royaltyPolicy: royaltyPolicyLRPAddr,
+                currencyToken: testMintFeeToken
+            })
+        );
+        commTerms.push(
             PILFlavors.commercialUse({
                 mintingFee: testMintFee,
                 currencyToken: testMintFeeToken,
                 royaltyPolicy: royaltyPolicyLRPAddr
             })
         );
+
+        licenseTemplates.push(pilTemplateAddr);
+        licenseTemplates.push(pilTemplateAddr);
+
+        commTermsId.push(pilTemplate.registerLicenseTerms(commTerms[0]));
+        commTermsId.push(pilTemplate.registerLicenseTerms(commTerms[1]));
     }
 }

--- a/test/workflows/DerivativeWorkflows.t.sol
+++ b/test/workflows/DerivativeWorkflows.t.sol
@@ -9,6 +9,7 @@ import { ICoreMetadataModule } from "@storyprotocol/core/interfaces/modules/meta
 import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
 import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingModule.sol";
 import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
+import { PILTerms } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
 
 // contracts
 import { Errors } from "../../contracts/lib/Errors.sol";
@@ -27,27 +28,31 @@ contract DerivativeWorkflowsTest is BaseTest {
     }
 
     modifier withNonCommercialParentIp() {
+        PILTerms[] memory terms = new PILTerms[](1);
+        terms[0] = PILFlavors.nonCommercialSocialRemixing();
         (ipIdParent, , ) = licenseAttachmentWorkflows.mintAndRegisterIpAndAttachPILTerms({
             spgNftContract: address(nftContract),
             recipient: caller,
             ipMetadata: ipMetadataDefault,
-            terms: PILFlavors.nonCommercialSocialRemixing(),
+            terms: terms,
             allowDuplicates: true
         });
         _;
     }
 
     modifier withCommercialParentIp() {
+        PILTerms[] memory terms = new PILTerms[](1);
+        terms[0] = PILFlavors.commercialRemix({
+            mintingFee: 100 * 10 ** mockToken.decimals(),
+            commercialRevShare: 10 * 10 ** 6, // 10%
+            royaltyPolicy: address(royaltyPolicyLAP),
+            currencyToken: address(mockToken)
+        });
         (ipIdParent, , ) = licenseAttachmentWorkflows.mintAndRegisterIpAndAttachPILTerms({
             spgNftContract: address(nftContract),
             recipient: caller,
             ipMetadata: ipMetadataDefault,
-            terms: PILFlavors.commercialRemix({
-                mintingFee: 100 * 10 ** mockToken.decimals(),
-                commercialRevShare: 10 * 10 ** 6, // 10%
-                royaltyPolicy: address(royaltyPolicyLAP),
-                currencyToken: address(mockToken)
-            }),
+            terms: terms,
             allowDuplicates: true
         });
         _;

--- a/test/workflows/GroupingWorkflows.t.sol
+++ b/test/workflows/GroupingWorkflows.t.sol
@@ -29,7 +29,7 @@ import { BaseTest } from "../utils/BaseTest.t.sol";
 contract GroupingWorkflowsTest is BaseTest {
     using Strings for uint256;
 
-    WorkflowStructs.LicenseTermsInfo[] internal testLicenseTermsInfo;
+    WorkflowStructs.LicenseInfo[] internal testLicenseInfo;
     uint32 internal revShare;
 
     address internal groupOwner;
@@ -89,7 +89,7 @@ contract GroupingWorkflowsTest is BaseTest {
             groupId: groupId,
             recipient: minter,
             ipMetadata: ipMetadataDefault,
-            licenseTermsInfo: testLicenseTermsInfo,
+            licenseInfo: testLicenseInfo,
             sigAddToGroup: WorkflowStructs.SignatureData({
                 signer: groupOwner,
                 deadline: deadline,
@@ -128,7 +128,7 @@ contract GroupingWorkflowsTest is BaseTest {
             groupId: groupId,
             recipient: minter,
             ipMetadata: ipMetadataDefault,
-            licenseTermsInfo: testLicenseTermsInfo,
+            licenseInfo: testLicenseInfo,
             sigAddToGroup: WorkflowStructs.SignatureData({
                 signer: groupOwner,
                 deadline: deadline,
@@ -154,11 +154,11 @@ contract GroupingWorkflowsTest is BaseTest {
         assertMetadata(ipId, ipMetadataDefault);
 
         // check the license terms is correctly attached
-        for (uint256 i = 0; i < testLicenseTermsInfo.length; i++) {
+        for (uint256 i = 0; i < testLicenseInfo.length; i++) {
             (address licenseTemplate, uint256 licenseTermsId) = ILicenseRegistry(address(licenseRegistry))
                 .getAttachedLicenseTerms(ipId, i);
-            assertEq(licenseTemplate, testLicenseTermsInfo[i].licenseTemplate);
-            assertEq(licenseTermsId, testLicenseTermsInfo[i].licenseTermsId);
+            assertEq(licenseTemplate, testLicenseInfo[i].licenseTemplate);
+            assertEq(licenseTermsId, testLicenseInfo[i].licenseTermsId);
         }
     }
 
@@ -176,7 +176,7 @@ contract GroupingWorkflowsTest is BaseTest {
 
         WorkflowStructs.SignatureData memory sigMetadataData;
         WorkflowStructs.SignatureData[] memory sigsAttachData = new WorkflowStructs.SignatureData[](
-            testLicenseTermsInfo.length
+            testLicenseInfo.length
         );
         WorkflowStructs.SignatureData memory sigAddToGroupData;
 
@@ -203,8 +203,8 @@ contract GroupingWorkflowsTest is BaseTest {
             });
 
             // Get the signature for executing `attachLicenseTerms` function in `LicensingModule` on behalf of the IP owner
-            bytes[] memory sigsAttach = new bytes[](testLicenseTermsInfo.length);
-            for (uint256 i = 0; i < testLicenseTermsInfo.length; i++) {
+            bytes[] memory sigsAttach = new bytes[](testLicenseInfo.length);
+            for (uint256 i = 0; i < testLicenseInfo.length; i++) {
                 (sigsAttach[i], expectedState) = _getSigForExecuteWithSig({
                     ipId: expectedIpId,
                     to: licensingModuleAddr,
@@ -213,8 +213,8 @@ contract GroupingWorkflowsTest is BaseTest {
                     data: abi.encodeWithSelector(
                         ILicensingModule.attachLicenseTerms.selector,
                         expectedIpId,
-                        testLicenseTermsInfo[i].licenseTemplate,
-                        testLicenseTermsInfo[i].licenseTermsId
+                        testLicenseInfo[i].licenseTemplate,
+                        testLicenseInfo[i].licenseTermsId
                     ),
                     signerSk: minterSk
                 });
@@ -247,7 +247,7 @@ contract GroupingWorkflowsTest is BaseTest {
             nftContract: address(mockNft),
             tokenId: tokenId,
             groupId: groupId,
-            licenseTermsInfo: testLicenseTermsInfo,
+            licenseInfo: testLicenseInfo,
             ipMetadata: ipMetadataDefault,
             sigMetadata: sigMetadataData,
             sigsAttach: sigsAttachData,
@@ -267,11 +267,11 @@ contract GroupingWorkflowsTest is BaseTest {
         assertMetadata(ipId, ipMetadataDefault);
 
         // check the license terms is correctly attached
-        for (uint256 i = 0; i < testLicenseTermsInfo.length; i++) {
+        for (uint256 i = 0; i < testLicenseInfo.length; i++) {
             (address licenseTemplate, uint256 licenseTermsId) = ILicenseRegistry(licenseRegistry)
                 .getAttachedLicenseTerms(ipId, i);
-            assertEq(licenseTemplate, testLicenseTermsInfo[i].licenseTemplate);
-            assertEq(licenseTermsId, testLicenseTermsInfo[i].licenseTermsId);
+            assertEq(licenseTemplate, testLicenseInfo[i].licenseTemplate);
+            assertEq(licenseTermsId, testLicenseInfo[i].licenseTermsId);
         }
     }
 
@@ -280,7 +280,7 @@ contract GroupingWorkflowsTest is BaseTest {
         vm.startPrank(groupOwner);
         address newGroupId = groupingWorkflows.registerGroupAndAttachLicense({
             groupPool: address(evenSplitGroupPool),
-            licenseTermsInfo: testLicenseTermsInfo[0]
+            licenseInfo: testLicenseInfo[0]
         });
         vm.stopPrank();
 
@@ -292,8 +292,8 @@ contract GroupingWorkflowsTest is BaseTest {
             newGroupId,
             0
         );
-        assertEq(licenseTemplate, testLicenseTermsInfo[0].licenseTemplate);
-        assertEq(licenseTermsId, testLicenseTermsInfo[0].licenseTermsId);
+        assertEq(licenseTemplate, testLicenseInfo[0].licenseTemplate);
+        assertEq(licenseTermsId, testLicenseInfo[0].licenseTermsId);
     }
 
     // Register group IP → Attach license terms to group IPA → Add existing IPs to the new group IPA
@@ -302,7 +302,7 @@ contract GroupingWorkflowsTest is BaseTest {
         address newGroupId = groupingWorkflows.registerGroupAndAttachLicenseAndAddIps({
             groupPool: address(evenSplitGroupPool),
             ipIds: ipIds,
-            licenseTermsInfo: testLicenseTermsInfo[0]
+            licenseInfo: testLicenseInfo[0]
         });
         vm.stopPrank();
 
@@ -320,8 +320,8 @@ contract GroupingWorkflowsTest is BaseTest {
             newGroupId,
             0
         );
-        assertEq(licenseTemplate, testLicenseTermsInfo[0].licenseTemplate);
-        assertEq(licenseTermsId, testLicenseTermsInfo[0].licenseTermsId);
+        assertEq(licenseTemplate, testLicenseInfo[0].licenseTemplate);
+        assertEq(licenseTermsId, testLicenseInfo[0].licenseTermsId);
     }
 
     // Collect royalties for the entire group and distribute to each member IP's royalty vault
@@ -333,7 +333,7 @@ contract GroupingWorkflowsTest is BaseTest {
         address newGroupId = groupingWorkflows.registerGroupAndAttachLicenseAndAddIps({
             groupPool: address(evenSplitGroupPool),
             ipIds: ipIds,
-            licenseTermsInfo: testLicenseTermsInfo[0]
+            licenseInfo: testLicenseInfo[0]
         });
         vm.stopPrank();
 
@@ -343,7 +343,7 @@ contract GroupingWorkflowsTest is BaseTest {
         address[] memory parentIpIds = new address[](1);
         parentIpIds[0] = newGroupId;
         uint256[] memory licenseTermsIds = new uint256[](1);
-        licenseTermsIds[0] = testLicenseTermsInfo[0].licenseTermsId;
+        licenseTermsIds[0] = testLicenseInfo[0].licenseTermsId;
 
         vm.startPrank(ipOwner1);
         // approve nft minting fee
@@ -355,7 +355,7 @@ contract GroupingWorkflowsTest is BaseTest {
             derivData: WorkflowStructs.MakeDerivative({
                 parentIpIds: parentIpIds,
                 licenseTermsIds: licenseTermsIds,
-                licenseTemplate: testLicenseTermsInfo[0].licenseTemplate,
+                licenseTemplate: testLicenseInfo[0].licenseTemplate,
                 royaltyContext: "",
                 maxMintingFee: 0
             }),
@@ -375,7 +375,7 @@ contract GroupingWorkflowsTest is BaseTest {
             derivData: WorkflowStructs.MakeDerivative({
                 parentIpIds: parentIpIds,
                 licenseTermsIds: licenseTermsIds,
-                licenseTemplate: testLicenseTermsInfo[0].licenseTemplate,
+                licenseTemplate: testLicenseInfo[0].licenseTemplate,
                 royaltyContext: "",
                 maxMintingFee: 0
             }),
@@ -481,7 +481,7 @@ contract GroupingWorkflowsTest is BaseTest {
                 address(spgNftPublic),
                 groupId,
                 minter,
-                testLicenseTermsInfo,
+                testLicenseInfo,
                 ipMetadataDefault,
                 WorkflowStructs.SignatureData({ signer: groupOwner, deadline: deadline, signature: sigsAddToGroup[i] }),
                 true
@@ -502,11 +502,11 @@ contract GroupingWorkflowsTest is BaseTest {
             assertTrue(IGroupIPAssetRegistry(ipAssetRegistry).containsIp(groupId, ipId));
             assertEq(spgNftPublic.tokenURI(tokenId), string.concat(testBaseURI, ipMetadataDefault.nftMetadataURI));
             assertMetadata(ipId, ipMetadataDefault);
-            for (uint256 j = 0; j < testLicenseTermsInfo.length; j++) {
+            for (uint256 j = 0; j < testLicenseInfo.length; j++) {
                 (address licenseTemplate, uint256 licenseTermsId) = ILicenseRegistry(licenseRegistry)
                     .getAttachedLicenseTerms(ipId, j);
-                assertEq(licenseTemplate, testLicenseTermsInfo[j].licenseTemplate);
-                assertEq(licenseTermsId, testLicenseTermsInfo[j].licenseTermsId);
+                assertEq(licenseTemplate, testLicenseInfo[j].licenseTemplate);
+                assertEq(licenseTermsId, testLicenseInfo[j].licenseTermsId);
             }
         }
     }
@@ -531,7 +531,7 @@ contract GroupingWorkflowsTest is BaseTest {
         WorkflowStructs.SignatureData[] memory sigAddToGroupData = new WorkflowStructs.SignatureData[](10);
         WorkflowStructs.SignatureData[][] memory sigAttachData = new WorkflowStructs.SignatureData[][](10);
         for (uint256 i = 0; i < 10; i++) {
-            sigAttachData[i] = new WorkflowStructs.SignatureData[](testLicenseTermsInfo.length);
+            sigAttachData[i] = new WorkflowStructs.SignatureData[](testLicenseInfo.length);
         }
 
         {
@@ -539,7 +539,7 @@ contract GroupingWorkflowsTest is BaseTest {
             // Get the signatures for setting the permission for calling `setAll` (IP metadata) and `attachLicenseTerms`
             // functions in `coreMetadataModule` and `licensingModule` from the IP owner
             bytes memory sigsMetadata;
-            bytes[] memory sigsAttach = new bytes[](testLicenseTermsInfo.length);
+            bytes[] memory sigsAttach = new bytes[](testLicenseInfo.length);
             for (uint256 i = 0; i < 10; i++) {
                 bytes32 expectedState = bytes32(0);
                 (sigsMetadata, expectedState) = _getSigForExecuteWithSig({
@@ -562,7 +562,7 @@ contract GroupingWorkflowsTest is BaseTest {
                     signature: sigsMetadata
                 });
 
-                for (uint256 j = 0; j < testLicenseTermsInfo.length; j++) {
+                for (uint256 j = 0; j < testLicenseInfo.length; j++) {
                     (sigsAttach[j], expectedState) = _getSigForExecuteWithSig({
                         ipId: expectedIpIds[i],
                         to: address(licensingModule),
@@ -571,8 +571,8 @@ contract GroupingWorkflowsTest is BaseTest {
                         data: abi.encodeWithSelector(
                             ILicensingModule.attachLicenseTerms.selector,
                             expectedIpIds[i],
-                            testLicenseTermsInfo[j].licenseTemplate,
-                            testLicenseTermsInfo[j].licenseTermsId
+                            testLicenseInfo[j].licenseTemplate,
+                            testLicenseInfo[j].licenseTermsId
                         ),
                         signerSk: minterSk
                     });
@@ -619,7 +619,7 @@ contract GroupingWorkflowsTest is BaseTest {
                 mockNft,
                 tokenIds[i],
                 groupId,
-                testLicenseTermsInfo,
+                testLicenseInfo,
                 ipMetadataDefault,
                 sigMetadataData[i],
                 sigAttachData[i],
@@ -640,11 +640,11 @@ contract GroupingWorkflowsTest is BaseTest {
             assertTrue(IIPAssetRegistry(ipAssetRegistry).isRegistered(ipId));
             assertTrue(IGroupIPAssetRegistry(ipAssetRegistry).containsIp(groupId, ipId));
             assertMetadata(ipId, ipMetadataDefault);
-            for (uint256 j = 0; j < testLicenseTermsInfo.length; j++) {
+            for (uint256 j = 0; j < testLicenseInfo.length; j++) {
                 (address licenseTemplate, uint256 licenseTermsId) = ILicenseRegistry(licenseRegistry)
                     .getAttachedLicenseTerms(ipId, j);
-                assertEq(licenseTemplate, testLicenseTermsInfo[j].licenseTemplate);
-                assertEq(licenseTermsId, testLicenseTermsInfo[j].licenseTermsId);
+                assertEq(licenseTemplate, testLicenseInfo[j].licenseTemplate);
+                assertEq(licenseTermsId, testLicenseInfo[j].licenseTermsId);
             }
         }
     }
@@ -653,8 +653,8 @@ contract GroupingWorkflowsTest is BaseTest {
     function _setupLicenseTerms() internal {
         revShare = 10 * 10 ** 6; // 10%
 
-        testLicenseTermsInfo.push(
-            WorkflowStructs.LicenseTermsInfo({
+        testLicenseInfo.push(
+            WorkflowStructs.LicenseInfo({
                 licenseTemplate: pilTemplateAddr,
                 licenseTermsId: pilTemplate.registerLicenseTerms(
                     // minting fee is set to 0 beacause currently core protocol requires group IP's minting fee to be 0
@@ -668,8 +668,8 @@ contract GroupingWorkflowsTest is BaseTest {
             })
         );
 
-        testLicenseTermsInfo.push(
-            WorkflowStructs.LicenseTermsInfo({
+        testLicenseInfo.push(
+            WorkflowStructs.LicenseInfo({
                 licenseTemplate: pilTemplateAddr,
                 licenseTermsId: pilTemplate.registerLicenseTerms(
                     // Another license that will not be associated with the group IP
@@ -693,8 +693,8 @@ contract GroupingWorkflowsTest is BaseTest {
         LicensingHelper.attachLicenseTerms(
             groupId,
             address(licensingModule),
-            testLicenseTermsInfo[0].licenseTemplate,
-            testLicenseTermsInfo[0].licenseTermsId
+            testLicenseInfo[0].licenseTemplate,
+            testLicenseInfo[0].licenseTermsId
         );
         vm.stopPrank();
     }
@@ -733,12 +733,12 @@ contract GroupingWorkflowsTest is BaseTest {
         // attach license terms to the IPs
         vm.startPrank(minter);
         for (uint256 i = 0; i < 10; i++) {
-            for (uint256 j = 0; j < testLicenseTermsInfo.length; j++) {
+            for (uint256 j = 0; j < testLicenseInfo.length; j++) {
                 LicensingHelper.attachLicenseTerms(
                     ipIds[i],
                     address(licensingModule),
-                    testLicenseTermsInfo[j].licenseTemplate,
-                    testLicenseTermsInfo[j].licenseTermsId
+                    testLicenseInfo[j].licenseTemplate,
+                    testLicenseInfo[j].licenseTermsId
                 );
             }
         }


### PR DESCRIPTION
## Description
<!-- Add a description of the changes that this PR introduces -->
This PR introduces support for attaching multiple licenses in the `LicenseAttachmentWorkflows` and `GroupingWorkflows` contracts on the main branch.

#### Key Changes
- Updated `mintAndRegisterIpAndAttachPILTerms`, `mintAndRegisterIpAndAttachLicenseTerms`, and `registerIpAndAttachLicenseTerms` in `LicenseAttachmentWorkflows` to support arrays of PIL terms/license template addresses and license term IDs for attaching multiple licenses to a newly registered IP.
- Updated `mintAndRegisterIpAndAttachLicenseAndAddToGroup` and `registerIpAndAttachLicenseAndAddToGroup` in `GroupingWorkflows` to support arrays of license template addresses and license term IDs for attaching multiple licenses to new group member IPs.
- Updated `registerPILTermsAndAttach` in `LicensingHelper` to manage the registration and attachment of multiple licenses.
- Removed the unused `registerPILTermsAndAttachWithSig` function in `LicensingHelper`.

## Test Plan 
<!-- The test plan section indicates detailed steps on how to verify and test code changes. 
You can list the test cases or test steps that need to be performed.-->
- Modified existing tests for `LicenseAttachmentWorkflows` and `GroupingWorkflows` to validate the attachment of multiple licenses per function call instead of one.
- Refactored tests to align with the updated functionality.

## Related Issue

- Closes #124 

## Notes
<!-- The Important Matters section can alert others to special requirements or matters that need extra attention -->
This PR include API changes, and requires updates to downstream integrations.