### PR TITLE
Revert "refactor(permission): enable direct function calls via `executeWithSig` (#121)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ function mintAndRegisterIpAndAttachPILTerms(
   address nftContract,
   address recipient,
   IPMetadata calldata ipMetadata,
-  PILTerms calldata terms,
-  bool allowDuplicates
+  PILTerms calldata terms
 ) external onlyCallerWithMinterRole(nftContract) returns (address ipId, uint256 tokenId, uint256 licenseTermsId)
 ```
 

--- a/contracts/interfaces/workflows/IDerivativeWorkflows.sol
+++ b/contracts/interfaces/workflows/IDerivativeWorkflows.sol
@@ -29,7 +29,6 @@ interface IDerivativeWorkflows {
     /// @param derivData The derivative data to be used for registerDerivative.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
     /// @param sigMetadata OPTIONAL. Signature data for setAll (metadata) for the IP via the Core Metadata Module.
-    /// @param sigMintingFee OPTIONAL. Signature data for approving license minting fee for the IP via the currency token.
     /// @param sigRegister Signature data for registerDerivative for the IP via the Licensing Module.
     /// @return ipId The ID of the newly registered IP.
     function registerIpAndMakeDerivative(
@@ -38,7 +37,6 @@ interface IDerivativeWorkflows {
         WorkflowStructs.MakeDerivative calldata derivData,
         WorkflowStructs.IPMetadata calldata ipMetadata,
         WorkflowStructs.SignatureData calldata sigMetadata,
-        WorkflowStructs.SignatureData calldata sigMintingFee,
         WorkflowStructs.SignatureData calldata sigRegister
     ) external returns (address ipId);
 
@@ -48,6 +46,7 @@ interface IDerivativeWorkflows {
     /// @param spgNftContract The address of the SPGNFT collection.
     /// @param licenseTokenIds The IDs of the license tokens to be burned for linking the IP to parent IPs.
     /// @param royaltyContext The context for royalty module, should be empty for Royalty Policy LAP.
+    /// @param maxRts The maximum number of royalty tokens that can be distributed to the external royalty policies.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
     /// @param recipient The address to receive the minted NFT.
     /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
@@ -57,6 +56,7 @@ interface IDerivativeWorkflows {
         address spgNftContract,
         uint256[] calldata licenseTokenIds,
         bytes calldata royaltyContext,
+        uint32 maxRts,
         WorkflowStructs.IPMetadata calldata ipMetadata,
         address recipient,
         bool allowDuplicates
@@ -68,6 +68,7 @@ interface IDerivativeWorkflows {
     /// @param tokenId The ID of the NFT.
     /// @param licenseTokenIds The IDs of the license tokens to be burned for linking the IP to parent IPs.
     /// @param royaltyContext The context for royalty module, should be empty for Royalty Policy LAP.
+    /// @param maxRts The maximum number of royalty tokens that can be distributed to the external royalty policies.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
     /// @param sigMetadata OPTIONAL. Signature data for setAll (metadata) for the IP via the Core Metadata Module.
     /// @param sigRegister Signature data for registerDerivativeWithLicenseTokens for the IP via the Licensing Module.
@@ -77,6 +78,7 @@ interface IDerivativeWorkflows {
         uint256 tokenId,
         uint256[] calldata licenseTokenIds,
         bytes calldata royaltyContext,
+        uint32 maxRts,
         WorkflowStructs.IPMetadata calldata ipMetadata,
         WorkflowStructs.SignatureData calldata sigMetadata,
         WorkflowStructs.SignatureData calldata sigRegister

--- a/contracts/interfaces/workflows/IGroupingWorkflows.sol
+++ b/contracts/interfaces/workflows/IGroupingWorkflows.sol
@@ -12,7 +12,8 @@ interface IGroupingWorkflows {
     /// @param spgNftContract The address of the SPGNFT collection.
     /// @param groupId The ID of the group IP to add the newly registered IP.
     /// @param recipient The address of the recipient of the minted NFT.
-    /// @param licenseInfo The information of the license terms that will be attached to the new IP.
+    /// @param licenseTemplate The address of the license template to be attached to the new IP.
+    /// @param licenseTermsId The ID of the registered license terms that will be attached to the new IP.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
     /// @param sigAddToGroup Signature data for addIp to the group IP via the Grouping Module.
     /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
@@ -22,7 +23,8 @@ interface IGroupingWorkflows {
         address spgNftContract,
         address groupId,
         address recipient,
-        WorkflowStructs.LicenseInfo[] calldata licenseInfo,
+        address licenseTemplate,
+        uint256 licenseTermsId,
         WorkflowStructs.IPMetadata calldata ipMetadata,
         WorkflowStructs.SignatureData calldata sigAddToGroup,
         bool allowDuplicates
@@ -33,32 +35,33 @@ interface IGroupingWorkflows {
     /// @param nftContract The address of the NFT collection.
     /// @param tokenId The ID of the NFT.
     /// @param groupId The ID of the group IP to add the newly registered IP.
-    /// @param licenseInfo The information of the license terms that will be attached to the new IP.
+    /// @param licenseTemplate The address of the license template to be attached to the new IP.
+    /// @param licenseTermsId The ID of the registered license terms that will be attached to the new IP.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
-    /// @param sigMetadata OPTIONAL. Signature data for setAll (metadata).
-    /// @param sigsAttach Signature data for attachLicenseTerms to the IP via the Licensing Module.
-    ///        The i th signature data is for attaching the i th license terms registered
-    ///        in the i th license template to the IP.
+    /// @param sigMetadataAndAttach Signature data for setAll (metadata) and attachLicenseTerms to the IP
+    /// via the Core Metadata Module and Licensing Module.
     /// @param sigAddToGroup Signature data for addIp to the group IP via the Grouping Module.
     /// @return ipId The ID of the newly registered IP.
     function registerIpAndAttachLicenseAndAddToGroup(
         address nftContract,
         uint256 tokenId,
         address groupId,
-        WorkflowStructs.LicenseInfo[] calldata licenseInfo,
+        address licenseTemplate,
+        uint256 licenseTermsId,
         WorkflowStructs.IPMetadata calldata ipMetadata,
-        WorkflowStructs.SignatureData calldata sigMetadata,
-        WorkflowStructs.SignatureData[] calldata sigsAttach,
+        WorkflowStructs.SignatureData calldata sigMetadataAndAttach,
         WorkflowStructs.SignatureData calldata sigAddToGroup
     ) external returns (address ipId);
 
     /// @notice Register a group IP with a group reward pool and attach license terms to the group IP
     /// @param groupPool The address of the group reward pool.
-    /// @param licenseInfo The information of the license terms that will be attached to the new group IP.
+    /// @param licenseTemplate The address of the license template to be attached to the new group IP.
+    /// @param licenseTermsId The ID of the registered license terms that will be attached to the new group IP.
     /// @return groupId The ID of the newly registered group IP.
     function registerGroupAndAttachLicense(
         address groupPool,
-        WorkflowStructs.LicenseInfo calldata licenseInfo
+        address licenseTemplate,
+        uint256 licenseTermsId
     ) external returns (address groupId);
 
     /// @notice Register a group IP with a group reward pool, attach license terms to the group IP,
@@ -66,12 +69,14 @@ interface IGroupingWorkflows {
     /// @dev ipIds must be have the same license terms as the group IP.
     /// @param groupPool The address of the group reward pool.
     /// @param ipIds The IDs of the IPs to add to the newly registered group IP.
-    /// @param licenseInfo The information of the license terms that will be attached to the new group IP.
+    /// @param licenseTemplate The address of the license template to be attached to the new group IP.
+    /// @param licenseTermsId The ID of the registered license terms that will be attached to the new group IP.
     /// @return groupId The ID of the newly registered group IP.
     function registerGroupAndAttachLicenseAndAddIps(
         address groupPool,
         address[] calldata ipIds,
-        WorkflowStructs.LicenseInfo calldata licenseInfo
+        address licenseTemplate,
+        uint256 licenseTermsId
     ) external returns (address groupId);
 
     /// @notice Collect royalties for the entire group and distribute the rewards to each member IP's royalty vault

--- a/contracts/interfaces/workflows/ILicenseAttachmentWorkflows.sol
+++ b/contracts/interfaces/workflows/ILicenseAttachmentWorkflows.sol
@@ -8,68 +8,54 @@ import { WorkflowStructs } from "../../lib/WorkflowStructs.sol";
 /// @title License Attachment Workflows Interface
 /// @notice Interface for IP license attachment workflows.
 interface ILicenseAttachmentWorkflows {
-    /// @notice Mint an NFT from a SPGNFT collection, register it as an IP, attach provided IP metadata,
-    /// register Programmable IPLicense Terms (if unregistered), and attach it to the newly registered IP.
+    /// @notice Register Programmable IP License Terms (if unregistered) and attach it to IP.
+    /// @param ipId The ID of the IP.
+    /// @param terms The PIL terms to be registered.
+    /// @param sigAttach Signature data for attachLicenseTerms to the IP via the Licensing Module.
+    /// @return licenseTermsId The ID of the newly registered PIL terms.
+    function registerPILTermsAndAttach(
+        address ipId,
+        PILTerms calldata terms,
+        WorkflowStructs.SignatureData calldata sigAttach
+    ) external returns (uint256 licenseTermsId);
+
+    /// @notice Mint an NFT from a SPGNFT collection, register it with metadata as an IP,
+    /// register Programmable IPLicense
+    /// Terms (if unregistered), and attach it to the registered IP.
     /// @dev Requires caller to have the minter role or the SPG NFT to allow public minting.
     /// @param spgNftContract The address of the SPGNFT collection.
     /// @param recipient The address of the recipient of the minted NFT.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
-    /// @param terms The PIL terms to be registered and attached to the newly registered IP.
+    /// @param terms The PIL terms to be registered.
     /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
     /// @return ipId The ID of the newly registered IP.
     /// @return tokenId The ID of the newly minted NFT.
-    /// @return licenseTermsIds The IDs of the newly registered PIL terms.
+    /// @return licenseTermsId The ID of the newly registered PIL terms.
     function mintAndRegisterIpAndAttachPILTerms(
         address spgNftContract,
         address recipient,
         WorkflowStructs.IPMetadata calldata ipMetadata,
-        PILTerms[] calldata terms,
+        PILTerms calldata terms,
         bool allowDuplicates
-    ) external returns (address ipId, uint256 tokenId, uint256[] memory licenseTermsIds);
+    ) external returns (address ipId, uint256 tokenId, uint256 licenseTermsId);
 
-    /// @notice Mint an NFT from a SPGNFT collection, register as an IP, attach provided IP metadata,
-    /// and attach the provided license terms to the newly registered IP.
-    /// @dev Requires caller to have the minter role or the SPG NFT to allow public minting.
-    /// @param spgNftContract The address of the SPGNFT collection.
-    /// @param recipient The address of the recipient of the newly minted NFT.
-    /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
-    /// @param licenseTemplates The addresses of the license templates used of the license terms to be attached.
-    /// @param licenseTermsIds The IDs of the license terms to attach. The i th license terms ID must be a valid license
-    ///        terms that was registered in the i th license template.
-    /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
-    /// @return ipId The ID of the newly registered IP.
-    /// @return tokenId The ID of the newly minted NFT.
-    function mintAndRegisterIpAndAttachLicenseTerms(
-        address spgNftContract,
-        address recipient,
-        WorkflowStructs.IPMetadata calldata ipMetadata,
-        address[] calldata licenseTemplates,
-        uint256[] calldata licenseTermsIds,
-        bool allowDuplicates
-    ) external returns (address ipId, uint256 tokenId);
-
-    /// @notice Register a given NFT as an IP, attach provided IP metadata, and attach the provided license terms to the
-    ///         newly registered IP.
-    /// @dev Since IP Account is created in this function, we need signatures to allow this contract to set metadata
-    ///      and attach PIL Terms to the newly created IP Account on behalf of the owner.
+    /// @notice Register a given NFT as an IP and attach Programmable IP License Terms.
+    /// @dev Because IP Account is created in this function, we need to set the permission via signature to allow this
+    /// contract to attach PIL Terms to the newly created IP Account in the same function.
     /// @param nftContract The address of the NFT collection.
     /// @param tokenId The ID of the NFT.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
-    /// @param licenseTemplates The addresses of the license templates used of the license terms to be attached.
-    /// @param licenseTermsIds The IDs of the license terms to attach. The i th license terms ID must be a valid license
-    ///        terms that was registered in the i th license template.
+    /// @param terms The PIL terms to be registered.
     /// @param sigMetadata OPTIONAL. Signature data for setAll (metadata) for the IP via the Core Metadata Module.
-    /// @param sigsAttach Signature data for attachLicenseTerms to the IP via the Licensing Module.
-    ///        The i th signature data is for attaching the i th license terms registered in the i th license template
-    ///        to the IP.
+    /// @param sigAttach Signature data for attachLicenseTerms to the IP via the Licensing Module.
     /// @return ipId The ID of the newly registered IP.
-    function registerIpAndAttachLicenseTerms(
+    /// @return licenseTermsId The ID of the newly registered PIL terms.
+    function registerIpAndAttachPILTerms(
         address nftContract,
         uint256 tokenId,
         WorkflowStructs.IPMetadata calldata ipMetadata,
-        address[] calldata licenseTemplates,
-        uint256[] calldata licenseTermsIds,
+        PILTerms calldata terms,
         WorkflowStructs.SignatureData calldata sigMetadata,
-        WorkflowStructs.SignatureData[] calldata sigsAttach
-    ) external returns (address ipId);
+        WorkflowStructs.SignatureData calldata sigAttach
+    ) external returns (address ipId, uint256 licenseTermsId);
 }

--- a/contracts/lib/LicensingHelper.sol
+++ b/contracts/lib/LicensingHelper.sol
@@ -2,11 +2,8 @@
 pragma solidity 0.8.26;
 
 import { Errors as CoreErrors } from "@storyprotocol/core/lib/Errors.sol";
-import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
 import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingModule.sol";
 import { IPILicenseTemplate, PILTerms } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
-
-import { WorkflowStructs } from "../lib/WorkflowStructs.sol";
 
 /// @title Periphery Licensing Helper Library
 /// @notice Library for all licensing related helper functions for Periphery contracts.
@@ -15,72 +12,35 @@ library LicensingHelper {
     /// @param ipId The ID of the IP.
     /// @param pilTemplate The address of the PIL License Template.
     /// @param licensingModule The address of the Licensing Module.
+    /// @param licenseRegistry The address of the License Registry.
     /// @param terms The PIL terms to be registered.
-    /// @return licenseTermsIds The IDs of the registered PIL terms.
+    /// @return licenseTermsId The ID of the registered PIL terms.
     function registerPILTermsAndAttach(
         address ipId,
         address pilTemplate,
         address licensingModule,
-        PILTerms[] memory terms
-    ) internal returns (uint256[] memory licenseTermsIds) {
-        licenseTermsIds = new uint256[](terms.length);
-        for (uint256 i = 0; i < terms.length; i++) {
-            licenseTermsIds[i] = IPILicenseTemplate(pilTemplate).registerLicenseTerms(terms[i]);
-            attachLicenseTerms(ipId, licensingModule, pilTemplate, licenseTermsIds[i]);
-        }
+        address licenseRegistry,
+        PILTerms calldata terms
+    ) internal returns (uint256 licenseTermsId) {
+        licenseTermsId = IPILicenseTemplate(pilTemplate).registerLicenseTerms(terms);
+
+        attachLicenseTerms(ipId, licensingModule, licenseRegistry, pilTemplate, licenseTermsId);
     }
 
     /// @dev Attaches license terms to the given IP.
     /// @param ipId The ID of the IP.
     /// @param licensingModule The address of the Licensing Module.
+    /// @param licenseRegistry The address of the License Registry.
     /// @param licenseTemplate The address of the license template.
     /// @param licenseTermsId The ID of the license terms to be attached.
     function attachLicenseTerms(
         address ipId,
         address licensingModule,
+        address licenseRegistry,
         address licenseTemplate,
         uint256 licenseTermsId
     ) internal {
         try ILicensingModule(licensingModule).attachLicenseTerms(ipId, licenseTemplate, licenseTermsId) {
-            return; // license terms are attached successfully
-        } catch (bytes memory reason) {
-            // if the error is not that the license terms are already attached, revert with the original error
-            if (CoreErrors.LicenseRegistry__LicenseTermsAlreadyAttached.selector != bytes4(reason)) {
-                assembly {
-                    revert(add(reason, 32), mload(reason))
-                }
-            }
-        }
-    }
-
-    /// @dev Attaches license terms to the given IP on behalf of the owner with a signature.
-    /// @param ipId The ID of the IP to which the license terms will be attached.
-    /// @param licensingModule The address of the Licensing Module.
-    /// @param licenseTemplate The address of the license template.
-    /// @param licenseTermsId The ID of the license terms to be attached.
-    /// @param sigAttach Signature data for attachLicenseTerms to the IP via the Licensing Module.
-    function attachLicenseTermsWithSig(
-        address ipId,
-        address licensingModule,
-        address licenseTemplate,
-        uint256 licenseTermsId,
-        WorkflowStructs.SignatureData memory sigAttach
-    ) internal {
-        try
-            IIPAccount(payable(ipId)).executeWithSig({
-                to: address(licensingModule),
-                value: 0,
-                data: abi.encodeWithSelector(
-                    ILicensingModule.attachLicenseTerms.selector,
-                    ipId,
-                    licenseTemplate,
-                    licenseTermsId
-                ),
-                signer: sigAttach.signer,
-                deadline: sigAttach.deadline,
-                signature: sigAttach.signature
-            })
-        {
             return; // license terms are attached successfully
         } catch (bytes memory reason) {
             // if the error is not that the license terms are already attached, revert with the original error

--- a/contracts/lib/MetadataHelper.sol
+++ b/contracts/lib/MetadataHelper.sol
@@ -2,9 +2,9 @@
 pragma solidity 0.8.26;
 
 import { ICoreMetadataModule } from "@storyprotocol/core/interfaces/modules/metadata/ICoreMetadataModule.sol";
-import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
 
 import { WorkflowStructs } from "./WorkflowStructs.sol";
+import { PermissionHelper } from "./PermissionHelper.sol";
 
 /// @title Periphery Metadata Helper Library
 /// @notice Library for all metadata related helper functions for Periphery contracts.
@@ -13,34 +13,26 @@ library MetadataHelper {
     /// metadata is non-empty and sets the metadata via signature.
     /// @param ipId The ID of the IP.
     /// @param coreMetadataModule The address of the Core Metadata Module.
+    /// @param accessController The address of the Access Controller.
     /// @param ipMetadata The metadata to set.
     /// @param sigData Signature data for setAll for this IP by SPG via the Core Metadata Module.
     function setMetadataWithSig(
         address ipId,
         address coreMetadataModule,
+        address accessController,
         WorkflowStructs.IPMetadata calldata ipMetadata,
         WorkflowStructs.SignatureData calldata sigData
     ) internal {
-        if (
-            keccak256(abi.encodePacked(ipMetadata.ipMetadataURI)) != keccak256("") ||
-            ipMetadata.ipMetadataHash != bytes32(0) ||
-            ipMetadata.nftMetadataHash != bytes32(0)
-        ) {
-            IIPAccount(payable(ipId)).executeWithSig({
-                to: coreMetadataModule,
-                value: 0,
-                data: abi.encodeWithSelector(
-                    ICoreMetadataModule.setAll.selector,
-                    ipId,
-                    ipMetadata.ipMetadataURI,
-                    ipMetadata.ipMetadataHash,
-                    ipMetadata.nftMetadataHash
-                ),
-                signer: sigData.signer,
-                deadline: sigData.deadline,
-                signature: sigData.signature
+        if (sigData.signer != address(0) && sigData.deadline != 0 && sigData.signature.length != 0) {
+            PermissionHelper.setPermissionForModule({
+                ipId: ipId,
+                module: coreMetadataModule,
+                accessController: accessController,
+                selector: ICoreMetadataModule.setAll.selector,
+                sigData: sigData
             });
         }
+        setMetadata(ipId, coreMetadataModule, ipMetadata);
     }
 
     /// @dev Sets the metadata for the given IP if metadata is non-empty.

--- a/contracts/lib/PermissionHelper.sol
+++ b/contracts/lib/PermissionHelper.sol
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
+import { AccessPermission } from "@storyprotocol/core/lib/AccessPermission.sol";
+import { IAccessController } from "@storyprotocol/core/interfaces/access/IAccessController.sol";
+
+import { WorkflowStructs } from "./WorkflowStructs.sol";
+
+/// @title Periphery Permission Helper Library
+/// @notice Library for all permissions related helper functions for Periphery contracts.
+library PermissionHelper {
+    /// @dev Sets permission via signature to allow this contract to interact with the Licensing Module on behalf of the
+    /// provided IP Account.
+    /// @param ipId The ID of the IP.
+    /// @param module The address of the module to set the permission for.
+    /// @param accessController The address of the Access Controller contract.
+    /// @param selector The selector of the function to be permitted for execution.
+    /// @param sigData Signature data for setting the permission.
+    function setPermissionForModule(
+        address ipId,
+        address module,
+        address accessController,
+        bytes4 selector,
+        WorkflowStructs.SignatureData calldata sigData
+    ) internal {
+        IIPAccount(payable(ipId)).executeWithSig(
+            accessController,
+            0,
+            abi.encodeWithSelector(
+                IAccessController.setPermission.selector,
+                address(ipId),
+                address(this),
+                address(module),
+                selector,
+                AccessPermission.ALLOW
+            ),
+            sigData.signer,
+            sigData.deadline,
+            sigData.signature
+        );
+    }
+
+    /// @dev Sets batch permission via signature to allow this contract to interact with mutiple modules
+    /// on behalf of the provided IP Account.
+    /// @param ipId The ID of the IP.
+    /// @param accessController The address of the Access Controller contract.
+    /// @param modules The addresses of the modules to set the permission for.
+    /// @param selectors The selectors of the functions to be permitted for execution.
+    /// @param sigData Signature data for setting the batch permission.
+    function setBatchPermissionForModules(
+        address ipId,
+        address accessController,
+        address[] memory modules,
+        bytes4[] memory selectors,
+        WorkflowStructs.SignatureData calldata sigData
+    ) internal {
+        // assumes modules and selectors must have a 1:1 mapping
+        AccessPermission.Permission[] memory permissionList = new AccessPermission.Permission[](modules.length);
+        for (uint256 i = 0; i < modules.length; i++) {
+            permissionList[i] = AccessPermission.Permission({
+                ipAccount: ipId,
+                signer: address(this),
+                to: modules[i],
+                func: selectors[i],
+                permission: AccessPermission.ALLOW
+            });
+        }
+
+        IIPAccount(payable(ipId)).executeWithSig(
+            accessController,
+            0,
+            abi.encodeWithSelector(IAccessController.setBatchPermissions.selector, permissionList),
+            sigData.signer,
+            sigData.deadline,
+            sigData.signature
+        );
+    }
+}

--- a/contracts/lib/WorkflowStructs.sol
+++ b/contracts/lib/WorkflowStructs.sol
@@ -33,19 +33,13 @@ library WorkflowStructs {
     /// @param licenseTermsIds The IDs of the license terms to be used for the linking.
     /// @param royaltyContext The context for royalty module, should be empty for Royalty Policy LAP.
     /// @param maxMintingFee The maximum minting fee that the caller is willing to pay. if set to 0 then no limit.
+    /// @param maxRts The maximum number of royalty tokens that can be distributed to the external royalty policies.
     struct MakeDerivative {
         address[] parentIpIds;
         address licenseTemplate;
         uint256[] licenseTermsIds;
         bytes royaltyContext;
         uint256 maxMintingFee;
-    }
-
-    /// @notice Struct for license terms information.
-    /// @param licenseTemplate The address of the license template.
-    /// @param licenseTermsId The ID of the license terms which was registered in the license template.
-    struct LicenseInfo {
-        address licenseTemplate;
-        uint256 licenseTermsId;
+        uint32 maxRts;
     }
 }

--- a/contracts/story-nft/BaseStoryNFT.sol
+++ b/contracts/story-nft/BaseStoryNFT.sol
@@ -123,13 +123,15 @@ abstract contract BaseStoryNFT is IStoryNFT, ERC721URIStorageUpgradeable, Ownabl
     /// @param licenseTermsIds The IDs of the license terms.
     /// @param royaltyContext The royalty context, should be empty for Royalty Policy LAP.
     /// @param maxMintingFee The maximum minting fee that the caller is willing to pay. if set to 0 then no limit.
+    /// @param maxRts The maximum number of royalty tokens that can be distributed to the external royalty policies.
     function _makeDerivative(
         address ipId,
         address[] memory parentIpIds,
         address licenseTemplate,
         uint256[] memory licenseTermsIds,
         bytes memory royaltyContext,
-        uint256 maxMintingFee
+        uint256 maxMintingFee,
+        uint32 maxRts
     ) internal virtual {
         LICENSING_MODULE.registerDerivative({
             childIpId: ipId,
@@ -137,7 +139,8 @@ abstract contract BaseStoryNFT is IStoryNFT, ERC721URIStorageUpgradeable, Ownabl
             licenseTermsIds: licenseTermsIds,
             licenseTemplate: licenseTemplate,
             royaltyContext: royaltyContext,
-            maxMintingFee: maxMintingFee
+            maxMintingFee: maxMintingFee,
+            maxRts: maxRts
         });
     }
 

--- a/contracts/story-nft/OrgNFT.sol
+++ b/contracts/story-nft/OrgNFT.sol
@@ -152,7 +152,8 @@ contract OrgNFT is IOrgNFT, ERC721URIStorageUpgradeable, AccessManagedUpgradeabl
             licenseTermsIds: licenseTermsIds,
             licenseTemplate: LICENSE_TEMPLATE,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRts: 0
         });
 
         _safeTransfer(address(this), recipient, orgTokenId);

--- a/contracts/story-nft/StoryBadgeNFT.sol
+++ b/contracts/story-nft/StoryBadgeNFT.sol
@@ -177,7 +177,7 @@ contract StoryBadgeNFT is IStoryBadgeNFT, BaseOrgStoryNFT, CachableNFT, ERC721Ho
         licenseTermsIds[0] = DEFAULT_LICENSE_TERMS_ID;
 
         // Make the badge a derivative of the organization IP
-        _makeDerivative(ipId, parentIpIds, PIL_TEMPLATE, licenseTermsIds, "", 0);
+        _makeDerivative(ipId, parentIpIds, PIL_TEMPLATE, licenseTermsIds, "", 0, 0);
     }
 
     /// @notice Transfers an NFT from one address to another.

--- a/contracts/workflows/LicenseAttachmentWorkflows.sol
+++ b/contracts/workflows/LicenseAttachmentWorkflows.sol
@@ -6,6 +6,8 @@ import { AccessManagedUpgradeable } from "@openzeppelin/contracts-upgradeable/ac
 import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
 import { MulticallUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/MulticallUpgradeable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
+import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingModule.sol";
 import { PILTerms } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
 
 import { BaseWorkflow } from "../BaseWorkflow.sol";
@@ -14,6 +16,7 @@ import { ILicenseAttachmentWorkflows } from "../interfaces/workflows/ILicenseAtt
 import { ISPGNFT } from "../interfaces/ISPGNFT.sol";
 import { LicensingHelper } from "../lib/LicensingHelper.sol";
 import { MetadataHelper } from "../lib/MetadataHelper.sol";
+import { PermissionHelper } from "../lib/PermissionHelper.sol";
 import { WorkflowStructs } from "../lib/WorkflowStructs.sol";
 
 /// @title License Attachment Workflows
@@ -86,28 +89,51 @@ contract LicenseAttachmentWorkflows is
         $.nftContractBeacon = newNftContractBeacon;
     }
 
-    /// @notice Mint an NFT from a SPGNFT collection, register it as an IP, attach provided IP metadata,
-    /// register Programmable IPLicense Terms (if unregistered), and attach it to the newly registered IP.
+    /// @notice Register Programmable IP License Terms (if unregistered) and attach it to IP.
+    /// @param ipId The ID of the IP.
+    /// @param terms The PIL terms to be registered.
+    /// @param sigAttach Signature data for attachLicenseTerms to the IP via the Licensing Module.
+    /// @return licenseTermsId The ID of the newly registered PIL terms.
+    function registerPILTermsAndAttach(
+        address ipId,
+        PILTerms calldata terms,
+        WorkflowStructs.SignatureData calldata sigAttach
+    ) external returns (uint256 licenseTermsId) {
+        PermissionHelper.setPermissionForModule(
+            ipId,
+            address(LICENSING_MODULE),
+            address(ACCESS_CONTROLLER),
+            ILicensingModule.attachLicenseTerms.selector,
+            sigAttach
+        );
+
+        licenseTermsId = LicensingHelper.registerPILTermsAndAttach(
+            ipId,
+            address(PIL_TEMPLATE),
+            address(LICENSING_MODULE),
+            address(LICENSE_REGISTRY),
+            terms
+        );
+    }
+
+    /// @notice Mint an NFT from a SPGNFT collection, register it with metadata as an IP,
+    /// register Programmable IP License Terms (if unregistered), and attach it to the registered IP.
     /// @dev Requires caller to have the minter role or the SPG NFT to allow public minting.
     /// @param spgNftContract The address of the SPGNFT collection.
     /// @param recipient The address of the recipient of the minted NFT.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
-    /// @param terms The PIL terms to be registered and attached to the newly registered IP.
+    /// @param terms The PIL terms to be registered.
     /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
     /// @return ipId The ID of the newly registered IP.
     /// @return tokenId The ID of the newly minted NFT.
-    /// @return licenseTermsIds The IDs of the newly registered PIL terms.
+    /// @return licenseTermsId The ID of the newly registered PIL terms.
     function mintAndRegisterIpAndAttachPILTerms(
         address spgNftContract,
         address recipient,
         WorkflowStructs.IPMetadata calldata ipMetadata,
-        PILTerms[] calldata terms,
+        PILTerms calldata terms,
         bool allowDuplicates
-    )
-        external
-        onlyMintAuthorized(spgNftContract)
-        returns (address ipId, uint256 tokenId, uint256[] memory licenseTermsIds)
-    {
+    ) external onlyMintAuthorized(spgNftContract) returns (address ipId, uint256 tokenId, uint256 licenseTermsId) {
         tokenId = ISPGNFT(spgNftContract).mintByPeriphery({
             to: address(this),
             payer: msg.sender,
@@ -119,95 +145,60 @@ contract LicenseAttachmentWorkflows is
         ipId = IP_ASSET_REGISTRY.register(block.chainid, spgNftContract, tokenId);
         MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);
 
-        licenseTermsIds = LicensingHelper.registerPILTermsAndAttach(
+        licenseTermsId = LicensingHelper.registerPILTermsAndAttach(
             ipId,
             address(PIL_TEMPLATE),
             address(LICENSING_MODULE),
+            address(LICENSE_REGISTRY),
             terms
         );
 
         ISPGNFT(spgNftContract).safeTransferFrom(address(this), recipient, tokenId, "");
     }
 
-    /// @notice Mint an NFT from a SPGNFT collection, register as an IP, attach provided IP metadata,
-    /// and attach the provided license terms to the newly registered IP.
-    /// @dev Requires caller to have the minter role or the SPG NFT to allow public minting.
-    /// @param spgNftContract The address of the SPGNFT collection.
-    /// @param recipient The address of the recipient of the newly minted NFT.
-    /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
-    /// @param licenseTemplates The addresses of the license templates used of the license terms to be attached.
-    /// @param licenseTermsIds The IDs of the license terms to attach. The i th license terms ID must be a valid license
-    ///        terms that was registered in the i th license template.
-    /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
-    /// @return ipId The ID of the newly registered IP.
-    /// @return tokenId The ID of the newly minted NFT.
-    function mintAndRegisterIpAndAttachLicenseTerms(
-        address spgNftContract,
-        address recipient,
-        WorkflowStructs.IPMetadata calldata ipMetadata,
-        address[] calldata licenseTemplates,
-        uint256[] calldata licenseTermsIds,
-        bool allowDuplicates
-    ) external onlyMintAuthorized(spgNftContract) returns (address ipId, uint256 tokenId) {
-        tokenId = ISPGNFT(spgNftContract).mintByPeriphery({
-            to: address(this),
-            payer: msg.sender,
-            nftMetadataURI: ipMetadata.nftMetadataURI,
-            nftMetadataHash: ipMetadata.nftMetadataHash,
-            allowDuplicates: allowDuplicates
-        });
-
-        ipId = IP_ASSET_REGISTRY.register(block.chainid, spgNftContract, tokenId);
-        MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);
-
-        for (uint256 i = 0; i < licenseTermsIds.length; i++) {
-            LicensingHelper.attachLicenseTerms(
-                ipId,
-                address(LICENSING_MODULE),
-                licenseTemplates[i],
-                licenseTermsIds[i]
-            );
-        }
-
-        ISPGNFT(spgNftContract).safeTransferFrom(address(this), recipient, tokenId, "");
-    }
-
-    /// @notice Register a given NFT as an IP, attach provided IP metadata, and attach the provided license terms to the
-    ///         newly registered IP.
-    /// @dev Since IP Account is created in this function, we need signatures to allow this contract to set metadata
-    ///      and attach PIL Terms to the newly created IP Account on behalf of the owner.
+    /// @notice Register a given NFT as an IP and attach Programmable IP License Terms.
+    /// @dev Because IP Account is created in this function, we need to set the permission via signature to allow this
+    /// contract to attach PIL Terms to the newly created IP Account in the same function.
     /// @param nftContract The address of the NFT collection.
     /// @param tokenId The ID of the NFT.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
-    /// @param licenseTemplates The addresses of the license templates used of the license terms to be attached.
-    /// @param licenseTermsIds The IDs of the license terms to attach. The i th license terms ID must be a valid license
-    ///        terms that was registered in the i th license template.
+    /// @param terms The PIL terms to be registered.
     /// @param sigMetadata OPTIONAL. Signature data for setAll (metadata) for the IP via the Core Metadata Module.
-    /// @param sigsAttach Signature data for attachLicenseTerms to the IP via the Licensing Module.
-    ///        The i th signature data is for attaching the i th license terms registered in the i th license template
-    ///        to the IP.
+    /// @param sigAttach Signature data for attachLicenseTerms to the IP via the Licensing Module.
     /// @return ipId The ID of the newly registered IP.
-    function registerIpAndAttachLicenseTerms(
+    /// @return licenseTermsId The ID of the newly registered PIL terms.
+    function registerIpAndAttachPILTerms(
         address nftContract,
         uint256 tokenId,
         WorkflowStructs.IPMetadata calldata ipMetadata,
-        address[] calldata licenseTemplates,
-        uint256[] calldata licenseTermsIds,
+        PILTerms calldata terms,
         WorkflowStructs.SignatureData calldata sigMetadata,
-        WorkflowStructs.SignatureData[] calldata sigsAttach
-    ) external returns (address ipId) {
+        WorkflowStructs.SignatureData calldata sigAttach
+    ) external returns (address ipId, uint256 licenseTermsId) {
         ipId = IP_ASSET_REGISTRY.register(block.chainid, nftContract, tokenId);
-        MetadataHelper.setMetadataWithSig(ipId, address(CORE_METADATA_MODULE), ipMetadata, sigMetadata);
+        MetadataHelper.setMetadataWithSig(
+            ipId,
+            address(CORE_METADATA_MODULE),
+            address(ACCESS_CONTROLLER),
+            ipMetadata,
+            sigMetadata
+        );
 
-        for (uint256 i = 0; i < licenseTermsIds.length; i++) {
-            LicensingHelper.attachLicenseTermsWithSig(
-                ipId,
-                address(LICENSING_MODULE),
-                licenseTemplates[i],
-                licenseTermsIds[i],
-                sigsAttach[i]
-            );
-        }
+        PermissionHelper.setPermissionForModule(
+            ipId,
+            address(LICENSING_MODULE),
+            address(ACCESS_CONTROLLER),
+            ILicensingModule.attachLicenseTerms.selector,
+            sigAttach
+        );
+
+        licenseTermsId = LicensingHelper.registerPILTermsAndAttach(
+            ipId,
+            address(PIL_TEMPLATE),
+            address(LICENSING_MODULE),
+            address(LICENSE_REGISTRY),
+            terms
+        );
     }
 
     //

--- a/contracts/workflows/RegistrationWorkflows.sol
+++ b/contracts/workflows/RegistrationWorkflows.sol
@@ -142,7 +142,13 @@ contract RegistrationWorkflows is
         WorkflowStructs.SignatureData calldata sigMetadata
     ) external returns (address ipId) {
         ipId = IP_ASSET_REGISTRY.register(block.chainid, nftContract, tokenId);
-        MetadataHelper.setMetadataWithSig(ipId, address(CORE_METADATA_MODULE), ipMetadata, sigMetadata);
+        MetadataHelper.setMetadataWithSig(
+            ipId,
+            address(CORE_METADATA_MODULE),
+            address(ACCESS_CONTROLLER),
+            ipMetadata,
+            sigMetadata
+        );
     }
 
     //

--- a/contracts/workflows/RoyaltyWorkflows.sol
+++ b/contracts/workflows/RoyaltyWorkflows.sol
@@ -7,6 +7,7 @@ import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC16
 import { MulticallUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/MulticallUpgradeable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
+import { Errors as CoreErrors } from "@storyprotocol/core/lib/Errors.sol";
 // solhint-disable-next-line max-line-length
 import { IGraphAwareRoyaltyPolicy } from "@storyprotocol/core/interfaces/modules/royalty/policies/IGraphAwareRoyaltyPolicy.sol";
 import { IIpRoyaltyVault } from "@storyprotocol/core/interfaces/modules/royalty/policies/IIpRoyaltyVault.sol";

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -13,12 +13,12 @@
 
 ### [License Attachment Workflows](../contracts/interfaces/workflows/ILicenseAttachmentWorkflows.sol)
 
+- `registerPILTermsAndAttach`:
+  - Registers PIL terms → Attaches them to an IP
+- `registerIpAndAttachPILTerms`:
+  - Registers an IP → Registers PIL terms → Attaches them to the IP
 - `mintAndRegisterIpAndAttachPILTerms`:
   - Mints a NFT → Registers it as an IP → Registers PIL terms → Attaches them to the IP
-- `mintAndRegisterIpAndAttachLicenseTerms`:
-  - Mints a NFT → Registers it as an IP → Attaches license terms to the IP
-- `registerIpAndAttachLicenseTerms`:
-  - Registers an IP → Attaches license terms to the IP
 
 ### [Derivative Workflows](../contracts/interfaces/workflows/IDerivativeWorkflows.sol)
 
@@ -50,4 +50,4 @@
   - Transfers specified amounts of royalties from various royalty policies to the royalty vault of the ancestor IP -> Claims all the revenue in each currency token from the ancestor IP's royalty vault to the claimer.
 
 - `claimAllRevenue`:
-  - Transfers all available royalties from various royalty policies to the royalty vault of the ancestor IP -> Claims all the revenue in each currency token from the ancestor IP's royalty vault to the claimer.
+  - Transfers all avaiable royalties from various royalty policies to the royalty vault of the ancestor IP -> Claims all the revenue in each currency token from the ancestor IP's royalty vault to the claimer.

--- a/script/utils/DeployHelper.sol
+++ b/script/utils/DeployHelper.sol
@@ -645,7 +645,7 @@ contract DeployHelper is
 
         // royaltyPolicyLRP
         impl = address(0); // Make sure we don't deploy wrong impl
-        impl = address(new RoyaltyPolicyLRP(address(royaltyModule), address(ipGraphACL)));
+        impl = address(new RoyaltyPolicyLRP(address(royaltyModule), address(royaltyPolicyLAP), address(ipGraphACL)));
         royaltyPolicyLRP = RoyaltyPolicyLRP(
             TestProxyHelper.deployUUPSProxy(
                 create3Deployer,

--- a/test/hooks/LockLicenseHook.t.sol
+++ b/test/hooks/LockLicenseHook.t.sol
@@ -31,7 +31,10 @@ contract LockLicenseHookTest is BaseTest {
             mintingFee: 0,
             licensingHook: address(lockLicenseHook),
             hookData: "",
-            commercialRevShare: 0
+            commercialRevShare: 0,
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(0) // not allowed to be added to any group
         });
         licensingModule.setLicensingConfig(ipId, address(pilTemplate), socialRemixTermsId, licensingConfig);
         vm.stopPrank();
@@ -68,7 +71,10 @@ contract LockLicenseHookTest is BaseTest {
             mintingFee: 0,
             licensingHook: address(lockLicenseHook),
             hookData: "",
-            commercialRevShare: 0
+            commercialRevShare: 0,
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(0) // not allowed to be added to any group
         });
         licensingModule.setLicensingConfig(ipId, address(pilTemplate), socialRemixTermsId, licensingConfig);
         vm.stopPrank();
@@ -94,7 +100,8 @@ contract LockLicenseHookTest is BaseTest {
             licenseTermsIds: licenseTermsIds,
             licenseTemplate: address(pilTemplate),
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRts: 0 // non-commercial remixing does not require royalty tokens
         });
     }
 
@@ -110,7 +117,10 @@ contract LockLicenseHookTest is BaseTest {
             mintingFee: 1000,
             licensingHook: address(lockLicenseHook),
             hookData: "",
-            commercialRevShare: 0
+            commercialRevShare: 0,
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(0) // not allowed to be added to any group
         });
         licensingModule.setLicensingConfig(ipId, address(pilTemplate), socialRemixTermsId, licensingConfig);
         vm.stopPrank();

--- a/test/hooks/TotalLicenseTokenLimitHook.t.sol
+++ b/test/hooks/TotalLicenseTokenLimitHook.t.sol
@@ -49,7 +49,10 @@ contract TotalLicenseTokenLimitHookTest is BaseTest {
             mintingFee: 100,
             licensingHook: address(totalLimitHook),
             hookData: "",
-            commercialRevShare: 0
+            commercialRevShare: 0,
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(0) // not allowed to be added to any group
         });
 
         vm.startPrank(ipOwner1);
@@ -150,7 +153,10 @@ contract TotalLicenseTokenLimitHookTest is BaseTest {
             mintingFee: 100,
             licensingHook: address(totalLimitHook),
             hookData: "",
-            commercialRevShare: 0
+            commercialRevShare: 0,
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(0) // not allowed to be added to any group
         });
 
         vm.startPrank(ipOwner1);
@@ -188,7 +194,10 @@ contract TotalLicenseTokenLimitHookTest is BaseTest {
             mintingFee: 100,
             licensingHook: address(totalLimitHook),
             hookData: "",
-            commercialRevShare: 0
+            commercialRevShare: 0,
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(0) // not allowed to be added to any group
         });
 
         vm.startPrank(ipOwner1);

--- a/test/integration/BaseIntegration.t.sol
+++ b/test/integration/BaseIntegration.t.sol
@@ -134,39 +134,140 @@ contract BaseIntegration is Test, Script, StoryProtocolCoreAddressManager, Story
     /*//////////////////////////////////////////////////////////////////////////
                                       HELPERS
     //////////////////////////////////////////////////////////////////////////*/
-    /// @dev Get the signature for executing a function on behalf of the IP via {IIPAccount.executeWithSig}.
-    /// @param ipId The ID of the IP whose account will execute the function.
-    /// @param to The address of the contract to execute the function on.
-    /// @param deadline The deadline for the signature.
-    /// @param state IPAccount's internal nonce
-    /// @param data the call data for the function.
-    /// @param signerSk The secret key of the signer.
-    /// @return signature The signature for executing the function.
-    /// @return expectedState The expected IPAccount's state after executing the function.
-    function _getSigForExecuteWithSig(
+
+    /// @dev Get the permission list for setting metadata and attaching license terms for the IP.
+    /// @param ipId The ID of the IP that the permissions are for.
+    /// @param to The address of the periphery contract to receive the permission.
+    /// @return permissionList The list of permissions for setting metadata and attaching license terms.
+    function _getMetadataAndAttachTermsPermissionList(
         address ipId,
-        address to,
+        address to
+    ) internal view returns (AccessPermission.Permission[] memory permissionList) {
+        address[] memory modules = new address[](2);
+        bytes4[] memory selectors = new bytes4[](2);
+        permissionList = new AccessPermission.Permission[](2);
+
+        modules[0] = coreMetadataModuleAddr;
+        modules[1] = licensingModuleAddr;
+        selectors[0] = ICoreMetadataModule.setAll.selector;
+        selectors[1] = ILicensingModule.attachLicenseTerms.selector;
+
+        for (uint256 i = 0; i < 2; i++) {
+            permissionList[i] = AccessPermission.Permission({
+                ipAccount: ipId,
+                signer: to,
+                to: modules[i],
+                func: selectors[i],
+                permission: AccessPermission.ALLOW
+            });
+        }
+    }
+
+    /// @dev Get the signature for setting batch permission for the IP by the SPG.
+    /// @param ipId The ID of the IP to set the permissions for.
+    /// @param permissionList A list of permissions to set.
+    /// @param deadline The deadline for the signature.
+    /// @param state IPAccount's internal state
+    /// @param signerSk The secret key of the signer.
+    /// @return signature The signature for setting the batch permission.
+    /// @return expectedState The expected IPAccount's state after setting batch permission.
+    /// @return data The call data for executing the setBatchPermissions function.
+    function _getSetBatchPermissionSigForPeriphery(
+        address ipId,
+        AccessPermission.Permission[] memory permissionList,
         uint256 deadline,
         bytes32 state,
-        bytes memory data,
         uint256 signerSk
-    ) internal view returns (bytes memory signature, bytes32 expectedState) {
+    ) internal view returns (bytes memory signature, bytes32 expectedState, bytes memory data) {
         expectedState = keccak256(
             abi.encode(
                 state, // ipAccount.state()
                 abi.encodeWithSelector(
                     IIPAccount.execute.selector,
-                    to, // to
-                    0, // value
-                    data
+                    address(accessControllerAddr),
+                    0, // amount of ether to send
+                    abi.encodeWithSelector(IAccessController.setBatchPermissions.selector, permissionList)
                 )
             )
+        );
+
+        data = abi.encodeWithSelector(IAccessController.setBatchPermissions.selector, permissionList);
+
+        bytes32 digest = MessageHashUtils.toTypedDataHash(
+            MetaTx.calculateDomainSeparator(ipId),
+            MetaTx.getExecuteStructHash(
+                MetaTx.Execute({
+                    to: address(accessControllerAddr),
+                    value: 0,
+                    data: data,
+                    nonce: expectedState,
+                    deadline: deadline
+                })
+            )
+        );
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerSk, digest);
+        signature = abi.encodePacked(r, s, v);
+    }
+
+    /// @dev Get the signature for setting permission for the IP by the SPG.
+    /// @param ipId The ID of the IP.
+    /// @param to The address of the periphery contract to receive the permission.
+    /// @param module The address of the module to set the permission for.
+    /// @param selector The selector of the function to be permitted for execution.
+    /// @param deadline The deadline for the signature.
+    /// @param state IPAccount's internal nonce
+    /// @param signerSk The secret key of the signer.
+    /// @return signature The signature for setting the permission.
+    /// @return expectedState The expected IPAccount's state after setting the permission.
+    /// @return data The call data for executing the setPermission function.
+    function _getSetPermissionSigForPeriphery(
+        address ipId,
+        address to,
+        address module,
+        bytes4 selector,
+        uint256 deadline,
+        bytes32 state,
+        uint256 signerSk
+    ) internal view returns (bytes memory signature, bytes32 expectedState, bytes memory data) {
+        expectedState = keccak256(
+            abi.encode(
+                state, // ipAccount.state()
+                abi.encodeWithSelector(
+                    IIPAccount.execute.selector,
+                    address(accessControllerAddr),
+                    0, // amount of ether to send
+                    abi.encodeWithSelector(
+                        IAccessController.setPermission.selector,
+                        ipId,
+                        to,
+                        address(module),
+                        selector,
+                        AccessPermission.ALLOW
+                    )
+                )
+            )
+        );
+
+        data = abi.encodeWithSelector(
+            IAccessController.setPermission.selector,
+            ipId,
+            to,
+            address(module),
+            selector,
+            AccessPermission.ALLOW
         );
 
         bytes32 digest = MessageHashUtils.toTypedDataHash(
             MetaTx.calculateDomainSeparator(ipId),
             MetaTx.getExecuteStructHash(
-                MetaTx.Execute({ to: to, value: 0, data: data, nonce: expectedState, deadline: deadline })
+                MetaTx.Execute({
+                    to: address(accessControllerAddr),
+                    value: 0,
+                    data: data,
+                    nonce: expectedState,
+                    deadline: deadline
+                })
             )
         );
 

--- a/test/integration/workflows/DerivativeIntegration.t.sol
+++ b/test/integration/workflows/DerivativeIntegration.t.sol
@@ -2,13 +2,11 @@
 pragma solidity 0.8.26;
 
 // external
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { ICoreMetadataModule } from "@storyprotocol/core/interfaces/modules/metadata/ICoreMetadataModule.sol";
 import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
 import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingModule.sol";
 import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
-import { PILTerms } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
 
 // contracts
 import { ISPGNFT } from "../../../contracts/interfaces/ISPGNFT.sol";
@@ -24,6 +22,7 @@ contract DerivativeIntegration is BaseIntegration {
     address[] private parentIpIds;
     uint256[] private parentLicenseTermIds;
     address private parentLicenseTemplate;
+    uint32 private revShare;
 
     /// @dev To use, run the following command:
     /// forge script test/integration/workflows/DerivativeIntegration.t.sol:DerivativeIntegration \
@@ -54,7 +53,8 @@ contract DerivativeIntegration is BaseIntegration {
                 licenseTemplate: parentLicenseTemplate,
                 licenseTermsIds: parentLicenseTermIds,
                 royaltyContext: "",
-                maxMintingFee: 0
+                maxMintingFee: 0,
+                maxRts: revShare
             }),
             ipMetadata: testIpMetadata,
             recipient: testSender,
@@ -97,49 +97,23 @@ contract DerivativeIntegration is BaseIntegration {
 
         uint256 deadline = block.timestamp + 1000;
 
-        bytes32 expectedState;
-        bytes memory sigMetadata;
-        bytes memory sigMintingFee;
-        bytes memory sigRegister;
-
-        (sigMetadata, expectedState) = _getSigForExecuteWithSig({
+        (bytes memory sigMetadata, bytes32 sigRegisterState, ) = _getSetPermissionSigForPeriphery({
             ipId: childIpId,
-            to: coreMetadataModuleAddr,
+            to: derivativeWorkflowsAddr,
+            module: coreMetadataModuleAddr,
+            selector: ICoreMetadataModule.setAll.selector,
             deadline: deadline,
             state: bytes32(0),
-            data: abi.encodeWithSelector(
-                ICoreMetadataModule.setAll.selector,
-                childIpId,
-                testIpMetadata.ipMetadataURI,
-                testIpMetadata.ipMetadataHash,
-                testIpMetadata.nftMetadataHash
-            ),
             signerSk: testSenderSk
         });
 
-        (sigMintingFee, expectedState) = _getSigForExecuteWithSig({
+        (bytes memory sigRegister, bytes32 expectedState, ) = _getSetPermissionSigForPeriphery({
             ipId: childIpId,
-            to: address(StoryUSD),
+            to: derivativeWorkflowsAddr,
+            module: licensingModuleAddr,
+            selector: ILicensingModule.registerDerivative.selector,
             deadline: deadline,
-            state: expectedState,
-            data: abi.encodeWithSelector(IERC20.approve.selector, address(royaltyModule), testMintFee),
-            signerSk: testSenderSk
-        });
-
-        (sigRegister, ) = _getSigForExecuteWithSig({
-            ipId: childIpId,
-            to: licensingModuleAddr,
-            deadline: deadline,
-            state: expectedState,
-            data: abi.encodeWithSelector(
-                ILicensingModule.registerDerivative.selector,
-                childIpId,
-                parentIpIds,
-                parentLicenseTermIds,
-                parentLicenseTemplate,
-                "",
-                0
-            ),
+            state: sigRegisterState,
             signerSk: testSenderSk
         });
 
@@ -153,18 +127,14 @@ contract DerivativeIntegration is BaseIntegration {
                 licenseTemplate: parentLicenseTemplate,
                 licenseTermsIds: parentLicenseTermIds,
                 royaltyContext: "",
-                maxMintingFee: 0
+                maxMintingFee: 0,
+                maxRts: revShare
             }),
             ipMetadata: testIpMetadata,
             sigMetadata: WorkflowStructs.SignatureData({
                 signer: testSender,
                 deadline: deadline,
                 signature: sigMetadata
-            }),
-            sigMintingFee: WorkflowStructs.SignatureData({
-                signer: testSender,
-                deadline: deadline,
-                signature: sigMintingFee
             }),
             sigRegister: WorkflowStructs.SignatureData({
                 signer: testSender,
@@ -221,6 +191,7 @@ contract DerivativeIntegration is BaseIntegration {
                 spgNftContract: address(spgNftContract),
                 licenseTokenIds: licenseTokenIds,
                 royaltyContext: "",
+                maxRts: revShare,
                 ipMetadata: testIpMetadata,
                 recipient: testSender,
                 allowDuplicates: true
@@ -278,31 +249,22 @@ contract DerivativeIntegration is BaseIntegration {
         licenseTokenIds[0] = startLicenseTokenId;
         licenseToken.approve(derivativeWorkflowsAddr, startLicenseTokenId);
 
-        (bytes memory sigMetadata, bytes32 sigRegisterState) = _getSigForExecuteWithSig({
+        (bytes memory sigMetadata, bytes32 sigRegisterState, ) = _getSetPermissionSigForPeriphery({
             ipId: childIpId,
-            to: coreMetadataModuleAddr,
+            to: derivativeWorkflowsAddr,
+            module: coreMetadataModuleAddr,
+            selector: ICoreMetadataModule.setAll.selector,
             deadline: deadline,
             state: bytes32(0),
-            data: abi.encodeWithSelector(
-                ICoreMetadataModule.setAll.selector,
-                childIpId,
-                testIpMetadata.ipMetadataURI,
-                testIpMetadata.ipMetadataHash,
-                testIpMetadata.nftMetadataHash
-            ),
             signerSk: testSenderSk
         });
-        (bytes memory sigRegister, bytes32 expectedState) = _getSigForExecuteWithSig({
+        (bytes memory sigRegister, bytes32 expectedState, ) = _getSetPermissionSigForPeriphery({
             ipId: childIpId,
-            to: licensingModuleAddr,
+            to: derivativeWorkflowsAddr,
+            module: licensingModuleAddr,
+            selector: ILicensingModule.registerDerivativeWithLicenseTokens.selector,
             deadline: deadline,
             state: sigRegisterState,
-            data: abi.encodeWithSelector(
-                ILicensingModule.registerDerivativeWithLicenseTokens.selector,
-                childIpId,
-                licenseTokenIds,
-                ""
-            ),
             signerSk: testSenderSk
         });
 
@@ -311,6 +273,7 @@ contract DerivativeIntegration is BaseIntegration {
             tokenId: childTokenId,
             licenseTokenIds: licenseTokenIds,
             royaltyContext: "",
+            maxRts: revShare,
             ipMetadata: testIpMetadata,
             sigMetadata: WorkflowStructs.SignatureData({
                 signer: testSender,
@@ -358,7 +321,8 @@ contract DerivativeIntegration is BaseIntegration {
                     licenseTemplate: parentLicenseTemplate,
                     licenseTermsIds: parentLicenseTermIds,
                     royaltyContext: "",
-                    maxMintingFee: 0
+                    maxMintingFee: 0,
+                    maxRts: revShare
                 }),
                 testIpMetadata,
                 testSender
@@ -412,21 +376,21 @@ contract DerivativeIntegration is BaseIntegration {
             )
         );
 
+        revShare = 10 * 10 ** 6; // 10%
+
         StoryUSD.mint(testSender, testMintFee);
         StoryUSD.approve(address(spgNftContract), testMintFee);
-        PILTerms[] memory terms = new PILTerms[](1);
-        terms[0] = PILFlavors.commercialRemix({
-            mintingFee: testMintFee,
-            commercialRevShare: 10 * 10 ** 6, // 10%
-            royaltyPolicy: royaltyPolicyLRPAddr,
-            currencyToken: testMintFeeToken
-        });
-        (address parentIpId, , uint256[] memory licenseTermsIdParent) = licenseAttachmentWorkflows
+        (address parentIpId, , uint256 licenseTermsIdParent) = licenseAttachmentWorkflows
             .mintAndRegisterIpAndAttachPILTerms({
                 spgNftContract: address(spgNftContract),
                 recipient: testSender,
                 ipMetadata: testIpMetadata,
-                terms: terms,
+                terms: PILFlavors.commercialRemix({
+                    mintingFee: testMintFee,
+                    commercialRevShare: revShare,
+                    royaltyPolicy: royaltyPolicyLRPAddr,
+                    currencyToken: testMintFeeToken
+                }),
                 allowDuplicates: true
             });
 
@@ -434,7 +398,7 @@ contract DerivativeIntegration is BaseIntegration {
         parentIpIds[0] = parentIpId;
 
         parentLicenseTermIds = new uint256[](1);
-        parentLicenseTermIds[0] = licenseTermsIdParent[0];
+        parentLicenseTermIds[0] = licenseTermsIdParent;
         parentLicenseTemplate = pilTemplateAddr;
     }
 

--- a/test/integration/workflows/RegistrationIntegration.t.sol
+++ b/test/integration/workflows/RegistrationIntegration.t.sol
@@ -97,18 +97,13 @@ contract RegistrationIntegration is BaseIntegration {
         // get signature for setting IP metadata
         uint256 deadline = block.timestamp + 1000;
         address expectedIpId = ipAssetRegistry.ipId(block.chainid, address(spgNftContract), tokenId);
-        (bytes memory sigMetadata, bytes32 expectedState) = _getSigForExecuteWithSig({
+        (bytes memory sigMetadata, bytes32 expectedState, ) = _getSetPermissionSigForPeriphery({
             ipId: expectedIpId,
-            to: coreMetadataModuleAddr,
+            to: registrationWorkflowsAddr,
+            module: coreMetadataModuleAddr,
+            selector: ICoreMetadataModule.setAll.selector,
             deadline: deadline,
             state: bytes32(0),
-            data: abi.encodeWithSelector(
-                ICoreMetadataModule.setAll.selector,
-                expectedIpId,
-                testIpMetadata.ipMetadataURI,
-                testIpMetadata.ipMetadataHash,
-                testIpMetadata.nftMetadataHash
-            ),
             signerSk: testSenderSk
         });
 

--- a/test/utils/BaseTest.t.sol
+++ b/test/utils/BaseTest.t.sol
@@ -280,39 +280,139 @@ contract BaseTest is Test, DeployHelper {
                                       HELPERS
     //////////////////////////////////////////////////////////////////////////*/
 
-    /// @dev Get the signature for executing a function on behalf of the IP via {IIPAccount.executeWithSig}.
-    /// @param ipId The ID of the IP whose account will execute the function.
-    /// @param to The address of the contract to execute the function on.
-    /// @param deadline The deadline for the signature.
-    /// @param state IPAccount's internal nonce
-    /// @param data the call data for the function.
-    /// @param signerSk The secret key of the signer.
-    /// @return signature The signature for executing the function.
-    /// @return expectedState The expected IPAccount's state after executing the function.
-    function _getSigForExecuteWithSig(
+    /// @dev Get the permission list for setting metadata and attaching license terms for the IP.
+    /// @param ipId The ID of the IP that the permissions are for.
+    /// @param to The address of the periphery contract to receive the permission.
+    /// @return permissionList The list of permissions for setting metadata and attaching license terms.
+    function _getMetadataAndAttachTermsPermissionList(
         address ipId,
-        address to,
+        address to
+    ) internal view returns (AccessPermission.Permission[] memory permissionList) {
+        address[] memory modules = new address[](2);
+        bytes4[] memory selectors = new bytes4[](2);
+        permissionList = new AccessPermission.Permission[](2);
+
+        modules[0] = coreMetadataModuleAddr;
+        modules[1] = licensingModuleAddr;
+        selectors[0] = ICoreMetadataModule.setAll.selector;
+        selectors[1] = ILicensingModule.attachLicenseTerms.selector;
+
+        for (uint256 i = 0; i < 2; i++) {
+            permissionList[i] = AccessPermission.Permission({
+                ipAccount: ipId,
+                signer: to,
+                to: modules[i],
+                func: selectors[i],
+                permission: AccessPermission.ALLOW
+            });
+        }
+    }
+
+    /// @dev Get the signature for setting batch permission for the IP by the SPG.
+    /// @param ipId The ID of the IP to set the permissions for.
+    /// @param permissionList A list of permissions to set.
+    /// @param deadline The deadline for the signature.
+    /// @param state IPAccount's internal state
+    /// @param signerSk The secret key of the signer.
+    /// @return signature The signature for setting the batch permission.
+    /// @return expectedState The expected IPAccount's state after setting batch permission.
+    /// @return data The call data for executing the setBatchPermissions function.
+    function _getSetBatchPermissionSigForPeriphery(
+        address ipId,
+        AccessPermission.Permission[] memory permissionList,
         uint256 deadline,
         bytes32 state,
-        bytes memory data,
         uint256 signerSk
-    ) internal view returns (bytes memory signature, bytes32 expectedState) {
+    ) internal view returns (bytes memory signature, bytes32 expectedState, bytes memory data) {
         expectedState = keccak256(
             abi.encode(
                 state, // ipAccount.state()
                 abi.encodeWithSelector(
                     IIPAccount.execute.selector,
-                    to, // to
-                    0, // value
-                    data
+                    address(accessControllerAddr),
+                    0, // amount of ether to send
+                    abi.encodeWithSelector(IAccessController.setBatchPermissions.selector, permissionList)
                 )
             )
+        );
+
+        data = abi.encodeWithSelector(IAccessController.setBatchPermissions.selector, permissionList);
+
+        bytes32 digest = MessageHashUtils.toTypedDataHash(
+            MetaTx.calculateDomainSeparator(ipId),
+            MetaTx.getExecuteStructHash(
+                MetaTx.Execute({
+                    to: address(accessControllerAddr),
+                    value: 0,
+                    data: data,
+                    nonce: expectedState,
+                    deadline: deadline
+                })
+            )
+        );
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerSk, digest);
+        signature = abi.encodePacked(r, s, v);
+    }
+
+    /// @dev Get the signature for setting permission for the IP by the SPG.
+    /// @param ipId The ID of the IP.
+    /// @param to The address of the periphery contract to receive the permission.
+    /// @param module The address of the module to set the permission for.
+    /// @param selector The selector of the function to be permitted for execution.
+    /// @param deadline The deadline for the signature.
+    /// @param state IPAccount's internal nonce
+    /// @param signerSk The secret key of the signer.
+    /// @return signature The signature for setting the permission.
+    /// @return expectedState The expected IPAccount's state after setting the permission.
+    /// @return data The call data for executing the setPermission function.
+    function _getSetPermissionSigForPeriphery(
+        address ipId,
+        address to,
+        address module,
+        bytes4 selector,
+        uint256 deadline,
+        bytes32 state,
+        uint256 signerSk
+    ) internal view returns (bytes memory signature, bytes32 expectedState, bytes memory data) {
+        expectedState = keccak256(
+            abi.encode(
+                state, // ipAccount.state()
+                abi.encodeWithSelector(
+                    IIPAccount.execute.selector,
+                    address(accessControllerAddr),
+                    0, // amount of ether to send
+                    abi.encodeWithSelector(
+                        IAccessController.setPermission.selector,
+                        ipId,
+                        to,
+                        address(module),
+                        selector,
+                        AccessPermission.ALLOW
+                    )
+                )
+            )
+        );
+
+        data = abi.encodeWithSelector(
+            IAccessController.setPermission.selector,
+            ipId,
+            to,
+            address(module),
+            selector,
+            AccessPermission.ALLOW
         );
 
         bytes32 digest = MessageHashUtils.toTypedDataHash(
             MetaTx.calculateDomainSeparator(ipId),
             MetaTx.getExecuteStructHash(
-                MetaTx.Execute({ to: to, value: 0, data: data, nonce: expectedState, deadline: deadline })
+                MetaTx.Execute({
+                    to: address(accessControllerAddr),
+                    value: 0,
+                    data: data,
+                    nonce: expectedState,
+                    deadline: deadline
+                })
             )
         );
 

--- a/test/workflows/DerivativeWorkflows.t.sol
+++ b/test/workflows/DerivativeWorkflows.t.sol
@@ -3,13 +3,11 @@ pragma solidity 0.8.26;
 /* solhint-disable no-console */
 
 // external
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { ICoreMetadataModule } from "@storyprotocol/core/interfaces/modules/metadata/ICoreMetadataModule.sol";
 import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
 import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingModule.sol";
 import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
-import { PILTerms } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
 
 // contracts
 import { Errors } from "../../contracts/lib/Errors.sol";
@@ -28,31 +26,27 @@ contract DerivativeWorkflowsTest is BaseTest {
     }
 
     modifier withNonCommercialParentIp() {
-        PILTerms[] memory terms = new PILTerms[](1);
-        terms[0] = PILFlavors.nonCommercialSocialRemixing();
         (ipIdParent, , ) = licenseAttachmentWorkflows.mintAndRegisterIpAndAttachPILTerms({
             spgNftContract: address(nftContract),
             recipient: caller,
             ipMetadata: ipMetadataDefault,
-            terms: terms,
+            terms: PILFlavors.nonCommercialSocialRemixing(),
             allowDuplicates: true
         });
         _;
     }
 
     modifier withCommercialParentIp() {
-        PILTerms[] memory terms = new PILTerms[](1);
-        terms[0] = PILFlavors.commercialRemix({
-            mintingFee: 100 * 10 ** mockToken.decimals(),
-            commercialRevShare: 10 * 10 ** 6, // 10%
-            royaltyPolicy: address(royaltyPolicyLAP),
-            currencyToken: address(mockToken)
-        });
         (ipIdParent, , ) = licenseAttachmentWorkflows.mintAndRegisterIpAndAttachPILTerms({
             spgNftContract: address(nftContract),
             recipient: caller,
             ipMetadata: ipMetadataDefault,
-            terms: terms,
+            terms: PILFlavors.commercialRemix({
+                mintingFee: 100 * 10 ** mockToken.decimals(),
+                commercialRevShare: 10 * 10 ** 6, // 10%
+                royaltyPolicy: address(royaltyPolicyLAP),
+                currencyToken: address(mockToken)
+            }),
             allowDuplicates: true
         });
         _;
@@ -66,7 +60,12 @@ contract DerivativeWorkflowsTest is BaseTest {
         withNonCommercialParentIp
     {
         // First, create an derivative with the same NFT metadata hash but with dedup turned off
-        (, uint256 licenseTermsIdParent) = licenseRegistry.getAttachedLicenseTerms(ipIdParent, 0);
+        (address licenseTemplateParent, uint256 licenseTermsIdParent) = licenseRegistry.getAttachedLicenseTerms(
+            ipIdParent,
+            0
+        );
+
+        uint32 revShare = pilTemplate.getLicenseTerms(licenseTermsIdParent).commercialRevShare;
 
         address[] memory parentIpIds = new address[](1);
         parentIpIds[0] = ipIdParent;
@@ -74,14 +73,15 @@ contract DerivativeWorkflowsTest is BaseTest {
         uint256[] memory licenseTermsIds = new uint256[](1);
         licenseTermsIds[0] = licenseTermsIdParent;
 
-        derivativeWorkflows.mintAndRegisterIpAndMakeDerivative({
+        (address ipIdChild, ) = derivativeWorkflows.mintAndRegisterIpAndMakeDerivative({
             spgNftContract: address(nftContract),
             derivData: WorkflowStructs.MakeDerivative({
                 parentIpIds: parentIpIds,
                 licenseTemplate: address(pilTemplate),
                 licenseTermsIds: licenseTermsIds,
                 royaltyContext: "",
-                maxMintingFee: 0
+                maxMintingFee: 0,
+                maxRts: revShare
             }),
             ipMetadata: ipMetadataDefault,
             recipient: caller,
@@ -104,7 +104,8 @@ contract DerivativeWorkflowsTest is BaseTest {
                 licenseTemplate: address(pilTemplate),
                 licenseTermsIds: licenseTermsIds,
                 royaltyContext: "",
-                maxMintingFee: 0
+                maxMintingFee: 0,
+                maxRts: revShare
             }),
             ipMetadata: ipMetadataDefault,
             recipient: caller,
@@ -164,6 +165,8 @@ contract DerivativeWorkflowsTest is BaseTest {
             0
         );
 
+        uint32 revShare = pilTemplate.getLicenseTerms(licenseTermsIdParent).commercialRevShare;
+
         uint256 startLicenseTokenId = licensingModule.mintLicenseTokens({
             licensorIpId: ipIdParent,
             licenseTemplate: address(pilTemplate),
@@ -185,6 +188,7 @@ contract DerivativeWorkflowsTest is BaseTest {
                 spgNftContract: address(nftContract),
                 licenseTokenIds: licenseTokenIds,
                 royaltyContext: "",
+                maxRts: revShare,
                 ipMetadata: ipMetadataDefault,
                 recipient: caller,
                 allowDuplicates: true
@@ -221,6 +225,8 @@ contract DerivativeWorkflowsTest is BaseTest {
             0
         );
 
+        uint32 revShare = pilTemplate.getLicenseTerms(licenseTermsIdParent).commercialRevShare;
+
         uint256 tokenIdChild = nftContract.mint({
             to: caller,
             nftMetadataURI: ipMetadataDefault.nftMetadataURI,
@@ -245,42 +251,48 @@ contract DerivativeWorkflowsTest is BaseTest {
         licenseTokenIds[0] = startLicenseTokenId;
         licenseToken.approve(address(derivativeWorkflows), startLicenseTokenId);
 
-        (bytes memory sigMetadata, bytes32 expectedState) = _getSigForExecuteWithSig({
-            ipId: ipIdChild,
-            to: address(coreMetadataModule),
-            deadline: deadline,
-            state: bytes32(0),
-            data: abi.encodeWithSelector(
-                ICoreMetadataModule.setAll.selector,
-                ipIdChild,
-                ipMetadataDefault.ipMetadataURI,
-                ipMetadataDefault.ipMetadataHash,
-                ipMetadataDefault.nftMetadataHash
-            ),
-            signerSk: sk.alice
-        });
-        (bytes memory sigRegister, ) = _getSigForExecuteWithSig({
-            ipId: ipIdChild,
-            to: address(licensingModule),
-            deadline: deadline,
-            state: expectedState,
-            data: abi.encodeWithSelector(
-                ILicensingModule.registerDerivativeWithLicenseTokens.selector,
-                ipIdChild,
-                licenseTokenIds,
-                ""
-            ),
-            signerSk: sk.alice
-        });
+        WorkflowStructs.SignatureData memory sigMetadata;
+        WorkflowStructs.SignatureData memory sigRegister;
+        {
+            (bytes memory signatureMetadata, bytes32 expectedState, ) = _getSetPermissionSigForPeriphery({
+                ipId: ipIdChild,
+                to: address(derivativeWorkflows),
+                module: address(coreMetadataModule),
+                selector: ICoreMetadataModule.setAll.selector,
+                deadline: deadline,
+                state: bytes32(0),
+                signerSk: sk.alice
+            });
+            (bytes memory signatureRegister, , ) = _getSetPermissionSigForPeriphery({
+                ipId: ipIdChild,
+                to: address(derivativeWorkflows),
+                module: address(licensingModule),
+                selector: ILicensingModule.registerDerivativeWithLicenseTokens.selector,
+                deadline: deadline,
+                state: expectedState,
+                signerSk: sk.alice
+            });
+            sigMetadata = WorkflowStructs.SignatureData({
+                signer: u.alice,
+                deadline: deadline,
+                signature: signatureMetadata
+            });
+            sigRegister = WorkflowStructs.SignatureData({
+                signer: u.alice,
+                deadline: deadline,
+                signature: signatureRegister
+            });
+        }
 
         address ipIdChildActual = derivativeWorkflows.registerIpAndMakeDerivativeWithLicenseTokens({
             nftContract: address(nftContract),
             tokenId: tokenIdChild,
             licenseTokenIds: licenseTokenIds,
             royaltyContext: "",
+            maxRts: revShare,
             ipMetadata: ipMetadataDefault,
-            sigMetadata: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: sigMetadata }),
-            sigRegister: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: sigRegister })
+            sigMetadata: sigMetadata,
+            sigRegister: sigRegister
         });
         assertEq(ipIdChildActual, ipIdChild);
         assertTrue(ipAssetRegistry.isRegistered(ipIdChild));
@@ -311,6 +323,9 @@ contract DerivativeWorkflowsTest is BaseTest {
             ipIdParent,
             0
         );
+
+        uint32 revShare = pilTemplate.getLicenseTerms(licenseTermsIdParent).commercialRevShare;
+
         address[] memory parentIpIds = new address[](1);
         parentIpIds[0] = ipIdParent;
 
@@ -327,7 +342,8 @@ contract DerivativeWorkflowsTest is BaseTest {
                     licenseTemplate: address(pilTemplate),
                     licenseTermsIds: licenseTermsIds,
                     royaltyContext: "",
-                    maxMintingFee: 0
+                    maxMintingFee: 0,
+                    maxRts: revShare
                 }),
                 ipMetadataDefault,
                 caller,
@@ -365,6 +381,8 @@ contract DerivativeWorkflowsTest is BaseTest {
             0
         );
 
+        uint32 revShare = pilTemplate.getLicenseTerms(licenseTermsIdParent).commercialRevShare;
+
         address[] memory parentIpIds = new address[](1);
         parentIpIds[0] = ipIdParent;
 
@@ -378,7 +396,8 @@ contract DerivativeWorkflowsTest is BaseTest {
                 licenseTemplate: address(pilTemplate),
                 licenseTermsIds: licenseTermsIds,
                 royaltyContext: "",
-                maxMintingFee: 0
+                maxMintingFee: 0,
+                maxRts: revShare
             }),
             ipMetadata: ipMetadataDefault,
             recipient: caller,
@@ -410,6 +429,8 @@ contract DerivativeWorkflowsTest is BaseTest {
             0
         );
 
+        uint32 revShare = pilTemplate.getLicenseTerms(licenseTermsIdParent).commercialRevShare;
+
         uint256 tokenIdChild = nftContract.mint({
             to: caller,
             nftMetadataURI: ipMetadataDefault.nftMetadataURI,
@@ -420,92 +441,30 @@ contract DerivativeWorkflowsTest is BaseTest {
 
         uint256 deadline = block.timestamp + 1000;
 
+        (bytes memory sigMetadata, bytes32 expectedState, ) = _getSetPermissionSigForPeriphery({
+            ipId: ipIdChild,
+            to: address(derivativeWorkflows),
+            module: address(coreMetadataModule),
+            selector: ICoreMetadataModule.setAll.selector,
+            deadline: deadline,
+            state: bytes32(0),
+            signerSk: sk.alice
+        });
+        (bytes memory sigRegister, , ) = _getSetPermissionSigForPeriphery({
+            ipId: ipIdChild,
+            to: address(derivativeWorkflows),
+            module: address(licensingModule),
+            selector: ILicensingModule.registerDerivative.selector,
+            deadline: deadline,
+            state: expectedState,
+            signerSk: sk.alice
+        });
+
         address[] memory parentIpIds = new address[](1);
         parentIpIds[0] = ipIdParent;
 
         uint256[] memory licenseTermsIds = new uint256[](1);
         licenseTermsIds[0] = licenseTermsIdParent;
-
-        WorkflowStructs.SignatureData memory sigMetadataData;
-        WorkflowStructs.SignatureData memory sigMintingFeeData;
-        WorkflowStructs.SignatureData memory sigRegisterData;
-
-        {
-            bytes32 expectedState;
-            {
-                bytes memory sigMetadata;
-                (sigMetadata, expectedState) = _getSigForExecuteWithSig({
-                    ipId: ipIdChild,
-                    to: address(coreMetadataModule),
-                    deadline: deadline,
-                    state: bytes32(0),
-                    data: abi.encodeWithSelector(
-                        ICoreMetadataModule.setAll.selector,
-                        ipIdChild,
-                        ipMetadataDefault.ipMetadataURI,
-                        ipMetadataDefault.ipMetadataHash,
-                        ipMetadataDefault.nftMetadataHash
-                    ),
-                    signerSk: sk.alice
-                });
-                sigMetadataData = WorkflowStructs.SignatureData({
-                    signer: u.alice,
-                    deadline: deadline,
-                    signature: sigMetadata
-                });
-            }
-
-            {
-                uint256 totalMintingFee = _getTotalMintingFee(parentIpIds, licenseTermsIds);
-                if (totalMintingFee == 0) {
-                    // If the total minting fee is 0, we don't need to have a signature for approving the minting fee
-                    sigMintingFeeData = WorkflowStructs.SignatureData({
-                        signer: u.alice,
-                        deadline: deadline,
-                        signature: ""
-                    });
-                } else {
-                    bytes memory sigMintingFee;
-                    (sigMintingFee, expectedState) = _getSigForExecuteWithSig({
-                        ipId: ipIdChild,
-                        to: address(mockToken),
-                        deadline: deadline,
-                        state: expectedState,
-                        data: abi.encodeWithSelector(IERC20.approve.selector, address(royaltyModule), totalMintingFee),
-                        signerSk: sk.alice
-                    });
-                    sigMintingFeeData = WorkflowStructs.SignatureData({
-                        signer: u.alice,
-                        deadline: deadline,
-                        signature: sigMintingFee
-                    });
-                }
-            }
-
-            {
-                (bytes memory sigRegister, ) = _getSigForExecuteWithSig({
-                    ipId: ipIdChild,
-                    to: address(licensingModule),
-                    deadline: deadline,
-                    state: expectedState,
-                    data: abi.encodeWithSelector(
-                        ILicensingModule.registerDerivative.selector,
-                        ipIdChild,
-                        parentIpIds,
-                        licenseTermsIds,
-                        address(pilTemplate),
-                        "",
-                        0
-                    ),
-                    signerSk: sk.alice
-                });
-                sigRegisterData = WorkflowStructs.SignatureData({
-                    signer: u.alice,
-                    deadline: deadline,
-                    signature: sigRegister
-                });
-            }
-        }
 
         address ipIdChildActual = derivativeWorkflows.registerIpAndMakeDerivative({
             nftContract: address(nftContract),
@@ -515,12 +474,12 @@ contract DerivativeWorkflowsTest is BaseTest {
                 licenseTemplate: address(pilTemplate),
                 licenseTermsIds: licenseTermsIds,
                 royaltyContext: "",
-                maxMintingFee: 0
+                maxMintingFee: 0,
+                maxRts: revShare
             }),
             ipMetadata: ipMetadataDefault,
-            sigMetadata: sigMetadataData,
-            sigMintingFee: sigMintingFeeData,
-            sigRegister: sigRegisterData
+            sigMetadata: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: sigMetadata }),
+            sigRegister: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: sigRegister })
         });
         assertEq(ipIdChildActual, ipIdChild);
         assertTrue(ipAssetRegistry.isRegistered(ipIdChild));
@@ -540,24 +499,5 @@ contract DerivativeWorkflowsTest is BaseTest {
             expectedParentCount: 1,
             expectedParentIndex: 0
         });
-    }
-
-    function _getTotalMintingFee(
-        address[] memory parentIpIds,
-        uint256[] memory licenseTermsIds
-    ) internal view returns (uint256) {
-        uint256 totalMintingFee;
-        for (uint256 i = 0; i < parentIpIds.length; i++) {
-            (, uint256 mintFee) = ILicensingModule(licensingModule).predictMintingLicenseFee({
-                licensorIpId: parentIpIds[i],
-                licenseTemplate: address(pilTemplate),
-                licenseTermsId: licenseTermsIds[i],
-                amount: 1,
-                receiver: address(this),
-                royaltyContext: ""
-            });
-            totalMintingFee += mintFee;
-        }
-        return totalMintingFee;
     }
 }

--- a/test/workflows/GroupingWorkflows.t.sol
+++ b/test/workflows/GroupingWorkflows.t.sol
@@ -4,17 +4,15 @@ pragma solidity 0.8.26;
 
 // external
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
-import { AccessPermission } from "@storyprotocol/core/lib/AccessPermission.sol";
-import { IAccessController } from "@storyprotocol/core/interfaces/access/IAccessController.sol";
-import { ICoreMetadataModule } from "@storyprotocol/core/interfaces/modules/metadata/ICoreMetadataModule.sol";
 import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
 import { ILicenseRegistry } from "@storyprotocol/core/interfaces/registries/ILicenseRegistry.sol";
-import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingModule.sol";
 import { IIPAssetRegistry } from "@storyprotocol/core/interfaces/registries/IIPAssetRegistry.sol";
+import { IIpRoyaltyVault } from "@storyprotocol/core/interfaces/modules/royalty/policies/IIpRoyaltyVault.sol";
 import { IGroupingModule } from "@storyprotocol/core/interfaces/modules/grouping/IGroupingModule.sol";
 import { IGroupIPAssetRegistry } from "@storyprotocol/core/interfaces/registries/IGroupIPAssetRegistry.sol";
 import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
 import { PILTerms } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
+import { Licensing } from "@storyprotocol/core/lib/Licensing.sol";
 
 // contracts
 import { Errors } from "../../contracts/lib/Errors.sol";
@@ -29,7 +27,9 @@ import { BaseTest } from "../utils/BaseTest.t.sol";
 contract GroupingWorkflowsTest is BaseTest {
     using Strings for uint256;
 
-    WorkflowStructs.LicenseInfo[] internal testLicenseInfo;
+    uint256 internal testLicenseTermsId;
+    PILTerms internal testLicenseTerms;
+    Licensing.LicensingConfig internal testLicensingConfig;
     uint32 internal revShare;
 
     address internal groupOwner;
@@ -46,8 +46,26 @@ contract GroupingWorkflowsTest is BaseTest {
         groupOwner = u.bob;
         groupOwnerSk = sk.bob;
 
-        // setup license terms
-        _setupLicenseTerms();
+        // register license terms
+        revShare = 10 * 10 ** 6; // 10%
+        testLicenseTerms = PILFlavors.commercialRemix({
+            mintingFee: 0,
+            commercialRevShare: revShare,
+            currencyToken: address(mockToken),
+            royaltyPolicy: address(royaltyPolicyLAP)
+        });
+        testLicenseTermsId = pilTemplate.registerLicenseTerms(testLicenseTerms);
+
+        testLicensingConfig = Licensing.LicensingConfig({
+            isSet: true,
+            mintingFee: 0,
+            licensingHook: address(0),
+            hookData: "",
+            commercialRevShare: revShare,
+            disabled: false,
+            expectMinimumGroupRewardShare: 0,
+            expectGroupRewardPool: address(evenSplitGroupPool)
+        });
 
         // setup a group IPA
         _setupGroup();
@@ -59,19 +77,13 @@ contract GroupingWorkflowsTest is BaseTest {
     function test_GroupingWorkflows_revert_DuplicatedNFTMetadataHash() public {
         uint256 deadline = block.timestamp + 1000;
 
-        (bytes memory sigAddToGroup, ) = _getSigForExecuteWithSig({
+        (bytes memory sigAddToGroup, bytes32 expectedState, ) = _getSetPermissionSigForPeriphery({
             ipId: groupId,
-            to: address(accessController),
+            to: address(groupingWorkflows),
+            module: address(groupingModule),
+            selector: IGroupingModule.addIp.selector,
             deadline: deadline,
             state: IIPAccount(payable(groupId)).state(),
-            data: abi.encodeWithSelector(
-                IAccessController.setPermission.selector,
-                groupId,
-                address(groupingWorkflows),
-                address(groupingModule),
-                IGroupingModule.addIp.selector,
-                AccessPermission.ALLOW
-            ),
             signerSk: groupOwnerSk
         });
 
@@ -89,7 +101,8 @@ contract GroupingWorkflowsTest is BaseTest {
             groupId: groupId,
             recipient: minter,
             ipMetadata: ipMetadataDefault,
-            licenseInfo: testLicenseInfo,
+            licenseTemplate: address(pilTemplate),
+            licenseTermsId: testLicenseTermsId,
             sigAddToGroup: WorkflowStructs.SignatureData({
                 signer: groupOwner,
                 deadline: deadline,
@@ -101,178 +114,116 @@ contract GroupingWorkflowsTest is BaseTest {
     }
 
     // Mint → Register IP → Attach license terms → Add new IP to group IPA
+    // TODO: enable set licensing config during license attachment to make this test work
     function test_GroupingWorkflows_mintAndRegisterIpAndAttachLicenseAndAddToGroup() public {
-        uint256 deadline = block.timestamp + 1000;
-
-        // Get the signature for setting the permission for calling `addIp` function in `GroupingModule`
-        // from the Group IP owner
-        (bytes memory sigAddToGroup, bytes32 expectedState) = _getSigForExecuteWithSig({
-            ipId: groupId,
-            to: address(accessController),
-            deadline: deadline,
-            state: IIPAccount(payable(groupId)).state(),
-            data: abi.encodeWithSelector(
-                IAccessController.setPermission.selector,
-                groupId,
-                address(groupingWorkflows),
-                address(groupingModule),
-                IGroupingModule.addIp.selector,
-                AccessPermission.ALLOW
-            ),
-            signerSk: groupOwnerSk
-        });
-
-        vm.startPrank(minter);
-        (address ipId, uint256 tokenId) = groupingWorkflows.mintAndRegisterIpAndAttachLicenseAndAddToGroup({
-            spgNftContract: address(spgNftPublic),
-            groupId: groupId,
-            recipient: minter,
-            ipMetadata: ipMetadataDefault,
-            licenseInfo: testLicenseInfo,
-            sigAddToGroup: WorkflowStructs.SignatureData({
-                signer: groupOwner,
-                deadline: deadline,
-                signature: sigAddToGroup
-            }),
-            allowDuplicates: true
-        });
-        vm.stopPrank();
-
-        // check the group IP account state matches the expected state
-        assertEq(IIPAccount(payable(groupId)).state(), expectedState);
-
-        // check the IP is registered
-        assertTrue(IIPAssetRegistry(ipAssetRegistry).isRegistered(ipId));
-
-        // check the IP is added to the group
-        assertTrue(IGroupIPAssetRegistry(ipAssetRegistry).containsIp(groupId, ipId));
-
-        // check the NFT metadata is correctly set
-        assertEq(spgNftPublic.tokenURI(tokenId), string.concat(testBaseURI, ipMetadataDefault.nftMetadataURI));
-
-        // check the IP metadata is correctly set
-        assertMetadata(ipId, ipMetadataDefault);
-
-        // check the license terms is correctly attached
-        for (uint256 i = 0; i < testLicenseInfo.length; i++) {
-            (address licenseTemplate, uint256 licenseTermsId) = ILicenseRegistry(address(licenseRegistry))
-                .getAttachedLicenseTerms(ipId, i);
-            assertEq(licenseTemplate, testLicenseInfo[i].licenseTemplate);
-            assertEq(licenseTermsId, testLicenseInfo[i].licenseTermsId);
-        }
+        // uint256 deadline = block.timestamp + 1000;
+        // // Get the signature for setting the permission for calling `addIp` function in `GroupingModule`
+        // // from the Group IP owner
+        // (bytes memory sigAddToGroup, bytes32 expectedState, ) = _getSetPermissionSigForPeriphery({
+        //     ipId: groupId,
+        //     to: address(groupingWorkflows),
+        //     module: address(groupingModule),
+        //     selector: IGroupingModule.addIp.selector,
+        //     deadline: deadline,
+        //     state: IIPAccount(payable(groupId)).state(),
+        //     signerSk: groupOwnerSk
+        // });
+        // vm.startPrank(minter);
+        // (address ipId, uint256 tokenId) = groupingWorkflows.mintAndRegisterIpAndAttachLicenseAndAddToGroup({
+        //     spgNftContract: address(spgNftPublic),
+        //     groupId: groupId,
+        //     recipient: minter,
+        //     ipMetadata: ipMetadataDefault,
+        //     licenseTemplate: address(pilTemplate),
+        //     licenseTermsId: testLicenseTermsId,
+        //     sigAddToGroup: WorkflowStructs.SignatureData({
+        //         signer: groupOwner,
+        //         deadline: deadline,
+        //         signature: sigAddToGroup
+        //     }),
+        //     allowDuplicates: true
+        // });
+        // vm.stopPrank();
+        // // check the group IP account state matches the expected state
+        // assertEq(IIPAccount(payable(groupId)).state(), expectedState);
+        // // check the IP is registered
+        // assertTrue(IIPAssetRegistry(ipAssetRegistry).isRegistered(ipId));
+        // // check the IP is added to the group
+        // assertTrue(IGroupIPAssetRegistry(ipAssetRegistry).containsIp(groupId, ipId));
+        // // check the NFT metadata is correctly set
+        // assertEq(spgNftPublic.tokenURI(tokenId), string.concat(testBaseURI, ipMetadataDefault.nftMetadataURI));
+        // // check the IP metadata is correctly set
+        // assertMetadata(ipId, ipMetadataDefault);
+        // // check the license terms is correctly attached
+        // (address licenseTemplate, uint256 licenseTermsId) = ILicenseRegistry(address(licenseRegistry))
+        //     .getAttachedLicenseTerms(ipId, 0);
+        // assertEq(licenseTemplate, address(pilTemplate));
+        // assertEq(licenseTermsId, testLicenseTermsId);
     }
 
     // Register IP → Attach license terms → Add new IP to group IPA
+    // TODO: enable set licensing config during license attachment to make this test work
     function test_GroupingWorkflows_registerIpAndAttachLicenseAndAddToGroup() public {
-        // mint a NFT from the mock ERC721 contract
-        vm.startPrank(minter);
-        uint256 tokenId = MockERC721(mockNft).mint(minter);
-        vm.stopPrank();
-
-        // get the expected IP ID
-        address expectedIpId = IIPAssetRegistry(ipAssetRegistry).ipId(block.chainid, address(mockNft), tokenId);
-
-        uint256 deadline = block.timestamp + 1000;
-
-        WorkflowStructs.SignatureData memory sigMetadataData;
-        WorkflowStructs.SignatureData[] memory sigsAttachData = new WorkflowStructs.SignatureData[](
-            testLicenseInfo.length
-        );
-        WorkflowStructs.SignatureData memory sigAddToGroupData;
-
-        {
-            // Get the signature for executing `setAll` function in `CoreMetadataModule` on behalf of the IP owner
-            (bytes memory sigMetadata, bytes32 expectedState) = _getSigForExecuteWithSig({
-                ipId: expectedIpId,
-                to: coreMetadataModuleAddr,
-                deadline: deadline,
-                state: bytes32(0),
-                data: abi.encodeWithSelector(
-                    ICoreMetadataModule.setAll.selector,
-                    expectedIpId,
-                    ipMetadataDefault.ipMetadataURI,
-                    ipMetadataDefault.ipMetadataHash,
-                    ipMetadataDefault.nftMetadataHash
-                ),
-                signerSk: minterSk
-            });
-            sigMetadataData = WorkflowStructs.SignatureData({
-                signer: minter,
-                deadline: deadline,
-                signature: sigMetadata
-            });
-
-            // Get the signature for executing `attachLicenseTerms` function in `LicensingModule` on behalf of the IP owner
-            bytes[] memory sigsAttach = new bytes[](testLicenseInfo.length);
-            for (uint256 i = 0; i < testLicenseInfo.length; i++) {
-                (sigsAttach[i], expectedState) = _getSigForExecuteWithSig({
-                    ipId: expectedIpId,
-                    to: licensingModuleAddr,
-                    deadline: deadline,
-                    state: expectedState,
-                    data: abi.encodeWithSelector(
-                        ILicensingModule.attachLicenseTerms.selector,
-                        expectedIpId,
-                        testLicenseInfo[i].licenseTemplate,
-                        testLicenseInfo[i].licenseTermsId
-                    ),
-                    signerSk: minterSk
-                });
-                sigsAttachData[i] = WorkflowStructs.SignatureData({
-                    signer: minter,
-                    deadline: deadline,
-                    signature: sigsAttach[i]
-                });
-            }
-
-            address[] memory expectedIpIds = new address[](1);
-            expectedIpIds[0] = expectedIpId;
-            // Get the signature for executing `addIp` function in `GroupingModule` on behalf of the Group IP owner
-            (bytes memory sigAddToGroup, ) = _getSigForExecuteWithSig({
-                ipId: groupId,
-                to: address(groupingModule),
-                deadline: deadline,
-                state: IIPAccount(payable(groupId)).state(),
-                data: abi.encodeWithSelector(IGroupingModule.addIp.selector, groupId, expectedIpIds),
-                signerSk: groupOwnerSk
-            });
-            sigAddToGroupData = WorkflowStructs.SignatureData({
-                signer: groupOwner,
-                deadline: deadline,
-                signature: sigAddToGroup
-            });
-        }
-
-        address ipId = groupingWorkflows.registerIpAndAttachLicenseAndAddToGroup({
-            nftContract: address(mockNft),
-            tokenId: tokenId,
-            groupId: groupId,
-            licenseInfo: testLicenseInfo,
-            ipMetadata: ipMetadataDefault,
-            sigMetadata: sigMetadataData,
-            sigsAttach: sigsAttachData,
-            sigAddToGroup: sigAddToGroupData
-        });
-
-        // check the IP id matches the expected IP id
-        assertEq(ipId, expectedIpId);
-
-        // check the IP is registered
-        assertTrue(IIPAssetRegistry(ipAssetRegistry).isRegistered(ipId));
-
-        // check the IP is added to the group
-        assertTrue(IGroupIPAssetRegistry(ipAssetRegistry).containsIp(groupId, ipId));
-
-        // check the IP metadata is correctly set
-        assertMetadata(ipId, ipMetadataDefault);
-
-        // check the license terms is correctly attached
-        for (uint256 i = 0; i < testLicenseInfo.length; i++) {
-            (address licenseTemplate, uint256 licenseTermsId) = ILicenseRegistry(licenseRegistry)
-                .getAttachedLicenseTerms(ipId, i);
-            assertEq(licenseTemplate, testLicenseInfo[i].licenseTemplate);
-            assertEq(licenseTermsId, testLicenseInfo[i].licenseTermsId);
-        }
+        // // mint a NFT from the mock ERC721 contract
+        // vm.startPrank(minter);
+        // uint256 tokenId = MockERC721(mockNft).mint(minter);
+        // vm.stopPrank();
+        // // get the expected IP ID
+        // address expectedIpId = IIPAssetRegistry(ipAssetRegistry).ipId(block.chainid, address(mockNft), tokenId);
+        // uint256 deadline = block.timestamp + 1000;
+        // // Get the signature for setting the permission for calling `setAll` (IP metadata) and `attachLicenseTerms`
+        // // functions in `coreMetadataModule` and `licensingModule` from the IP owner
+        // (bytes memory sigMetadataAndAttach, , ) = _getSetBatchPermissionSigForPeriphery({
+        //     ipId: expectedIpId,
+        //     permissionList: _getMetadataAndAttachTermsPermissionList(expectedIpId, address(groupingWorkflows)),
+        //     deadline: deadline,
+        //     state: bytes32(0),
+        //     signerSk: minterSk
+        // });
+        // // Get the signature for setting the permission for calling `addIp` function in `GroupingModule`
+        // // from the Group IP owner
+        // (bytes memory sigAddToGroup, , ) = _getSetPermissionSigForPeriphery({
+        //     ipId: groupId,
+        //     to: address(groupingWorkflows),
+        //     module: address(groupingModule),
+        //     selector: IGroupingModule.addIp.selector,
+        //     deadline: deadline,
+        //     state: IIPAccount(payable(groupId)).state(),
+        //     signerSk: groupOwnerSk
+        // });
+        // address ipId = groupingWorkflows.registerIpAndAttachLicenseAndAddToGroup({
+        //     nftContract: address(mockNft),
+        //     tokenId: tokenId,
+        //     groupId: groupId,
+        //     licenseTemplate: address(pilTemplate),
+        //     licenseTermsId: testLicenseTermsId,
+        //     ipMetadata: ipMetadataDefault,
+        //     sigMetadataAndAttach: WorkflowStructs.SignatureData({
+        //         signer: minter,
+        //         deadline: deadline,
+        //         signature: sigMetadataAndAttach
+        //     }),
+        //     sigAddToGroup: WorkflowStructs.SignatureData({
+        //         signer: groupOwner,
+        //         deadline: deadline,
+        //         signature: sigAddToGroup
+        //     })
+        // });
+        // // check the IP id matches the expected IP id
+        // assertEq(ipId, expectedIpId);
+        // // check the IP is registered
+        // assertTrue(IIPAssetRegistry(ipAssetRegistry).isRegistered(ipId));
+        // // check the IP is added to the group
+        // assertTrue(IGroupIPAssetRegistry(ipAssetRegistry).containsIp(groupId, ipId));
+        // // check the IP metadata is correctly set
+        // assertMetadata(ipId, ipMetadataDefault);
+        // // check the license terms is correctly attached
+        // (address licenseTemplate, uint256 licenseTermsId) = ILicenseRegistry(licenseRegistry).getAttachedLicenseTerms(
+        //     ipId,
+        //     0
+        // );
+        // assertEq(licenseTemplate, address(pilTemplate));
+        // assertEq(licenseTermsId, testLicenseTermsId);
     }
 
     // Register group IP → Attach license terms to group IPA
@@ -280,7 +231,8 @@ contract GroupingWorkflowsTest is BaseTest {
         vm.startPrank(groupOwner);
         address newGroupId = groupingWorkflows.registerGroupAndAttachLicense({
             groupPool: address(evenSplitGroupPool),
-            licenseInfo: testLicenseInfo[0]
+            licenseTemplate: address(pilTemplate),
+            licenseTermsId: testLicenseTermsId
         });
         vm.stopPrank();
 
@@ -292,8 +244,8 @@ contract GroupingWorkflowsTest is BaseTest {
             newGroupId,
             0
         );
-        assertEq(licenseTemplate, testLicenseInfo[0].licenseTemplate);
-        assertEq(licenseTermsId, testLicenseInfo[0].licenseTermsId);
+        assertEq(licenseTemplate, address(pilTemplate));
+        assertEq(licenseTermsId, testLicenseTermsId);
     }
 
     // Register group IP → Attach license terms to group IPA → Add existing IPs to the new group IPA
@@ -302,7 +254,8 @@ contract GroupingWorkflowsTest is BaseTest {
         address newGroupId = groupingWorkflows.registerGroupAndAttachLicenseAndAddIps({
             groupPool: address(evenSplitGroupPool),
             ipIds: ipIds,
-            licenseInfo: testLicenseInfo[0]
+            licenseTemplate: address(pilTemplate),
+            licenseTermsId: testLicenseTermsId
         });
         vm.stopPrank();
 
@@ -320,8 +273,8 @@ contract GroupingWorkflowsTest is BaseTest {
             newGroupId,
             0
         );
-        assertEq(licenseTemplate, testLicenseInfo[0].licenseTemplate);
-        assertEq(licenseTermsId, testLicenseInfo[0].licenseTermsId);
+        assertEq(licenseTemplate, address(pilTemplate));
+        assertEq(licenseTermsId, testLicenseTermsId);
     }
 
     // Collect royalties for the entire group and distribute to each member IP's royalty vault
@@ -333,7 +286,8 @@ contract GroupingWorkflowsTest is BaseTest {
         address newGroupId = groupingWorkflows.registerGroupAndAttachLicenseAndAddIps({
             groupPool: address(evenSplitGroupPool),
             ipIds: ipIds,
-            licenseInfo: testLicenseInfo[0]
+            licenseTemplate: address(pilTemplate),
+            licenseTermsId: testLicenseTermsId
         });
         vm.stopPrank();
 
@@ -343,7 +297,7 @@ contract GroupingWorkflowsTest is BaseTest {
         address[] memory parentIpIds = new address[](1);
         parentIpIds[0] = newGroupId;
         uint256[] memory licenseTermsIds = new uint256[](1);
-        licenseTermsIds[0] = testLicenseInfo[0].licenseTermsId;
+        licenseTermsIds[0] = testLicenseTermsId;
 
         vm.startPrank(ipOwner1);
         // approve nft minting fee
@@ -355,9 +309,10 @@ contract GroupingWorkflowsTest is BaseTest {
             derivData: WorkflowStructs.MakeDerivative({
                 parentIpIds: parentIpIds,
                 licenseTermsIds: licenseTermsIds,
-                licenseTemplate: testLicenseInfo[0].licenseTemplate,
+                licenseTemplate: address(pilTemplate),
                 royaltyContext: "",
-                maxMintingFee: 0
+                maxMintingFee: 0,
+                maxRts: revShare
             }),
             ipMetadata: ipMetadataDefault,
             recipient: ipOwner1,
@@ -375,9 +330,10 @@ contract GroupingWorkflowsTest is BaseTest {
             derivData: WorkflowStructs.MakeDerivative({
                 parentIpIds: parentIpIds,
                 licenseTermsIds: licenseTermsIds,
-                licenseTemplate: testLicenseInfo[0].licenseTemplate,
+                licenseTemplate: address(pilTemplate),
                 royaltyContext: "",
-                maxMintingFee: 0
+                maxMintingFee: 0,
+                maxRts: revShare
             }),
             ipMetadata: ipMetadataDefault,
             recipient: ipOwner2,
@@ -448,240 +404,138 @@ contract GroupingWorkflowsTest is BaseTest {
     }
 
     // Multicall (mint → Register IP → Attach PIL terms → Add new IP to group IPA)
+    // TODO: enable set licensing config during license attachment to make this test work
     function test_GroupingWorkflows_multicall_mintAndRegisterIpAndAttachLicenseAndAddToGroup() public {
-        uint256 deadline = block.timestamp + 1000;
-
-        // Get the signatures for setting the permission for calling `addIp` function in `GroupingModule`
-        // from the Group IP owner
-        bytes[] memory sigsAddToGroup = new bytes[](10);
-        bytes32 expectedStates = IIPAccount(payable(groupId)).state();
-        for (uint256 i = 0; i < 10; i++) {
-            (sigsAddToGroup[i], expectedStates) = _getSigForExecuteWithSig({
-                ipId: groupId,
-                to: address(accessController),
-                deadline: deadline,
-                state: expectedStates,
-                data: abi.encodeWithSelector(
-                    IAccessController.setPermission.selector,
-                    groupId,
-                    address(groupingWorkflows),
-                    address(groupingModule),
-                    IGroupingModule.addIp.selector,
-                    AccessPermission.ALLOW
-                ),
-                signerSk: groupOwnerSk
-            });
-        }
-
-        // setup call data for batch calling 10 `mintAndRegisterIpAndAttachLicenseAndAddToGroup`
-        bytes[] memory data = new bytes[](10);
-        for (uint256 i = 0; i < 10; i++) {
-            data[i] = abi.encodeWithSelector(
-                groupingWorkflows.mintAndRegisterIpAndAttachLicenseAndAddToGroup.selector,
-                address(spgNftPublic),
-                groupId,
-                minter,
-                testLicenseInfo,
-                ipMetadataDefault,
-                WorkflowStructs.SignatureData({ signer: groupOwner, deadline: deadline, signature: sigsAddToGroup[i] }),
-                true
-            );
-        }
-
-        // batch call `mintAndRegisterIpAndAttachLicenseAndAddToGroup`
-        vm.startPrank(minter);
-        bytes[] memory results = groupingWorkflows.multicall(data);
-        vm.stopPrank();
-
-        // check each IP is registered, added to the group, and metadata is set, license terms are attached
-        address ipId;
-        uint256 tokenId;
-        for (uint256 i = 0; i < 10; i++) {
-            (ipId, tokenId) = abi.decode(results[i], (address, uint256));
-            assertTrue(IIPAssetRegistry(ipAssetRegistry).isRegistered(ipId));
-            assertTrue(IGroupIPAssetRegistry(ipAssetRegistry).containsIp(groupId, ipId));
-            assertEq(spgNftPublic.tokenURI(tokenId), string.concat(testBaseURI, ipMetadataDefault.nftMetadataURI));
-            assertMetadata(ipId, ipMetadataDefault);
-            for (uint256 j = 0; j < testLicenseInfo.length; j++) {
-                (address licenseTemplate, uint256 licenseTermsId) = ILicenseRegistry(licenseRegistry)
-                    .getAttachedLicenseTerms(ipId, j);
-                assertEq(licenseTemplate, testLicenseInfo[j].licenseTemplate);
-                assertEq(licenseTermsId, testLicenseInfo[j].licenseTermsId);
-            }
-        }
+        // uint256 deadline = block.timestamp + 1000;
+        // // Get the signatures for setting the permission for calling `addIp` function in `GroupingModule`
+        // // from the Group IP owner
+        // bytes[] memory sigsAddToGroup = new bytes[](10);
+        // bytes32 expectedStates = IIPAccount(payable(groupId)).state();
+        // for (uint256 i = 0; i < 10; i++) {
+        //     (sigsAddToGroup[i], expectedStates, ) = _getSetPermissionSigForPeriphery({
+        //         ipId: groupId,
+        //         to: address(groupingWorkflows),
+        //         module: address(groupingModule),
+        //         selector: IGroupingModule.addIp.selector,
+        //         deadline: deadline,
+        //         state: expectedStates,
+        //         signerSk: groupOwnerSk
+        //     });
+        // }
+        // // setup call data for batch calling 10 `mintAndRegisterIpAndAttachLicenseAndAddToGroup`
+        // bytes[] memory data = new bytes[](10);
+        // for (uint256 i = 0; i < 10; i++) {
+        //     data[i] = abi.encodeWithSelector(
+        //         groupingWorkflows.mintAndRegisterIpAndAttachLicenseAndAddToGroup.selector,
+        //         address(spgNftPublic),
+        //         groupId,
+        //         minter,
+        //         pilTemplate,
+        //         testLicenseTermsId,
+        //         ipMetadataDefault,
+        //         WorkflowStructs.SignatureData({ signer: groupOwner, deadline: deadline, signature: sigsAddToGroup[i] }),
+        //         true
+        //     );
+        // }
+        // // batch call `mintAndRegisterIpAndAttachLicenseAndAddToGroup`
+        // vm.startPrank(minter);
+        // bytes[] memory results = groupingWorkflows.multicall(data);
+        // vm.stopPrank();
+        // // check each IP is registered, added to the group, and metadata is set, license terms are attached
+        // address ipId;
+        // uint256 tokenId;
+        // for (uint256 i = 0; i < 10; i++) {
+        //     (ipId, tokenId) = abi.decode(results[i], (address, uint256));
+        //     assertTrue(IIPAssetRegistry(ipAssetRegistry).isRegistered(ipId));
+        //     assertTrue(IGroupIPAssetRegistry(ipAssetRegistry).containsIp(groupId, ipId));
+        //     assertEq(spgNftPublic.tokenURI(tokenId), string.concat(testBaseURI, ipMetadataDefault.nftMetadataURI));
+        //     assertMetadata(ipId, ipMetadataDefault);
+        //     (address licenseTemplate, uint256 licenseTermsId) = ILicenseRegistry(licenseRegistry)
+        //         .getAttachedLicenseTerms(ipId, 0);
+        //     assertEq(licenseTemplate, address(pilTemplate));
+        //     assertEq(licenseTermsId, testLicenseTermsId);
+        // }
     }
 
     // Multicall (Register IP → Attach PIL terms → Add new IP to group IPA)
+    // TODO: enable set licensing config during license attachment to make this test work
     function test_GroupingWorkflows_multicall_registerIpAndAttachLicenseAndAddToGroup() public {
-        // mint a NFT from the mock ERC721 contract
-        uint256[] memory tokenIds = new uint256[](10);
-        vm.startPrank(minter);
-        for (uint256 i = 0; i < 10; i++) {
-            tokenIds[i] = MockERC721(mockNft).mint(minter);
-        }
-        vm.stopPrank();
-
-        // get the expected IP ID
-        address[] memory expectedIpIds = new address[](10);
-        for (uint256 i = 0; i < 10; i++) {
-            expectedIpIds[i] = IIPAssetRegistry(ipAssetRegistry).ipId(block.chainid, address(mockNft), tokenIds[i]);
-        }
-
-        WorkflowStructs.SignatureData[] memory sigMetadataData = new WorkflowStructs.SignatureData[](10);
-        WorkflowStructs.SignatureData[] memory sigAddToGroupData = new WorkflowStructs.SignatureData[](10);
-        WorkflowStructs.SignatureData[][] memory sigAttachData = new WorkflowStructs.SignatureData[][](10);
-        for (uint256 i = 0; i < 10; i++) {
-            sigAttachData[i] = new WorkflowStructs.SignatureData[](testLicenseInfo.length);
-        }
-
-        {
-            uint256 deadline = block.timestamp + 1000;
-            // Get the signatures for setting the permission for calling `setAll` (IP metadata) and `attachLicenseTerms`
-            // functions in `coreMetadataModule` and `licensingModule` from the IP owner
-            bytes memory sigsMetadata;
-            bytes[] memory sigsAttach = new bytes[](testLicenseInfo.length);
-            for (uint256 i = 0; i < 10; i++) {
-                bytes32 expectedState = bytes32(0);
-                (sigsMetadata, expectedState) = _getSigForExecuteWithSig({
-                    ipId: expectedIpIds[i],
-                    to: address(coreMetadataModule),
-                    deadline: deadline,
-                    state: expectedState,
-                    data: abi.encodeWithSelector(
-                        ICoreMetadataModule.setAll.selector,
-                        expectedIpIds[i],
-                        ipMetadataDefault.ipMetadataURI,
-                        ipMetadataDefault.ipMetadataHash,
-                        ipMetadataDefault.nftMetadataHash
-                    ),
-                    signerSk: minterSk
-                });
-                sigMetadataData[i] = WorkflowStructs.SignatureData({
-                    signer: minter,
-                    deadline: deadline,
-                    signature: sigsMetadata
-                });
-
-                for (uint256 j = 0; j < testLicenseInfo.length; j++) {
-                    (sigsAttach[j], expectedState) = _getSigForExecuteWithSig({
-                        ipId: expectedIpIds[i],
-                        to: address(licensingModule),
-                        deadline: deadline,
-                        state: expectedState,
-                        data: abi.encodeWithSelector(
-                            ILicensingModule.attachLicenseTerms.selector,
-                            expectedIpIds[i],
-                            testLicenseInfo[j].licenseTemplate,
-                            testLicenseInfo[j].licenseTermsId
-                        ),
-                        signerSk: minterSk
-                    });
-
-                    sigAttachData[i][j] = WorkflowStructs.SignatureData({
-                        signer: minter,
-                        deadline: deadline,
-                        signature: sigsAttach[j]
-                    });
-                }
-            }
-
-            // Get the signatures for setting the permission for calling `addIp` function in `GroupingModule`
-            // from the Group IP owner
-            bytes memory sigsAddToGroup;
-            bytes memory data;
-            bytes32 expectedState = IIPAccount(payable(groupId)).state();
-            address[] memory ipIdArr = new address[](1);
-            for (uint256 i = 0; i < 10; i++) {
-                ipIdArr[0] = expectedIpIds[i];
-                data = abi.encodeWithSelector(IGroupingModule.addIp.selector, groupId, ipIdArr);
-                (sigsAddToGroup, expectedState) = _getSigForExecuteWithSig({
-                    ipId: groupId,
-                    to: address(groupingModule),
-                    deadline: deadline,
-                    state: expectedState,
-                    data: data,
-                    signerSk: groupOwnerSk
-                });
-
-                sigAddToGroupData[i] = WorkflowStructs.SignatureData({
-                    signer: groupOwner,
-                    deadline: deadline,
-                    signature: sigsAddToGroup
-                });
-            }
-        }
-
-        // setup call data for batch calling 10 `registerIpAndAttachLicenseAndAddToGroup`
-        bytes[] memory data = new bytes[](10);
-        for (uint256 i = 0; i < 10; i++) {
-            data[i] = abi.encodeWithSelector(
-                groupingWorkflows.registerIpAndAttachLicenseAndAddToGroup.selector,
-                mockNft,
-                tokenIds[i],
-                groupId,
-                testLicenseInfo,
-                ipMetadataDefault,
-                sigMetadataData[i],
-                sigAttachData[i],
-                sigAddToGroupData[i]
-            );
-        }
-
-        // batch call `registerIpAndAttachLicenseAndAddToGroup`
-        vm.startPrank(minter);
-        bytes[] memory results = groupingWorkflows.multicall(data);
-        vm.stopPrank();
-
-        // check each IP is registered, added to the group, and metadata is set, license terms are attached
-        address ipId;
-        for (uint256 i = 0; i < 10; i++) {
-            ipId = abi.decode(results[i], (address));
-            assertEq(ipId, expectedIpIds[i]);
-            assertTrue(IIPAssetRegistry(ipAssetRegistry).isRegistered(ipId));
-            assertTrue(IGroupIPAssetRegistry(ipAssetRegistry).containsIp(groupId, ipId));
-            assertMetadata(ipId, ipMetadataDefault);
-            for (uint256 j = 0; j < testLicenseInfo.length; j++) {
-                (address licenseTemplate, uint256 licenseTermsId) = ILicenseRegistry(licenseRegistry)
-                    .getAttachedLicenseTerms(ipId, j);
-                assertEq(licenseTemplate, testLicenseInfo[j].licenseTemplate);
-                assertEq(licenseTermsId, testLicenseInfo[j].licenseTermsId);
-            }
-        }
-    }
-
-    // setup license terms for testing
-    function _setupLicenseTerms() internal {
-        revShare = 10 * 10 ** 6; // 10%
-
-        testLicenseInfo.push(
-            WorkflowStructs.LicenseInfo({
-                licenseTemplate: pilTemplateAddr,
-                licenseTermsId: pilTemplate.registerLicenseTerms(
-                    // minting fee is set to 0 beacause currently core protocol requires group IP's minting fee to be 0
-                    PILFlavors.commercialRemix({
-                        mintingFee: 0,
-                        commercialRevShare: revShare,
-                        royaltyPolicy: address(royaltyPolicyLAP),
-                        currencyToken: address(mockToken)
-                    })
-                )
-            })
-        );
-
-        testLicenseInfo.push(
-            WorkflowStructs.LicenseInfo({
-                licenseTemplate: pilTemplateAddr,
-                licenseTermsId: pilTemplate.registerLicenseTerms(
-                    // Another license that will not be associated with the group IP
-                    PILFlavors.commercialRemix({
-                        mintingFee: 10 * 10 ** mockToken.decimals(), // 10 tokens
-                        commercialRevShare: revShare,
-                        royaltyPolicy: address(royaltyPolicyLAP),
-                        currencyToken: address(mockToken)
-                    })
-                )
-            })
-        );
+        // // mint a NFT from the mock ERC721 contract
+        // uint256[] memory tokenIds = new uint256[](10);
+        // vm.startPrank(minter);
+        // for (uint256 i = 0; i < 10; i++) {
+        //     tokenIds[i] = MockERC721(mockNft).mint(minter);
+        // }
+        // vm.stopPrank();
+        // // get the expected IP ID
+        // address[] memory expectedIpIds = new address[](10);
+        // for (uint256 i = 0; i < 10; i++) {
+        //     expectedIpIds[i] = IIPAssetRegistry(ipAssetRegistry).ipId(block.chainid, address(mockNft), tokenIds[i]);
+        // }
+        // uint256 deadline = block.timestamp + 10000;
+        // // Get the signatures for setting the permission for calling `setAll` (IP metadata) and `attachLicenseTerms`
+        // // functions in `coreMetadataModule` and `licensingModule` from the IP owner
+        // bytes[] memory sigsMetadataAndAttach = new bytes[](10);
+        // for (uint256 i = 0; i < 10; i++) {
+        //     (sigsMetadataAndAttach[i], , ) = _getSetBatchPermissionSigForPeriphery({
+        //         ipId: expectedIpIds[i],
+        //         permissionList: _getMetadataAndAttachTermsPermissionList(expectedIpIds[i], address(groupingWorkflows)),
+        //         deadline: deadline,
+        //         state: bytes32(0),
+        //         signerSk: minterSk
+        //     });
+        // }
+        // // Get the signatures for setting the permission for calling `addIp` function in `GroupingModule`
+        // // from the Group IP owner
+        // bytes[] memory sigsAddToGroup = new bytes[](10);
+        // bytes32 expectedStates = IIPAccount(payable(groupId)).state();
+        // for (uint256 i = 0; i < 10; i++) {
+        //     (sigsAddToGroup[i], expectedStates, ) = _getSetPermissionSigForPeriphery({
+        //         ipId: groupId,
+        //         to: address(groupingWorkflows),
+        //         module: address(groupingModule),
+        //         selector: IGroupingModule.addIp.selector,
+        //         deadline: deadline,
+        //         state: expectedStates,
+        //         signerSk: groupOwnerSk
+        //     });
+        // }
+        // // setup call data for batch calling 10 `registerIpAndAttachLicenseAndAddToGroup`
+        // bytes[] memory data = new bytes[](10);
+        // for (uint256 i = 0; i < 10; i++) {
+        //     data[i] = abi.encodeWithSelector(
+        //         groupingWorkflows.registerIpAndAttachLicenseAndAddToGroup.selector,
+        //         mockNft,
+        //         tokenIds[i],
+        //         groupId,
+        //         pilTemplate,
+        //         testLicenseTermsId,
+        //         ipMetadataDefault,
+        //         WorkflowStructs.SignatureData({
+        //             signer: minter,
+        //             deadline: deadline,
+        //             signature: sigsMetadataAndAttach[i]
+        //         }),
+        //         WorkflowStructs.SignatureData({ signer: groupOwner, deadline: deadline, signature: sigsAddToGroup[i] })
+        //     );
+        // }
+        // // batch call `registerIpAndAttachLicenseAndAddToGroup`
+        // vm.startPrank(minter);
+        // bytes[] memory results = groupingWorkflows.multicall(data);
+        // vm.stopPrank();
+        // // check each IP is registered, added to the group, and metadata is set, license terms are attached
+        // address ipId;
+        // for (uint256 i = 0; i < 10; i++) {
+        //     ipId = abi.decode(results[i], (address));
+        //     assertEq(ipId, expectedIpIds[i]);
+        //     assertTrue(IIPAssetRegistry(ipAssetRegistry).isRegistered(ipId));
+        //     assertTrue(IGroupIPAssetRegistry(ipAssetRegistry).containsIp(groupId, ipId));
+        //     assertMetadata(ipId, ipMetadataDefault);
+        //     (address licenseTemplate, uint256 licenseTermsId) = ILicenseRegistry(licenseRegistry)
+        //         .getAttachedLicenseTerms(ipId, 0);
+        //     assertEq(licenseTemplate, address(pilTemplate));
+        //     assertEq(licenseTermsId, testLicenseTermsId);
+        // }
     }
 
     // setup a group IPA for testing
@@ -693,8 +547,9 @@ contract GroupingWorkflowsTest is BaseTest {
         LicensingHelper.attachLicenseTerms(
             groupId,
             address(licensingModule),
-            testLicenseInfo[0].licenseTemplate,
-            testLicenseInfo[0].licenseTermsId
+            address(licenseRegistry),
+            address(pilTemplate),
+            testLicenseTermsId
         );
         vm.stopPrank();
     }
@@ -733,14 +588,14 @@ contract GroupingWorkflowsTest is BaseTest {
         // attach license terms to the IPs
         vm.startPrank(minter);
         for (uint256 i = 0; i < 10; i++) {
-            for (uint256 j = 0; j < testLicenseInfo.length; j++) {
-                LicensingHelper.attachLicenseTerms(
-                    ipIds[i],
-                    address(licensingModule),
-                    testLicenseInfo[j].licenseTemplate,
-                    testLicenseInfo[j].licenseTermsId
-                );
-            }
+            LicensingHelper.attachLicenseTerms(
+                ipIds[i],
+                address(licensingModule),
+                address(licenseRegistry),
+                address(pilTemplate),
+                testLicenseTermsId
+            );
+            licensingModule.setLicensingConfig(ipIds[i], address(pilTemplate), testLicenseTermsId, testLicensingConfig);
         }
         vm.stopPrank();
     }

--- a/test/workflows/RegistrationWorkflows.t.sol
+++ b/test/workflows/RegistrationWorkflows.t.sol
@@ -1,5 +1,6 @@
 //SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
+/* solhint-disable no-console */
 
 // external
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
@@ -173,18 +174,13 @@ contract RegistrationWorkflowsTest is BaseTest {
 
         uint256 deadline = block.timestamp + 1000;
 
-        (bytes memory sigMetadata, bytes32 expectedState) = _getSigForExecuteWithSig({
+        (bytes memory sigMetadata, bytes32 expectedState, ) = _getSetPermissionSigForPeriphery({
             ipId: expectedIpId,
-            to: address(coreMetadataModule),
+            to: address(registrationWorkflows),
+            module: address(coreMetadataModule),
+            selector: ICoreMetadataModule.setAll.selector,
             deadline: deadline,
             state: bytes32(0),
-            data: abi.encodeWithSelector(
-                ICoreMetadataModule.setAll.selector,
-                expectedIpId,
-                ipMetadataDefault.ipMetadataURI,
-                ipMetadataDefault.ipMetadataHash,
-                ipMetadataDefault.nftMetadataHash
-            ),
             signerSk: sk.alice
         });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -313,9 +313,9 @@
   integrity sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==
 
 "@noble/hashes@^1.4.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.5.0.tgz#abadc5ca20332db2b1b2aa3e496e9af1213570b0"
-  integrity sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.6.1.tgz#df6e5943edcea504bac61395926d6fd67869a0d5"
+  integrity sha512-pq5D8h10hHBjyqX+cfBm0i8JUXJ0UhczFc4r74zbuT9XgewFo2E3J1cOaGtdZynILNmQ685YWGzGE1Zv6io50w==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -421,13 +421,18 @@
   resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.18.0.tgz#8e77a02a09ecce957255a2f48c9a7178ec191908"
   integrity sha512-yfORGUIPgLck41qyN7nbwJRAx17/jAIXCTanHOJZhB6PJ1iAk/84b/xlsVKFSyNyLXIj0dhppoE0+CRws7wlzA==
 
+"@solidity-parser/parser@^0.19.0":
+  version "0.19.0"
+  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.19.0.tgz#37a8983b2725af9b14ff8c4a475fa0e98d773c3f"
+  integrity sha512-RV16k/qIxW/wWc+mLzV3ARyKUaMUTBy9tOLMzFhtNSKYeTAanQ3a5MudJKf/8arIFnA2L27SNjarQKmFg0w/jA==
+
 "@story-protocol/create3-deployer@github:storyprotocol/create3-deployer#main":
   version "0.0.0"
   resolved "https://codeload.github.com/storyprotocol/create3-deployer/tar.gz/094147bda866490dd1c3e8261bb3dfee65e7af54"
 
 "@story-protocol/protocol-core@github:storyprotocol/protocol-core-v1#main":
   version "1.1.0"
-  resolved "https://codeload.github.com/storyprotocol/protocol-core-v1/tar.gz/c1b0f11f7ad41a3525b13ca09423e87be5ee2d93"
+  resolved "https://codeload.github.com/storyprotocol/protocol-core-v1/tar.gz/ed12aec4bfea9127234873dcf06f9f914db068ab"
   dependencies:
     "@openzeppelin/contracts" "5.0.2"
     "@openzeppelin/contracts-upgradeable" "5.0.2"
@@ -480,11 +485,11 @@
   integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
 "@types/node@*":
-  version "22.9.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.9.0.tgz#b7f16e5c3384788542c72dc3d561a7ceae2c0365"
-  integrity sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==
+  version "22.10.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.10.1.tgz#41ffeee127b8975a05f8c4f83fb89bcb2987d766"
+  integrity sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==
   dependencies:
-    undici-types "~6.19.8"
+    undici-types "~6.20.0"
 
 "@types/node@22.7.5":
   version "22.7.5"
@@ -869,9 +874,9 @@ create-require@^1.1.0:
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
 cross-spawn@^7.0.2:
-  version "7.0.5"
-  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.5.tgz#910aac880ff5243da96b728bc6521a5f6c2f2f82"
-  integrity sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==
+  version "7.0.6"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
+  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
   dependencies:
     path-key "^3.1.0"
     shebang-command "^2.0.0"
@@ -1252,9 +1257,9 @@ flat@^5.0.2:
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
 
 flatted@^3.2.9:
-  version "3.3.1"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.1.tgz#21db470729a6734d4997002f439cb308987f567a"
-  integrity sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.2.tgz#adba1448a9841bec72b42c532ea23dbbedef1a27"
+  integrity sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==
 
 form-data-encoder@^2.1.2:
   version "2.1.4"
@@ -1516,9 +1521,9 @@ http2-wrapper@^2.1.10:
     resolve-alpn "^1.2.0"
 
 husky@^9.0.11:
-  version "9.1.6"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-9.1.6.tgz#e23aa996b6203ab33534bdc82306b0cf2cb07d6c"
-  integrity sha512-sqbjZKK7kf44hfdE94EoX8MZNk0n7HeW37O4YrVGCF4wzgQjp+akPAkfUK5LZ6KuR/6sqeAVuXHji+RzQgOn5A==
+  version "9.1.7"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-9.1.7.tgz#d46a38035d101b46a70456a850ff4201344c0b2d"
+  integrity sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==
 
 ignore@^5.1.1, ignore@^5.2.0, ignore@^5.2.4:
   version "5.3.2"
@@ -2079,9 +2084,9 @@ prettier@^2.3.1, prettier@^2.8.3:
   integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
 prettier@^3.0.0:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.3.tgz#30c54fe0be0d8d12e6ae61dbb10109ea00d53105"
-  integrity sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.4.1.tgz#e211d451d6452db0a291672ca9154bc8c2579f7b"
+  integrity sha512-G+YdqtITVZmOJje6QkXQWzl3fSfMxFwm1tjTyo9exhkmWSqC4Yhd1+lug++IlR2mvRVAxEDDWYkQdeSztajqgg==
 
 proto-list@~1.2.1:
   version "1.2.4"
@@ -2147,9 +2152,9 @@ reduce-flatten@^2.0.0:
   integrity sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==
 
 registry-auth-token@^5.0.1:
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-5.0.2.tgz#8b026cc507c8552ebbe06724136267e63302f756"
-  integrity sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/registry-auth-token/-/registry-auth-token-5.0.3.tgz#417d758c8164569de8cf5cabff16cc937902dcc6"
+  integrity sha512-1bpc9IyC+e+CNFRaWyn77tk4xGG4PPUyfakSmA6F6cvUDjrm58dfyJ3II+9yb10EDkHoy1LaPSmHaWLOH3m6HA==
   dependencies:
     "@pnpm/npm-conf" "^2.1.0"
 
@@ -2332,12 +2337,12 @@ solhint@^4.1.1:
     prettier "^2.8.3"
 
 solidity-coverage@^0.8.6:
-  version "0.8.13"
-  resolved "https://registry.yarnpkg.com/solidity-coverage/-/solidity-coverage-0.8.13.tgz#8eeada2e82ae19d25568368aa782a2baad0e0ce7"
-  integrity sha512-RiBoI+kF94V3Rv0+iwOj3HQVSqNzA9qm/qDP1ZDXK5IX0Cvho1qiz8hAXTsAo6KOIUeP73jfscq0KlLqVxzGWA==
+  version "0.8.14"
+  resolved "https://registry.yarnpkg.com/solidity-coverage/-/solidity-coverage-0.8.14.tgz#db9bfcc10e3bc369fc074b35b267d665bcc6ae2e"
+  integrity sha512-ItAAObe5GaEOp20kXC2BZRnph+9P7Rtoqg2mQc2SXGEHgSDF2wWd1Wxz3ntzQWXkbCtIIGdJT918HG00cObwbA==
   dependencies:
     "@ethersproject/abi" "^5.0.9"
-    "@solidity-parser/parser" "^0.18.0"
+    "@solidity-parser/parser" "^0.19.0"
     chalk "^2.4.2"
     death "^1.1.0"
     difflib "^0.2.4"
@@ -2579,10 +2584,15 @@ uglify-js@^3.1.4:
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.19.3.tgz#82315e9bbc6f2b25888858acd1fff8441035b77f"
   integrity sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==
 
-undici-types@~6.19.2, undici-types@~6.19.8:
+undici-types@~6.19.2:
   version "6.19.8"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
   integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
+
+undici-types@~6.20.0:
+  version "6.20.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.20.0.tgz#8171bf22c1f588d1554d55bf204bc624af388433"
+  integrity sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==
 
 universalify@^0.1.0:
   version "0.1.2"


### PR DESCRIPTION
## Description

This PR reverts the changes introduced in #121, restoring the use of the permission-setting approach that allows periphery contracts to call protocol core functions on behalf of IP owners. Additionally, it reverts the changes from #128 and #123, which will be reimplemented in the next PR.

### Reasons for Reverting the Changes

- **Scalability Concerns with `executeWithSig`**  
  After offline discussions, we determined that while `executeWithSig` offers better security guarantees, it does not scale well with the addition of new core protocol functionalities. Specifically, each protocol interaction requires a user signature, which rapidly increases the stack size of periphery functions and renders them unusable.  
  Conversely, the previous permission-setting method does not introduce security risks when proper guardrails are in place. This approach can be further optimized by using `setBatchPermission`, which reduces the required signatures to a single batch. This simplification greatly improves developer experience and scalability for periphery functions.

- **Reimplementation of Changes from # 128 and # 123**  
  Changes introduced in #128 and #123 were designed around the `executeWithSig` model, leading to functionality compromises. For instance, the ability to register PIL terms and immediately attach them to IPs was removed because `executeWithSig` required predicting the new license term ID to generate appropriate signatures.  
  By reverting #121, these limitations no longer apply, enabling us to reintroduce these functionalities without compromises in the next PR.

### Additional Changes
- Updated the package to the latest `protocol-core` main branch to address compilation issues caused by import changes from [protocol-core PR #291](https://github.com/storyprotocol/protocol-core-v1/pull/291):  
  ```diff
  - import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable-v4/security/ReentrancyGuardUpgradeable.sol";
  + import { ERC20Upgradeable } from "@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol";
 - Adjusted existing functions to align with the updated core protocol API.
  
 ## Related Issues
- Reopens #124
- Further work required to address #129
- Introduces interface changes; a future PR (#131) will ensure backward compatibility with v1.2.4