### PR TITLE
feat(licensing): enable multi-license attachment and licensing config during IP registration

### DIFF
--- a/contracts/interfaces/workflows/IGroupingWorkflows.sol
+++ b/contracts/interfaces/workflows/IGroupingWorkflows.sol
@@ -12,8 +12,7 @@ interface IGroupingWorkflows {
     /// @param spgNftContract The address of the SPGNFT collection.
     /// @param groupId The ID of the group IP to add the newly registered IP.
     /// @param recipient The address of the recipient of the minted NFT.
-    /// @param licenseTemplate The address of the license template to be attached to the new IP.
-    /// @param licenseTermsId The ID of the registered license terms that will be attached to the new IP.
+    /// @param licensesData The data of the licenses and their configurations to be attached to the new IP.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
     /// @param sigAddToGroup Signature data for addIp to the group IP via the Grouping Module.
     /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
@@ -23,8 +22,7 @@ interface IGroupingWorkflows {
         address spgNftContract,
         address groupId,
         address recipient,
-        address licenseTemplate,
-        uint256 licenseTermsId,
+        WorkflowStructs.LicenseData[] calldata licensesData,
         WorkflowStructs.IPMetadata calldata ipMetadata,
         WorkflowStructs.SignatureData calldata sigAddToGroup,
         bool allowDuplicates
@@ -35,33 +33,29 @@ interface IGroupingWorkflows {
     /// @param nftContract The address of the NFT collection.
     /// @param tokenId The ID of the NFT.
     /// @param groupId The ID of the group IP to add the newly registered IP.
-    /// @param licenseTemplate The address of the license template to be attached to the new IP.
-    /// @param licenseTermsId The ID of the registered license terms that will be attached to the new IP.
+    /// @param licensesData The data of the licenses and their configurations to be attached to the new IP.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
-    /// @param sigMetadataAndAttach Signature data for setAll (metadata) and attachLicenseTerms to the IP
-    /// via the Core Metadata Module and Licensing Module.
+    /// @param sigMetadataAndAttachAndConfig Signature data for setAll (metadata), attachLicenseTerms, and
+    /// setLicensingConfig to the IP via the Core Metadata Module and Licensing Module.
     /// @param sigAddToGroup Signature data for addIp to the group IP via the Grouping Module.
     /// @return ipId The ID of the newly registered IP.
     function registerIpAndAttachLicenseAndAddToGroup(
         address nftContract,
         uint256 tokenId,
         address groupId,
-        address licenseTemplate,
-        uint256 licenseTermsId,
+        WorkflowStructs.LicenseData[] calldata licensesData,
         WorkflowStructs.IPMetadata calldata ipMetadata,
-        WorkflowStructs.SignatureData calldata sigMetadataAndAttach,
+        WorkflowStructs.SignatureData calldata sigMetadataAndAttachAndConfig,
         WorkflowStructs.SignatureData calldata sigAddToGroup
     ) external returns (address ipId);
 
     /// @notice Register a group IP with a group reward pool and attach license terms to the group IP
     /// @param groupPool The address of the group reward pool.
-    /// @param licenseTemplate The address of the license template to be attached to the new group IP.
-    /// @param licenseTermsId The ID of the registered license terms that will be attached to the new group IP.
+    /// @param licenseData The data of the license and its configuration to be attached to the new group IP.
     /// @return groupId The ID of the newly registered group IP.
     function registerGroupAndAttachLicense(
         address groupPool,
-        address licenseTemplate,
-        uint256 licenseTermsId
+        WorkflowStructs.LicenseData calldata licenseData
     ) external returns (address groupId);
 
     /// @notice Register a group IP with a group reward pool, attach license terms to the group IP,
@@ -69,14 +63,12 @@ interface IGroupingWorkflows {
     /// @dev ipIds must be have the same license terms as the group IP.
     /// @param groupPool The address of the group reward pool.
     /// @param ipIds The IDs of the IPs to add to the newly registered group IP.
-    /// @param licenseTemplate The address of the license template to be attached to the new group IP.
-    /// @param licenseTermsId The ID of the registered license terms that will be attached to the new group IP.
+    /// @param licenseData The data of the license and its configuration to be attached to the new group IP.
     /// @return groupId The ID of the newly registered group IP.
     function registerGroupAndAttachLicenseAndAddIps(
         address groupPool,
         address[] calldata ipIds,
-        address licenseTemplate,
-        uint256 licenseTermsId
+        WorkflowStructs.LicenseData calldata licenseData
     ) external returns (address groupId);
 
     /// @notice Collect royalties for the entire group and distribute the rewards to each member IP's royalty vault

--- a/contracts/interfaces/workflows/ILicenseAttachmentWorkflows.sol
+++ b/contracts/interfaces/workflows/ILicenseAttachmentWorkflows.sol
@@ -7,12 +7,12 @@ import { WorkflowStructs } from "../../lib/WorkflowStructs.sol";
 interface ILicenseAttachmentWorkflows {
     /// @notice Register Programmable IP License Terms (if unregistered) and attach it to IP.
     /// @param ipId The ID of the IP.
-    /// @param pilTermsData The PIL terms and licensing configuration data to be attached to the IP.
+    /// @param licenseTermsData The PIL terms and licensing configuration data to be attached to the IP.
     /// @param sigAttachAndConfig Signature data for attachLicenseTerms and setLicensingConfig to the IP via the Licensing Module.
     /// @return licenseTermsIds The IDs of the newly registered PIL terms.
     function registerPILTermsAndAttach(
         address ipId,
-        WorkflowStructs.PILTermsData[] calldata pilTermsData,
+        WorkflowStructs.LicenseTermsData[] calldata licenseTermsData,
         WorkflowStructs.SignatureData calldata sigAttachAndConfig
     ) external returns (uint256[] memory licenseTermsIds);
 
@@ -23,7 +23,7 @@ interface ILicenseAttachmentWorkflows {
     /// @param spgNftContract The address of the SPGNFT collection.
     /// @param recipient The address of the recipient of the minted NFT.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
-    /// @param pilTermsData The PIL terms and licensing configuration data to be attached to the IP.
+    /// @param licenseTermsData The PIL terms and licensing configuration data to be attached to the IP.
     /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
     /// @return ipId The ID of the newly registered IP.
     /// @return tokenId The ID of the newly minted NFT.
@@ -32,7 +32,7 @@ interface ILicenseAttachmentWorkflows {
         address spgNftContract,
         address recipient,
         WorkflowStructs.IPMetadata calldata ipMetadata,
-        WorkflowStructs.PILTermsData[] calldata pilTermsData,
+        WorkflowStructs.LicenseTermsData[] calldata licenseTermsData,
         bool allowDuplicates
     ) external returns (address ipId, uint256 tokenId, uint256[] memory licenseTermsIds);
 
@@ -42,7 +42,7 @@ interface ILicenseAttachmentWorkflows {
     /// @param nftContract The address of the NFT collection.
     /// @param tokenId The ID of the NFT.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
-    /// @param pilTermsData The PIL terms and licensing configuration data to be attached to the IP.
+    /// @param licenseTermsData The PIL terms and licensing configuration data to be attached to the IP.
     /// @param sigMetadataAndAttachAndConfig Signature data for setAll (metadata), attachLicenseTerms, and
     /// setLicensingConfig to the IP via the Core Metadata Module and Licensing Module.
     /// @return ipId The ID of the newly registered IP.
@@ -51,7 +51,7 @@ interface ILicenseAttachmentWorkflows {
         address nftContract,
         uint256 tokenId,
         WorkflowStructs.IPMetadata calldata ipMetadata,
-        WorkflowStructs.PILTermsData[] calldata pilTermsData,
+        WorkflowStructs.LicenseTermsData[] calldata licenseTermsData,
         WorkflowStructs.SignatureData calldata sigMetadataAndAttachAndConfig
     ) external returns (address ipId, uint256[] memory licenseTermsIds);
 }

--- a/contracts/interfaces/workflows/ILicenseAttachmentWorkflows.sol
+++ b/contracts/interfaces/workflows/ILicenseAttachmentWorkflows.sol
@@ -1,8 +1,5 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
-
-import { PILTerms } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
-
 import { WorkflowStructs } from "../../lib/WorkflowStructs.sol";
 
 /// @title License Attachment Workflows Interface
@@ -10,14 +7,14 @@ import { WorkflowStructs } from "../../lib/WorkflowStructs.sol";
 interface ILicenseAttachmentWorkflows {
     /// @notice Register Programmable IP License Terms (if unregistered) and attach it to IP.
     /// @param ipId The ID of the IP.
-    /// @param terms The PIL terms to be registered.
-    /// @param sigAttach Signature data for attachLicenseTerms to the IP via the Licensing Module.
-    /// @return licenseTermsId The ID of the newly registered PIL terms.
+    /// @param pilTermsData The PIL terms and licensing configuration data to be attached to the IP.
+    /// @param sigAttachAndConfig Signature data for attachLicenseTerms and setLicensingConfig to the IP via the Licensing Module.
+    /// @return licenseTermsIds The IDs of the newly registered PIL terms.
     function registerPILTermsAndAttach(
         address ipId,
-        PILTerms calldata terms,
-        WorkflowStructs.SignatureData calldata sigAttach
-    ) external returns (uint256 licenseTermsId);
+        WorkflowStructs.PILTermsData[] calldata pilTermsData,
+        WorkflowStructs.SignatureData calldata sigAttachAndConfig
+    ) external returns (uint256[] memory licenseTermsIds);
 
     /// @notice Mint an NFT from a SPGNFT collection, register it with metadata as an IP,
     /// register Programmable IPLicense
@@ -26,18 +23,18 @@ interface ILicenseAttachmentWorkflows {
     /// @param spgNftContract The address of the SPGNFT collection.
     /// @param recipient The address of the recipient of the minted NFT.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
-    /// @param terms The PIL terms to be registered.
+    /// @param pilTermsData The PIL terms and licensing configuration data to be attached to the IP.
     /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
     /// @return ipId The ID of the newly registered IP.
     /// @return tokenId The ID of the newly minted NFT.
-    /// @return licenseTermsId The ID of the newly registered PIL terms.
+    /// @return licenseTermsIds The IDs of the newly registered PIL terms.
     function mintAndRegisterIpAndAttachPILTerms(
         address spgNftContract,
         address recipient,
         WorkflowStructs.IPMetadata calldata ipMetadata,
-        PILTerms calldata terms,
+        WorkflowStructs.PILTermsData[] calldata pilTermsData,
         bool allowDuplicates
-    ) external returns (address ipId, uint256 tokenId, uint256 licenseTermsId);
+    ) external returns (address ipId, uint256 tokenId, uint256[] memory licenseTermsIds);
 
     /// @notice Register a given NFT as an IP and attach Programmable IP License Terms.
     /// @dev Because IP Account is created in this function, we need to set the permission via signature to allow this
@@ -45,17 +42,16 @@ interface ILicenseAttachmentWorkflows {
     /// @param nftContract The address of the NFT collection.
     /// @param tokenId The ID of the NFT.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
-    /// @param terms The PIL terms to be registered.
-    /// @param sigMetadata OPTIONAL. Signature data for setAll (metadata) for the IP via the Core Metadata Module.
-    /// @param sigAttach Signature data for attachLicenseTerms to the IP via the Licensing Module.
+    /// @param pilTermsData The PIL terms and licensing configuration data to be attached to the IP.
+    /// @param sigMetadataAndAttachAndConfig Signature data for setAll (metadata), attachLicenseTerms, and
+    /// setLicensingConfig to the IP via the Core Metadata Module and Licensing Module.
     /// @return ipId The ID of the newly registered IP.
-    /// @return licenseTermsId The ID of the newly registered PIL terms.
+    /// @return licenseTermsIds The IDs of the newly registered PIL terms.
     function registerIpAndAttachPILTerms(
         address nftContract,
         uint256 tokenId,
         WorkflowStructs.IPMetadata calldata ipMetadata,
-        PILTerms calldata terms,
-        WorkflowStructs.SignatureData calldata sigMetadata,
-        WorkflowStructs.SignatureData calldata sigAttach
-    ) external returns (address ipId, uint256 licenseTermsId);
+        WorkflowStructs.PILTermsData[] calldata pilTermsData,
+        WorkflowStructs.SignatureData calldata sigMetadataAndAttachAndConfig
+    ) external returns (address ipId, uint256[] memory licenseTermsIds);
 }

--- a/contracts/lib/LicensingHelper.sol
+++ b/contracts/lib/LicensingHelper.sol
@@ -15,21 +15,21 @@ library LicensingHelper {
     /// @param ipId The ID of the IP.
     /// @param pilTemplate The address of the PIL License Template.
     /// @param licensingModule The address of the Licensing Module.
-    /// @param pilTermsData The PIL terms and licensing configuration data to be attached to the IP.
+    /// @param licenseTermsData The PIL terms and licensing configuration data to be attached to the IP.
     /// @return licenseTermsId The ID of the registered PIL terms.
     function registerPILTermsAndAttachAndSetConfigs(
         address ipId,
         address pilTemplate,
         address licensingModule,
-        WorkflowStructs.PILTermsData memory pilTermsData
+        WorkflowStructs.LicenseTermsData memory licenseTermsData
     ) internal returns (uint256 licenseTermsId) {
-        licenseTermsId = IPILicenseTemplate(pilTemplate).registerLicenseTerms(pilTermsData.terms);
+        licenseTermsId = IPILicenseTemplate(pilTemplate).registerLicenseTerms(licenseTermsData.terms);
         attachLicenseTermsAndSetConfigs(
             ipId,
             licensingModule,
             pilTemplate,
             licenseTermsId,
-            pilTermsData.licensingConfig
+            licenseTermsData.licensingConfig
         );
     }
 

--- a/contracts/lib/LicensingHelper.sol
+++ b/contracts/lib/LicensingHelper.sol
@@ -3,45 +3,57 @@ pragma solidity 0.8.26;
 
 import { Errors as CoreErrors } from "@storyprotocol/core/lib/Errors.sol";
 import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingModule.sol";
-import { IPILicenseTemplate, PILTerms } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
+import { IPILicenseTemplate } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
+import { Licensing } from "@storyprotocol/core/lib/Licensing.sol";
+
+import { WorkflowStructs } from "./WorkflowStructs.sol";
 
 /// @title Periphery Licensing Helper Library
 /// @notice Library for all licensing related helper functions for Periphery contracts.
 library LicensingHelper {
-    /// @dev Registers PIL License Terms and attaches them to the given IP.
+    /// @dev Registers PIL License Terms and attaches them to the given IP and sets their licensing configurations.
     /// @param ipId The ID of the IP.
     /// @param pilTemplate The address of the PIL License Template.
     /// @param licensingModule The address of the Licensing Module.
-    /// @param licenseRegistry The address of the License Registry.
-    /// @param terms The PIL terms to be registered.
+    /// @param pilTermsData The PIL terms and licensing configuration data to be attached to the IP.
     /// @return licenseTermsId The ID of the registered PIL terms.
-    function registerPILTermsAndAttach(
+    function registerPILTermsAndAttachAndSetConfigs(
         address ipId,
         address pilTemplate,
         address licensingModule,
-        address licenseRegistry,
-        PILTerms calldata terms
+        WorkflowStructs.PILTermsData memory pilTermsData
     ) internal returns (uint256 licenseTermsId) {
-        licenseTermsId = IPILicenseTemplate(pilTemplate).registerLicenseTerms(terms);
-
-        attachLicenseTerms(ipId, licensingModule, licenseRegistry, pilTemplate, licenseTermsId);
+        licenseTermsId = IPILicenseTemplate(pilTemplate).registerLicenseTerms(pilTermsData.terms);
+        attachLicenseTermsAndSetConfigs(
+            ipId,
+            licensingModule,
+            pilTemplate,
+            licenseTermsId,
+            pilTermsData.licensingConfig
+        );
     }
 
-    /// @dev Attaches license terms to the given IP.
+    /// @dev Attaches license terms to the given IP and sets their licensing configurations.
     /// @param ipId The ID of the IP.
     /// @param licensingModule The address of the Licensing Module.
-    /// @param licenseRegistry The address of the License Registry.
     /// @param licenseTemplate The address of the license template.
     /// @param licenseTermsId The ID of the license terms to be attached.
-    function attachLicenseTerms(
+    /// @param licensingConfig The licensing configuration for the license terms.
+    function attachLicenseTermsAndSetConfigs(
         address ipId,
         address licensingModule,
-        address licenseRegistry,
         address licenseTemplate,
-        uint256 licenseTermsId
+        uint256 licenseTermsId,
+        Licensing.LicensingConfig memory licensingConfig
     ) internal {
         try ILicensingModule(licensingModule).attachLicenseTerms(ipId, licenseTemplate, licenseTermsId) {
-            return; // license terms are attached successfully
+            // license terms are attached successfully, now we set the licensing config
+            ILicensingModule(licensingModule).setLicensingConfig(
+                ipId,
+                licenseTemplate,
+                licenseTermsId,
+                licensingConfig
+            );
         } catch (bytes memory reason) {
             // if the error is not that the license terms are already attached, revert with the original error
             if (CoreErrors.LicenseRegistry__LicenseTermsAlreadyAttached.selector != bytes4(reason)) {

--- a/contracts/lib/WorkflowStructs.sol
+++ b/contracts/lib/WorkflowStructs.sol
@@ -59,7 +59,7 @@ library WorkflowStructs {
     /// @notice Struct for PIL terms data for PIL registration and attachment on IP registration.
     /// @param terms The PIL terms to be used for the licensing.
     /// @param licenseTermsConfig The licensing configuration for the PIL terms.
-    struct PILTermsData {
+    struct LicenseTermsData {
         PILTerms terms;
         Licensing.LicensingConfig licensingConfig;
     }

--- a/contracts/lib/WorkflowStructs.sol
+++ b/contracts/lib/WorkflowStructs.sol
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
+import { Licensing } from "@storyprotocol/core/lib/Licensing.sol";
+import { PILTerms } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
+
 /// @title Workflow Structs Library
 /// @notice Library for all the structs used in periphery workflows.
 library WorkflowStructs {
@@ -41,5 +44,23 @@ library WorkflowStructs {
         bytes royaltyContext;
         uint256 maxMintingFee;
         uint32 maxRts;
+    }
+
+    /// @notice Struct for license data for license attachment on IP registration.
+    /// @param licenseTemplate The address of the license template to be used for the licensing.
+    /// @param licenseTermsId The ID of the license terms to be used for the licensing.
+    /// @param licensingConfig The licensing configuration for the IP.
+    struct LicenseData {
+        address licenseTemplate;
+        uint256 licenseTermsId;
+        Licensing.LicensingConfig licensingConfig;
+    }
+
+    /// @notice Struct for PIL terms data for PIL registration and attachment on IP registration.
+    /// @param terms The PIL terms to be used for the licensing.
+    /// @param licenseTermsConfig The licensing configuration for the PIL terms.
+    struct PILTermsData {
+        PILTerms terms;
+        Licensing.LicensingConfig licensingConfig;
     }
 }

--- a/contracts/workflows/LicenseAttachmentWorkflows.sol
+++ b/contracts/workflows/LicenseAttachmentWorkflows.sol
@@ -91,12 +91,12 @@ contract LicenseAttachmentWorkflows is
 
     /// @notice Register Programmable IP License Terms (if unregistered) and attach it to IP.
     /// @param ipId The ID of the IP.
-    /// @param pilTermsData The PIL terms and licensing configuration data to be attached to the IP.
+    /// @param licenseTermsData The PIL terms and licensing configuration data to be attached to the IP.
     /// @param sigAttachAndConfig Signature data for attachLicenseTerms and setLicensingConfig to the IP via the Licensing Module.
     /// @return licenseTermsIds The IDs of the newly registered PIL terms.
     function registerPILTermsAndAttach(
         address ipId,
-        WorkflowStructs.PILTermsData[] calldata pilTermsData,
+        WorkflowStructs.LicenseTermsData[] calldata licenseTermsData,
         WorkflowStructs.SignatureData calldata sigAttachAndConfig
     ) external returns (uint256[] memory licenseTermsIds) {
         address[] memory modules = new address[](2);
@@ -113,7 +113,7 @@ contract LicenseAttachmentWorkflows is
             sigData: sigAttachAndConfig
         });
 
-        licenseTermsIds = _registerMultiplePILTermsAndAttachAndSetConfigs(ipId, pilTermsData);
+        licenseTermsIds = _registerMultiplePILTermsAndAttachAndSetConfigs(ipId, licenseTermsData);
     }
 
     /// @notice Mint an NFT from a SPGNFT collection, register it with metadata as an IP,
@@ -122,7 +122,7 @@ contract LicenseAttachmentWorkflows is
     /// @param spgNftContract The address of the SPGNFT collection.
     /// @param recipient The address of the recipient of the minted NFT.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
-    /// @param pilTermsData The PIL terms and licensing configuration data to be attached to the IP.
+    /// @param licenseTermsData The PIL terms and licensing configuration data to be attached to the IP.
     /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
     /// @return ipId The ID of the newly registered IP.
     /// @return tokenId The ID of the newly minted NFT.
@@ -131,7 +131,7 @@ contract LicenseAttachmentWorkflows is
         address spgNftContract,
         address recipient,
         WorkflowStructs.IPMetadata calldata ipMetadata,
-        WorkflowStructs.PILTermsData[] calldata pilTermsData,
+        WorkflowStructs.LicenseTermsData[] calldata licenseTermsData,
         bool allowDuplicates
     )
         external
@@ -149,7 +149,7 @@ contract LicenseAttachmentWorkflows is
         ipId = IP_ASSET_REGISTRY.register(block.chainid, spgNftContract, tokenId);
         MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);
 
-        licenseTermsIds = _registerMultiplePILTermsAndAttachAndSetConfigs(ipId, pilTermsData);
+        licenseTermsIds = _registerMultiplePILTermsAndAttachAndSetConfigs(ipId, licenseTermsData);
 
         ISPGNFT(spgNftContract).safeTransferFrom(address(this), recipient, tokenId, "");
     }
@@ -160,7 +160,7 @@ contract LicenseAttachmentWorkflows is
     /// @param nftContract The address of the NFT collection.
     /// @param tokenId The ID of the NFT.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
-    /// @param pilTermsData The PIL terms and licensing configuration data to be attached to the IP.
+    /// @param licenseTermsData The PIL terms and licensing configuration data to be attached to the IP.
     /// @param sigMetadataAndAttachAndConfig Signature data for setAll (metadata), attachLicenseTerms, and
     /// setLicensingConfig to the IP via the Core Metadata Module and Licensing Module.
     /// @return ipId The ID of the newly registered IP.
@@ -169,7 +169,7 @@ contract LicenseAttachmentWorkflows is
         address nftContract,
         uint256 tokenId,
         WorkflowStructs.IPMetadata calldata ipMetadata,
-        WorkflowStructs.PILTermsData[] calldata pilTermsData,
+        WorkflowStructs.LicenseTermsData[] calldata licenseTermsData,
         WorkflowStructs.SignatureData calldata sigMetadataAndAttachAndConfig
     ) external returns (address ipId, uint256[] memory licenseTermsIds) {
         ipId = IP_ASSET_REGISTRY.register(block.chainid, nftContract, tokenId);
@@ -192,24 +192,24 @@ contract LicenseAttachmentWorkflows is
 
         MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);
 
-        licenseTermsIds = _registerMultiplePILTermsAndAttachAndSetConfigs(ipId, pilTermsData);
+        licenseTermsIds = _registerMultiplePILTermsAndAttachAndSetConfigs(ipId, licenseTermsData);
     }
 
     /// @notice Registers multiple PIL terms and attaches them to the given IP and sets their licensing configurations.
     /// @param ipId The ID of the IP.
-    /// @param pilTermsData The PIL terms and licensing configuration data to be attached to the IP.
+    /// @param licenseTermsData The PIL terms and licensing configuration data to be attached to the IP.
     /// @return licenseTermsIds The IDs of the newly registered PIL terms.
     function _registerMultiplePILTermsAndAttachAndSetConfigs(
         address ipId,
-        WorkflowStructs.PILTermsData[] calldata pilTermsData
+        WorkflowStructs.LicenseTermsData[] calldata licenseTermsData
     ) private returns (uint256[] memory licenseTermsIds) {
-        licenseTermsIds = new uint256[](pilTermsData.length);
-        for (uint256 i; i < pilTermsData.length; i++) {
+        licenseTermsIds = new uint256[](licenseTermsData.length);
+        for (uint256 i; i < licenseTermsData.length; i++) {
             licenseTermsIds[i] = LicensingHelper.registerPILTermsAndAttachAndSetConfigs(
                 ipId,
                 address(PIL_TEMPLATE),
                 address(LICENSING_MODULE),
-                pilTermsData[i]
+                licenseTermsData[i]
             );
         }
     }

--- a/contracts/workflows/LicenseAttachmentWorkflows.sol
+++ b/contracts/workflows/LicenseAttachmentWorkflows.sol
@@ -7,8 +7,8 @@ import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC16
 import { MulticallUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/MulticallUpgradeable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
+import { ICoreMetadataModule } from "@storyprotocol/core/interfaces/modules/metadata/ICoreMetadataModule.sol";
 import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingModule.sol";
-import { PILTerms } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
 
 import { BaseWorkflow } from "../BaseWorkflow.sol";
 import { Errors } from "../lib/Errors.sol";
@@ -91,29 +91,29 @@ contract LicenseAttachmentWorkflows is
 
     /// @notice Register Programmable IP License Terms (if unregistered) and attach it to IP.
     /// @param ipId The ID of the IP.
-    /// @param terms The PIL terms to be registered.
-    /// @param sigAttach Signature data for attachLicenseTerms to the IP via the Licensing Module.
-    /// @return licenseTermsId The ID of the newly registered PIL terms.
+    /// @param pilTermsData The PIL terms and licensing configuration data to be attached to the IP.
+    /// @param sigAttachAndConfig Signature data for attachLicenseTerms and setLicensingConfig to the IP via the Licensing Module.
+    /// @return licenseTermsIds The IDs of the newly registered PIL terms.
     function registerPILTermsAndAttach(
         address ipId,
-        PILTerms calldata terms,
-        WorkflowStructs.SignatureData calldata sigAttach
-    ) external returns (uint256 licenseTermsId) {
-        PermissionHelper.setPermissionForModule(
-            ipId,
-            address(LICENSING_MODULE),
-            address(ACCESS_CONTROLLER),
-            ILicensingModule.attachLicenseTerms.selector,
-            sigAttach
-        );
+        WorkflowStructs.PILTermsData[] calldata pilTermsData,
+        WorkflowStructs.SignatureData calldata sigAttachAndConfig
+    ) external returns (uint256[] memory licenseTermsIds) {
+        address[] memory modules = new address[](2);
+        bytes4[] memory selectors = new bytes4[](2);
+        modules[0] = address(LICENSING_MODULE);
+        modules[1] = address(LICENSING_MODULE);
+        selectors[0] = ILicensingModule.attachLicenseTerms.selector;
+        selectors[1] = ILicensingModule.setLicensingConfig.selector;
+        PermissionHelper.setBatchPermissionForModules({
+            ipId: ipId,
+            accessController: address(ACCESS_CONTROLLER),
+            modules: modules,
+            selectors: selectors,
+            sigData: sigAttachAndConfig
+        });
 
-        licenseTermsId = LicensingHelper.registerPILTermsAndAttach(
-            ipId,
-            address(PIL_TEMPLATE),
-            address(LICENSING_MODULE),
-            address(LICENSE_REGISTRY),
-            terms
-        );
+        licenseTermsIds = _registerMultiplePILTermsAndAttachAndSetConfigs(ipId, pilTermsData);
     }
 
     /// @notice Mint an NFT from a SPGNFT collection, register it with metadata as an IP,
@@ -122,18 +122,22 @@ contract LicenseAttachmentWorkflows is
     /// @param spgNftContract The address of the SPGNFT collection.
     /// @param recipient The address of the recipient of the minted NFT.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly minted NFT and registered IP.
-    /// @param terms The PIL terms to be registered.
+    /// @param pilTermsData The PIL terms and licensing configuration data to be attached to the IP.
     /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
     /// @return ipId The ID of the newly registered IP.
     /// @return tokenId The ID of the newly minted NFT.
-    /// @return licenseTermsId The ID of the newly registered PIL terms.
+    /// @return licenseTermsIds The IDs of the newly registered PIL terms.
     function mintAndRegisterIpAndAttachPILTerms(
         address spgNftContract,
         address recipient,
         WorkflowStructs.IPMetadata calldata ipMetadata,
-        PILTerms calldata terms,
+        WorkflowStructs.PILTermsData[] calldata pilTermsData,
         bool allowDuplicates
-    ) external onlyMintAuthorized(spgNftContract) returns (address ipId, uint256 tokenId, uint256 licenseTermsId) {
+    )
+        external
+        onlyMintAuthorized(spgNftContract)
+        returns (address ipId, uint256 tokenId, uint256[] memory licenseTermsIds)
+    {
         tokenId = ISPGNFT(spgNftContract).mintByPeriphery({
             to: address(this),
             payer: msg.sender,
@@ -145,13 +149,7 @@ contract LicenseAttachmentWorkflows is
         ipId = IP_ASSET_REGISTRY.register(block.chainid, spgNftContract, tokenId);
         MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);
 
-        licenseTermsId = LicensingHelper.registerPILTermsAndAttach(
-            ipId,
-            address(PIL_TEMPLATE),
-            address(LICENSING_MODULE),
-            address(LICENSE_REGISTRY),
-            terms
-        );
+        licenseTermsIds = _registerMultiplePILTermsAndAttachAndSetConfigs(ipId, pilTermsData);
 
         ISPGNFT(spgNftContract).safeTransferFrom(address(this), recipient, tokenId, "");
     }
@@ -162,43 +160,58 @@ contract LicenseAttachmentWorkflows is
     /// @param nftContract The address of the NFT collection.
     /// @param tokenId The ID of the NFT.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
-    /// @param terms The PIL terms to be registered.
-    /// @param sigMetadata OPTIONAL. Signature data for setAll (metadata) for the IP via the Core Metadata Module.
-    /// @param sigAttach Signature data for attachLicenseTerms to the IP via the Licensing Module.
+    /// @param pilTermsData The PIL terms and licensing configuration data to be attached to the IP.
+    /// @param sigMetadataAndAttachAndConfig Signature data for setAll (metadata), attachLicenseTerms, and
+    /// setLicensingConfig to the IP via the Core Metadata Module and Licensing Module.
     /// @return ipId The ID of the newly registered IP.
-    /// @return licenseTermsId The ID of the newly registered PIL terms.
+    /// @return licenseTermsIds The IDs of the newly registered PIL terms.
     function registerIpAndAttachPILTerms(
         address nftContract,
         uint256 tokenId,
         WorkflowStructs.IPMetadata calldata ipMetadata,
-        PILTerms calldata terms,
-        WorkflowStructs.SignatureData calldata sigMetadata,
-        WorkflowStructs.SignatureData calldata sigAttach
-    ) external returns (address ipId, uint256 licenseTermsId) {
+        WorkflowStructs.PILTermsData[] calldata pilTermsData,
+        WorkflowStructs.SignatureData calldata sigMetadataAndAttachAndConfig
+    ) external returns (address ipId, uint256[] memory licenseTermsIds) {
         ipId = IP_ASSET_REGISTRY.register(block.chainid, nftContract, tokenId);
-        MetadataHelper.setMetadataWithSig(
-            ipId,
-            address(CORE_METADATA_MODULE),
-            address(ACCESS_CONTROLLER),
-            ipMetadata,
-            sigMetadata
-        );
 
-        PermissionHelper.setPermissionForModule(
-            ipId,
-            address(LICENSING_MODULE),
-            address(ACCESS_CONTROLLER),
-            ILicensingModule.attachLicenseTerms.selector,
-            sigAttach
-        );
+        address[] memory modules = new address[](3);
+        bytes4[] memory selectors = new bytes4[](3);
+        modules[0] = address(CORE_METADATA_MODULE);
+        modules[1] = address(LICENSING_MODULE);
+        modules[2] = address(LICENSING_MODULE);
+        selectors[0] = ICoreMetadataModule.setAll.selector;
+        selectors[1] = ILicensingModule.attachLicenseTerms.selector;
+        selectors[2] = ILicensingModule.setLicensingConfig.selector;
+        PermissionHelper.setBatchPermissionForModules({
+            ipId: ipId,
+            accessController: address(ACCESS_CONTROLLER),
+            modules: modules,
+            selectors: selectors,
+            sigData: sigMetadataAndAttachAndConfig
+        });
 
-        licenseTermsId = LicensingHelper.registerPILTermsAndAttach(
-            ipId,
-            address(PIL_TEMPLATE),
-            address(LICENSING_MODULE),
-            address(LICENSE_REGISTRY),
-            terms
-        );
+        MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);
+
+        licenseTermsIds = _registerMultiplePILTermsAndAttachAndSetConfigs(ipId, pilTermsData);
+    }
+
+    /// @notice Registers multiple PIL terms and attaches them to the given IP and sets their licensing configurations.
+    /// @param ipId The ID of the IP.
+    /// @param pilTermsData The PIL terms and licensing configuration data to be attached to the IP.
+    /// @return licenseTermsIds The IDs of the newly registered PIL terms.
+    function _registerMultiplePILTermsAndAttachAndSetConfigs(
+        address ipId,
+        WorkflowStructs.PILTermsData[] calldata pilTermsData
+    ) private returns (uint256[] memory licenseTermsIds) {
+        licenseTermsIds = new uint256[](pilTermsData.length);
+        for (uint256 i; i < pilTermsData.length; i++) {
+            licenseTermsIds[i] = LicensingHelper.registerPILTermsAndAttachAndSetConfigs(
+                ipId,
+                address(PIL_TEMPLATE),
+                address(LICENSING_MODULE),
+                pilTermsData[i]
+            );
+        }
     }
 
     //

--- a/test/integration/BaseIntegration.t.sol
+++ b/test/integration/BaseIntegration.t.sol
@@ -134,25 +134,52 @@ contract BaseIntegration is Test, Script, StoryProtocolCoreAddressManager, Story
     /*//////////////////////////////////////////////////////////////////////////
                                       HELPERS
     //////////////////////////////////////////////////////////////////////////*/
-
-    /// @dev Get the permission list for setting metadata and attaching license terms for the IP.
+    /// @dev Get the permission list for attaching license terms and setting licensing config for the IP.
     /// @param ipId The ID of the IP that the permissions are for.
     /// @param to The address of the periphery contract to receive the permission.
-    /// @return permissionList The list of permissions for setting metadata and attaching license terms.
-    function _getMetadataAndAttachTermsPermissionList(
+    /// @return permissionList The list of permissions for attaching license terms and setting licensing config.
+    function _getAttachTermsAndConfigPermissionList(
         address ipId,
         address to
     ) internal view returns (AccessPermission.Permission[] memory permissionList) {
         address[] memory modules = new address[](2);
         bytes4[] memory selectors = new bytes4[](2);
         permissionList = new AccessPermission.Permission[](2);
+        modules[0] = licensingModuleAddr;
+        modules[1] = licensingModuleAddr;
+        selectors[0] = ILicensingModule.attachLicenseTerms.selector;
+        selectors[1] = ILicensingModule.setLicensingConfig.selector;
+        for (uint256 i = 0; i < 2; i++) {
+            permissionList[i] = AccessPermission.Permission({
+                ipAccount: ipId,
+                signer: to,
+                to: modules[i],
+                func: selectors[i],
+                permission: AccessPermission.ALLOW
+            });
+        }
+    }
+
+    /// @dev Get the permission list for setting metadata and attaching license terms for the IP.
+    /// @param ipId The ID of the IP that the permissions are for.
+    /// @param to The address of the periphery contract to receive the permission.
+    /// @return permissionList The list of permissions for setting metadata, attaching license terms, and
+    /// setting licensing config.
+    function _getMetadataAndAttachTermsAndConfigPermissionList(
+        address ipId,
+        address to
+    ) internal view returns (AccessPermission.Permission[] memory permissionList) {
+        address[] memory modules = new address[](3);
+        bytes4[] memory selectors = new bytes4[](3);
+        permissionList = new AccessPermission.Permission[](3);
 
         modules[0] = coreMetadataModuleAddr;
         modules[1] = licensingModuleAddr;
+        modules[2] = licensingModuleAddr;
         selectors[0] = ICoreMetadataModule.setAll.selector;
         selectors[1] = ILicensingModule.attachLicenseTerms.selector;
-
-        for (uint256 i = 0; i < 2; i++) {
+        selectors[2] = ILicensingModule.setLicensingConfig.selector;
+        for (uint256 i = 0; i < 3; i++) {
             permissionList[i] = AccessPermission.Permission({
                 ipAccount: ipId,
                 signer: to,

--- a/test/integration/workflows/DerivativeIntegration.t.sol
+++ b/test/integration/workflows/DerivativeIntegration.t.sol
@@ -23,7 +23,7 @@ contract DerivativeIntegration is BaseIntegration {
     address[] private parentIpIds;
     uint256[] private parentLicenseTermIds;
     address private parentLicenseTemplate;
-    WorkflowStructs.PILTermsData[] internal pilTermsData;
+    WorkflowStructs.LicenseTermsData[] internal licenseTermsData;
     uint32 private revShare;
 
     /// @dev To use, run the following command:
@@ -385,8 +385,8 @@ contract DerivativeIntegration is BaseIntegration {
 
         revShare = 10 * 10 ** 6; // 10%
 
-        pilTermsData.push(
-            WorkflowStructs.PILTermsData({
+        licenseTermsData.push(
+            WorkflowStructs.LicenseTermsData({
                 terms: PILFlavors.commercialRemix({
                     mintingFee: testMintFee,
                     commercialRevShare: revShare,
@@ -413,7 +413,7 @@ contract DerivativeIntegration is BaseIntegration {
             spgNftContract: address(spgNftContract),
             recipient: testSender,
             ipMetadata: testIpMetadata,
-            pilTermsData: pilTermsData,
+            licenseTermsData: licenseTermsData,
             allowDuplicates: true
         });
 

--- a/test/integration/workflows/DerivativeIntegration.t.sol
+++ b/test/integration/workflows/DerivativeIntegration.t.sol
@@ -7,6 +7,7 @@ import { ICoreMetadataModule } from "@storyprotocol/core/interfaces/modules/meta
 import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
 import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingModule.sol";
 import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
+import { Licensing } from "@storyprotocol/core/lib/Licensing.sol";
 
 // contracts
 import { ISPGNFT } from "../../../contracts/interfaces/ISPGNFT.sol";
@@ -22,6 +23,7 @@ contract DerivativeIntegration is BaseIntegration {
     address[] private parentIpIds;
     uint256[] private parentLicenseTermIds;
     address private parentLicenseTemplate;
+    WorkflowStructs.PILTermsData[] internal pilTermsData;
     uint32 private revShare;
 
     /// @dev To use, run the following command:
@@ -249,7 +251,6 @@ contract DerivativeIntegration is BaseIntegration {
         licenseTokenIds[0] = startLicenseTokenId;
         licenseToken.approve(derivativeWorkflowsAddr, startLicenseTokenId);
 
-
         WorkflowStructs.SignatureData memory sigMetadata;
         WorkflowStructs.SignatureData memory sigRegister;
         {
@@ -384,27 +385,41 @@ contract DerivativeIntegration is BaseIntegration {
 
         revShare = 10 * 10 ** 6; // 10%
 
-        StoryUSD.mint(testSender, testMintFee);
-        StoryUSD.approve(address(spgNftContract), testMintFee);
-        (address parentIpId, , uint256 licenseTermsIdParent) = licenseAttachmentWorkflows
-            .mintAndRegisterIpAndAttachPILTerms({
-                spgNftContract: address(spgNftContract),
-                recipient: testSender,
-                ipMetadata: testIpMetadata,
+        pilTermsData.push(
+            WorkflowStructs.PILTermsData({
                 terms: PILFlavors.commercialRemix({
                     mintingFee: testMintFee,
                     commercialRevShare: revShare,
                     royaltyPolicy: royaltyPolicyLRPAddr,
                     currencyToken: testMintFeeToken
                 }),
-                allowDuplicates: true
-            });
+                licensingConfig: Licensing.LicensingConfig({
+                    isSet: true,
+                    mintingFee: testMintFee,
+                    licensingHook: address(0),
+                    hookData: "",
+                    commercialRevShare: revShare,
+                    disabled: false,
+                    expectMinimumGroupRewardShare: 0,
+                    expectGroupRewardPool: evenSplitGroupPoolAddr
+                })
+            })
+        );
+
+        StoryUSD.mint(testSender, testMintFee);
+        StoryUSD.approve(address(spgNftContract), testMintFee);
+        address parentIpId;
+        (parentIpId, , parentLicenseTermIds) = licenseAttachmentWorkflows.mintAndRegisterIpAndAttachPILTerms({
+            spgNftContract: address(spgNftContract),
+            recipient: testSender,
+            ipMetadata: testIpMetadata,
+            pilTermsData: pilTermsData,
+            allowDuplicates: true
+        });
 
         parentIpIds = new address[](1);
         parentIpIds[0] = parentIpId;
 
-        parentLicenseTermIds = new uint256[](1);
-        parentLicenseTermIds[0] = licenseTermsIdParent;
         parentLicenseTemplate = pilTemplateAddr;
     }
 

--- a/test/integration/workflows/LicenseAttachmentIntegration.t.sol
+++ b/test/integration/workflows/LicenseAttachmentIntegration.t.sol
@@ -3,11 +3,9 @@ pragma solidity 0.8.26;
 
 // external
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
-import { ICoreMetadataModule } from "@storyprotocol/core/interfaces/modules/metadata/ICoreMetadataModule.sol";
 import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
-import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingModule.sol";
+import { Licensing } from "@storyprotocol/core/lib/Licensing.sol";
 import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
-import { PILTerms } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
 
 // contracts
 import { ISPGNFT } from "../../../contracts/interfaces/ISPGNFT.sol";
@@ -20,7 +18,7 @@ contract LicenseAttachmentIntegration is BaseIntegration {
     using Strings for uint256;
 
     ISPGNFT private spgNftContract;
-    PILTerms private commUseTerms;
+    WorkflowStructs.PILTermsData[] private commTermsData;
 
     /// @dev To use, run the following command:
     /// forge script test/integration/workflows/LicenseAttachmentIntegration.t.sol:LicenseAttachmentIntegration \
@@ -50,23 +48,27 @@ contract LicenseAttachmentIntegration is BaseIntegration {
         });
 
         uint256 deadline = block.timestamp + 1000;
-        (bytes memory signature, , ) = _getSetPermissionSigForPeriphery({
+        (bytes memory signature, , ) = _getSetBatchPermissionSigForPeriphery({
             ipId: ipId,
-            to: licenseAttachmentWorkflowsAddr,
-            module: licensingModuleAddr,
-            selector: ILicensingModule.attachLicenseTerms.selector,
+            permissionList: _getAttachTermsAndConfigPermissionList(ipId, licenseAttachmentWorkflowsAddr),
             deadline: deadline,
             state: IIPAccount(payable(ipId)).state(),
             signerSk: testSenderSk
         });
 
-        uint256 licenseTermsId = licenseAttachmentWorkflows.registerPILTermsAndAttach({
+        uint256[] memory licenseTermsIds = licenseAttachmentWorkflows.registerPILTermsAndAttach({
             ipId: ipId,
-            terms: commUseTerms,
-            sigAttach: WorkflowStructs.SignatureData({ signer: testSender, deadline: deadline, signature: signature })
+            pilTermsData: commTermsData,
+            sigAttachAndConfig: WorkflowStructs.SignatureData({
+                signer: testSender,
+                deadline: deadline,
+                signature: signature
+            })
         });
 
-        assertEq(licenseTermsId, pilTemplate.getLicenseTermsId(commUseTerms));
+        for (uint256 i = 0; i < licenseTermsIds.length; i++) {
+            assertEq(licenseTermsIds[i], pilTemplate.getLicenseTermsId(commTermsData[i].terms));
+        }
     }
 
     function _test_LicenseAttachmentIntegration_mintAndRegisterIpAndAttachPILTerms()
@@ -78,22 +80,24 @@ contract LicenseAttachmentIntegration is BaseIntegration {
             StoryUSD.mint(testSender, testMintFee);
             StoryUSD.approve(address(spgNftContract), testMintFee);
 
-            (address ipId1, uint256 tokenId1, uint256 licenseTermsId1) = licenseAttachmentWorkflows
+            (address ipId1, uint256 tokenId1, uint256[] memory licenseTermsIds1) = licenseAttachmentWorkflows
                 .mintAndRegisterIpAndAttachPILTerms({
                     spgNftContract: address(spgNftContract),
                     recipient: testSender,
                     ipMetadata: testIpMetadata,
-                    terms: commUseTerms,
+                    pilTermsData: commTermsData,
                     allowDuplicates: true
                 });
             assertTrue(ipAssetRegistry.isRegistered(ipId1));
             assertEq(tokenId1, spgNftContract.totalSupply());
-            assertEq(licenseTermsId1, pilTemplate.getLicenseTermsId(commUseTerms));
             assertEq(spgNftContract.tokenURI(tokenId1), string.concat(testBaseURI, testIpMetadata.nftMetadataURI));
             assertMetadata(ipId1, testIpMetadata);
-            (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId1, 0);
-            assertEq(licenseTemplate, pilTemplateAddr);
-            assertEq(licenseTermsId, licenseTermsId1);
+            for (uint256 i = 0; i < licenseTermsIds1.length; i++) {
+                (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId1, i);
+                assertEq(licenseTemplate, pilTemplateAddr);
+                assertEq(licenseTermsId, licenseTermsIds1[i]);
+                assertEq(licenseTermsId, pilTemplate.getLicenseTermsId(commTermsData[i].terms));
+            }
         }
 
         // IP 2
@@ -101,22 +105,24 @@ contract LicenseAttachmentIntegration is BaseIntegration {
             StoryUSD.mint(testSender, testMintFee);
             StoryUSD.approve(address(spgNftContract), testMintFee);
 
-            (address ipId2, uint256 tokenId2, uint256 licenseTermsId2) = licenseAttachmentWorkflows
+            (address ipId2, uint256 tokenId2, uint256[] memory licenseTermsIds2) = licenseAttachmentWorkflows
                 .mintAndRegisterIpAndAttachPILTerms({
                     spgNftContract: address(spgNftContract),
                     recipient: testSender,
                     ipMetadata: testIpMetadata,
-                    terms: commUseTerms,
+                    pilTermsData: commTermsData,
                     allowDuplicates: true
                 });
             assertTrue(ipAssetRegistry.isRegistered(ipId2));
             assertEq(tokenId2, spgNftContract.totalSupply());
-            assertEq(licenseTermsId2, pilTemplate.getLicenseTermsId(commUseTerms));
             assertEq(spgNftContract.tokenURI(tokenId2), string.concat(testBaseURI, testIpMetadata.nftMetadataURI));
             assertMetadata(ipId2, testIpMetadata);
-            (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId2, 0);
-            assertEq(licenseTemplate, pilTemplateAddr);
-            assertEq(licenseTermsId, licenseTermsId2);
+            for (uint256 i = 0; i < licenseTermsIds2.length; i++) {
+                (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId2, i);
+                assertEq(licenseTemplate, pilTemplateAddr);
+                assertEq(licenseTermsIds2[i], licenseTermsId);
+                assertEq(licenseTermsId, pilTemplate.getLicenseTermsId(commTermsData[i].terms));
+            }
         }
     }
 
@@ -137,48 +143,41 @@ contract LicenseAttachmentIntegration is BaseIntegration {
 
         uint256 deadline = block.timestamp + 1000;
 
-        (bytes memory sigMetadata, bytes32 sigAttachState, ) = _getSetPermissionSigForPeriphery({
+        (bytes memory sigMetadataAndAttachAndConfig, bytes32 expectedState, ) = _getSetBatchPermissionSigForPeriphery({
             ipId: expectedIpId,
-            to: licenseAttachmentWorkflowsAddr,
-            module: coreMetadataModuleAddr,
-            selector: ICoreMetadataModule.setAll.selector,
+            permissionList: _getMetadataAndAttachTermsAndConfigPermissionList(
+                expectedIpId,
+                licenseAttachmentWorkflowsAddr
+            ),
             deadline: deadline,
             state: bytes32(0),
             signerSk: testSenderSk
         });
 
-        (bytes memory sigAttach, bytes32 expectedState, ) = _getSetPermissionSigForPeriphery({
-            ipId: expectedIpId,
-            to: licenseAttachmentWorkflowsAddr,
-            module: licensingModuleAddr,
-            selector: ILicensingModule.attachLicenseTerms.selector,
-            deadline: deadline,
-            state: sigAttachState,
-            signerSk: testSenderSk
-        });
-
-        (address ipId, uint256 licenseTermsId) = licenseAttachmentWorkflows.registerIpAndAttachPILTerms({
+        (address ipId, uint256[] memory licenseTermsIds) = licenseAttachmentWorkflows.registerIpAndAttachPILTerms({
             nftContract: address(spgNftContract),
             tokenId: tokenId,
             ipMetadata: testIpMetadata,
-            terms: commUseTerms,
-            sigMetadata: WorkflowStructs.SignatureData({
+            pilTermsData: commTermsData,
+            sigMetadataAndAttachAndConfig: WorkflowStructs.SignatureData({
                 signer: testSender,
                 deadline: deadline,
-                signature: sigMetadata
-            }),
-            sigAttach: WorkflowStructs.SignatureData({ signer: testSender, deadline: deadline, signature: sigAttach })
+                signature: sigMetadataAndAttachAndConfig
+            })
         });
 
         assertEq(ipId, expectedIpId);
         assertTrue(ipAssetRegistry.isRegistered(ipId));
         assertEq(IIPAccount(payable(ipId)).state(), expectedState);
-        (address expectedLicenseTemplate, uint256 expectedLicenseTermsId) = licenseRegistry.getAttachedLicenseTerms(
-            expectedIpId,
-            0
-        );
-        assertEq(expectedLicenseTemplate, pilTemplateAddr);
-        assertEq(expectedLicenseTermsId, licenseTermsId);
+        for (uint256 i = 0; i < licenseTermsIds.length; i++) {
+            (address expectedLicenseTemplate, uint256 expectedLicenseTermsId) = licenseRegistry.getAttachedLicenseTerms(
+                expectedIpId,
+                i
+            );
+            assertEq(expectedLicenseTemplate, pilTemplateAddr);
+            assertEq(licenseTermsIds[i], expectedLicenseTermsId);
+            assertEq(expectedLicenseTermsId, pilTemplate.getLicenseTermsId(commTermsData[i].terms));
+        }
     }
 
     function _setUpTest() private {
@@ -200,10 +199,86 @@ contract LicenseAttachmentIntegration is BaseIntegration {
             )
         );
 
-        commUseTerms = PILFlavors.commercialUse({
-            mintingFee: testMintFee,
-            currencyToken: testMintFeeToken,
-            royaltyPolicy: royaltyPolicyLRPAddr
-        });
+        commTermsData.push(
+            WorkflowStructs.PILTermsData({
+                terms: PILFlavors.commercialUse({
+                    mintingFee: testMintFee,
+                    currencyToken: testMintFeeToken,
+                    royaltyPolicy: royaltyPolicyLRPAddr
+                }),
+                licensingConfig: Licensing.LicensingConfig({
+                    isSet: true,
+                    mintingFee: testMintFee,
+                    licensingHook: address(0),
+                    hookData: "",
+                    commercialRevShare: 0,
+                    disabled: false,
+                    expectMinimumGroupRewardShare: 0,
+                    expectGroupRewardPool: evenSplitGroupPoolAddr
+                })
+            })
+        );
+
+        commTermsData.push(
+            WorkflowStructs.PILTermsData({
+                terms: PILFlavors.commercialUse({
+                    mintingFee: testMintFee,
+                    currencyToken: testMintFeeToken,
+                    royaltyPolicy: royaltyPolicyLAPAddr
+                }),
+                licensingConfig: Licensing.LicensingConfig({
+                    isSet: false,
+                    mintingFee: testMintFee,
+                    licensingHook: address(0),
+                    hookData: "",
+                    commercialRevShare: 0,
+                    disabled: false,
+                    expectMinimumGroupRewardShare: 0,
+                    expectGroupRewardPool: evenSplitGroupPoolAddr
+                })
+            })
+        );
+
+        commTermsData.push(
+            WorkflowStructs.PILTermsData({
+                terms: PILFlavors.commercialRemix({
+                    mintingFee: testMintFee,
+                    commercialRevShare: 5_000_000, // 5%
+                    royaltyPolicy: royaltyPolicyLRPAddr,
+                    currencyToken: testMintFeeToken
+                }),
+                licensingConfig: Licensing.LicensingConfig({
+                    isSet: true,
+                    mintingFee: testMintFee,
+                    licensingHook: address(0),
+                    hookData: "",
+                    commercialRevShare: 5_000_000, // 5%
+                    disabled: false,
+                    expectMinimumGroupRewardShare: 0,
+                    expectGroupRewardPool: evenSplitGroupPoolAddr
+                })
+            })
+        );
+
+        commTermsData.push(
+            WorkflowStructs.PILTermsData({
+                terms: PILFlavors.commercialRemix({
+                    mintingFee: testMintFee,
+                    commercialRevShare: 8_000_000, // 8%
+                    royaltyPolicy: royaltyPolicyLAPAddr,
+                    currencyToken: testMintFeeToken
+                }),
+                licensingConfig: Licensing.LicensingConfig({
+                    isSet: true,
+                    mintingFee: testMintFee,
+                    licensingHook: address(0),
+                    hookData: "",
+                    commercialRevShare: 8_000_000, // 8%
+                    disabled: false,
+                    expectMinimumGroupRewardShare: 0,
+                    expectGroupRewardPool: evenSplitGroupPoolAddr
+                })
+            })
+        );
     }
 }

--- a/test/integration/workflows/LicenseAttachmentIntegration.t.sol
+++ b/test/integration/workflows/LicenseAttachmentIntegration.t.sol
@@ -18,7 +18,7 @@ contract LicenseAttachmentIntegration is BaseIntegration {
     using Strings for uint256;
 
     ISPGNFT private spgNftContract;
-    WorkflowStructs.PILTermsData[] private commTermsData;
+    WorkflowStructs.LicenseTermsData[] private commTermsData;
 
     /// @dev To use, run the following command:
     /// forge script test/integration/workflows/LicenseAttachmentIntegration.t.sol:LicenseAttachmentIntegration \
@@ -58,7 +58,7 @@ contract LicenseAttachmentIntegration is BaseIntegration {
 
         uint256[] memory licenseTermsIds = licenseAttachmentWorkflows.registerPILTermsAndAttach({
             ipId: ipId,
-            pilTermsData: commTermsData,
+            licenseTermsData: commTermsData,
             sigAttachAndConfig: WorkflowStructs.SignatureData({
                 signer: testSender,
                 deadline: deadline,
@@ -85,7 +85,7 @@ contract LicenseAttachmentIntegration is BaseIntegration {
                     spgNftContract: address(spgNftContract),
                     recipient: testSender,
                     ipMetadata: testIpMetadata,
-                    pilTermsData: commTermsData,
+                    licenseTermsData: commTermsData,
                     allowDuplicates: true
                 });
             assertTrue(ipAssetRegistry.isRegistered(ipId1));
@@ -110,7 +110,7 @@ contract LicenseAttachmentIntegration is BaseIntegration {
                     spgNftContract: address(spgNftContract),
                     recipient: testSender,
                     ipMetadata: testIpMetadata,
-                    pilTermsData: commTermsData,
+                    licenseTermsData: commTermsData,
                     allowDuplicates: true
                 });
             assertTrue(ipAssetRegistry.isRegistered(ipId2));
@@ -158,7 +158,7 @@ contract LicenseAttachmentIntegration is BaseIntegration {
             nftContract: address(spgNftContract),
             tokenId: tokenId,
             ipMetadata: testIpMetadata,
-            pilTermsData: commTermsData,
+            licenseTermsData: commTermsData,
             sigMetadataAndAttachAndConfig: WorkflowStructs.SignatureData({
                 signer: testSender,
                 deadline: deadline,
@@ -200,7 +200,7 @@ contract LicenseAttachmentIntegration is BaseIntegration {
         );
 
         commTermsData.push(
-            WorkflowStructs.PILTermsData({
+            WorkflowStructs.LicenseTermsData({
                 terms: PILFlavors.commercialUse({
                     mintingFee: testMintFee,
                     currencyToken: testMintFeeToken,
@@ -220,7 +220,7 @@ contract LicenseAttachmentIntegration is BaseIntegration {
         );
 
         commTermsData.push(
-            WorkflowStructs.PILTermsData({
+            WorkflowStructs.LicenseTermsData({
                 terms: PILFlavors.commercialUse({
                     mintingFee: testMintFee,
                     currencyToken: testMintFeeToken,
@@ -240,7 +240,7 @@ contract LicenseAttachmentIntegration is BaseIntegration {
         );
 
         commTermsData.push(
-            WorkflowStructs.PILTermsData({
+            WorkflowStructs.LicenseTermsData({
                 terms: PILFlavors.commercialRemix({
                     mintingFee: testMintFee,
                     commercialRevShare: 5_000_000, // 5%
@@ -261,7 +261,7 @@ contract LicenseAttachmentIntegration is BaseIntegration {
         );
 
         commTermsData.push(
-            WorkflowStructs.PILTermsData({
+            WorkflowStructs.LicenseTermsData({
                 terms: PILFlavors.commercialRemix({
                     mintingFee: testMintFee,
                     commercialRevShare: 8_000_000, // 8%

--- a/test/integration/workflows/RoyaltyIntegration.t.sol
+++ b/test/integration/workflows/RoyaltyIntegration.t.sol
@@ -3,16 +3,13 @@ pragma solidity 0.8.26;
 /* solhint-disable no-console */
 
 // external
-import { console2 } from "forge-std/console2.sol";
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
-import { IpRoyaltyVault } from "@storyprotocol/core/modules/royalty/policies/IpRoyaltyVault.sol";
-import { IVaultController } from "@storyprotocol/core/interfaces/modules/royalty/policies/IVaultController.sol";
+import { Licensing } from "@storyprotocol/core/lib/Licensing.sol";
 import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
 
 // contracts
 import { ISPGNFT } from "../../../contracts/interfaces/ISPGNFT.sol";
-import { IRoyaltyWorkflows } from "../../../contracts/interfaces/workflows/IRoyaltyWorkflows.sol";
 import { WorkflowStructs } from "../../../contracts/lib/WorkflowStructs.sol";
 // test
 import { BaseIntegration } from "../BaseIntegration.t.sol";
@@ -35,6 +32,8 @@ contract RoyaltyIntegration is BaseIntegration {
     uint256 internal commRemixTermsIdC;
     uint256 internal defaultMintingFeeC = 500 * 10 ** StoryUSD.decimals(); // 500 SUSD
     uint32 internal defaultCommRevShareC = 20 * 10 ** 6; // 20%
+
+    WorkflowStructs.PILTermsData[] internal commTermsData;
 
     uint256 internal amountLicenseTokensToMint = 1;
 
@@ -211,50 +210,70 @@ contract RoyaltyIntegration is BaseIntegration {
 
         uint256 deadline = block.timestamp + 1000;
 
-        // set permission for licensing module to attach license terms to ancestor IP
-        (bytes memory signatureA, , ) = _getSetPermissionSigForPeriphery({
-            ipId: ancestorIpId,
-            to: licenseAttachmentWorkflowsAddr,
-            module: licensingModuleAddr,
-            selector: licensingModule.attachLicenseTerms.selector,
-            deadline: deadline,
-            state: IIPAccount(payable(ancestorIpId)).state(),
-            signerSk: testSenderSk
-        });
+        {
+            commTermsData.push(
+                WorkflowStructs.PILTermsData({
+                    terms: PILFlavors.commercialRemix({
+                        mintingFee: defaultMintingFeeA,
+                        commercialRevShare: defaultCommRevShareA,
+                        royaltyPolicy: royaltyPolicyLRPAddr,
+                        currencyToken: address(StoryUSD)
+                    }),
+                    licensingConfig: Licensing.LicensingConfig({
+                        isSet: true,
+                        mintingFee: defaultMintingFeeA,
+                        licensingHook: address(0),
+                        hookData: "",
+                        commercialRevShare: defaultCommRevShareA,
+                        disabled: false,
+                        expectMinimumGroupRewardShare: 0,
+                        expectGroupRewardPool: evenSplitGroupPoolAddr
+                    })
+                })
+            );
+            commTermsData.push(
+                WorkflowStructs.PILTermsData({
+                    terms: PILFlavors.commercialRemix({
+                        mintingFee: defaultMintingFeeC,
+                        commercialRevShare: defaultCommRevShareC,
+                        royaltyPolicy: royaltyPolicyLAPAddr,
+                        currencyToken: address(StoryUSD)
+                    }),
+                    licensingConfig: Licensing.LicensingConfig({
+                        isSet: true,
+                        mintingFee: defaultMintingFeeC,
+                        licensingHook: address(0),
+                        hookData: "",
+                        commercialRevShare: defaultCommRevShareC,
+                        disabled: false,
+                        expectMinimumGroupRewardShare: 0,
+                        expectGroupRewardPool: evenSplitGroupPoolAddr
+                    })
+                })
+            );
 
-        // register and attach Terms A and C to ancestor IP
-        commRemixTermsIdA = licenseAttachmentWorkflows.registerPILTermsAndAttach({
-            ipId: ancestorIpId,
-            terms: PILFlavors.commercialRemix({
-                mintingFee: defaultMintingFeeA,
-                commercialRevShare: defaultCommRevShareA,
-                royaltyPolicy: royaltyPolicyLRPAddr,
-                currencyToken: address(StoryUSD)
-            }),
-            sigAttach: WorkflowStructs.SignatureData({ signer: testSender, deadline: deadline, signature: signatureA })
-        });
+            // set permission for licensing module to attach license terms to ancestor IP
+            (bytes memory signature, , ) = _getSetBatchPermissionSigForPeriphery({
+                ipId: ancestorIpId,
+                permissionList: _getAttachTermsAndConfigPermissionList(ancestorIpId, licenseAttachmentWorkflowsAddr),
+                deadline: deadline,
+                state: bytes32(0),
+                signerSk: testSenderSk
+            });
 
-        // set permission for licensing module to attach license terms to ancestor IP
-        (bytes memory signatureC, , ) = _getSetPermissionSigForPeriphery({
-            ipId: ancestorIpId,
-            to: licenseAttachmentWorkflowsAddr,
-            module: licensingModuleAddr,
-            selector: licensingModule.attachLicenseTerms.selector,
-            deadline: deadline,
-            state: IIPAccount(payable(ancestorIpId)).state(),
-            signerSk: testSenderSk
-        });
+            uint256[] memory licenseTermsIds = licenseAttachmentWorkflows.registerPILTermsAndAttach({
+                ipId: ancestorIpId,
+                pilTermsData: commTermsData,
+                sigAttachAndConfig: WorkflowStructs.SignatureData({
+                    signer: testSender,
+                    deadline: deadline,
+                    signature: signature
+                })
+            });
 
-        commRemixTermsIdC = licenseAttachmentWorkflows.registerPILTermsAndAttach({
-            ipId: ancestorIpId,
-            terms: PILFlavors.commercialRemix({
-                mintingFee: defaultMintingFeeC,
-                commercialRevShare: defaultCommRevShareC,
-                royaltyPolicy: royaltyPolicyLAPAddr,
-                currencyToken: address(StoryUSD)
-            }),
-            sigAttach: WorkflowStructs.SignatureData({ signer: testSender, deadline: deadline, signature: signatureC })
-        });
+            commRemixTermsIdA = licenseTermsIds[0];
+            commRemixTermsIdC = licenseTermsIds[1];
+        }
 
         // register childIpA as derivative of ancestorIp under Terms A
         {

--- a/test/integration/workflows/RoyaltyIntegration.t.sol
+++ b/test/integration/workflows/RoyaltyIntegration.t.sol
@@ -33,7 +33,7 @@ contract RoyaltyIntegration is BaseIntegration {
     uint256 internal defaultMintingFeeC = 500 * 10 ** StoryUSD.decimals(); // 500 SUSD
     uint32 internal defaultCommRevShareC = 20 * 10 ** 6; // 20%
 
-    WorkflowStructs.PILTermsData[] internal commTermsData;
+    WorkflowStructs.LicenseTermsData[] internal commTermsData;
 
     uint256 internal amountLicenseTokensToMint = 1;
 
@@ -212,7 +212,7 @@ contract RoyaltyIntegration is BaseIntegration {
 
         {
             commTermsData.push(
-                WorkflowStructs.PILTermsData({
+                WorkflowStructs.LicenseTermsData({
                     terms: PILFlavors.commercialRemix({
                         mintingFee: defaultMintingFeeA,
                         commercialRevShare: defaultCommRevShareA,
@@ -232,7 +232,7 @@ contract RoyaltyIntegration is BaseIntegration {
                 })
             );
             commTermsData.push(
-                WorkflowStructs.PILTermsData({
+                WorkflowStructs.LicenseTermsData({
                     terms: PILFlavors.commercialRemix({
                         mintingFee: defaultMintingFeeC,
                         commercialRevShare: defaultCommRevShareC,
@@ -263,7 +263,7 @@ contract RoyaltyIntegration is BaseIntegration {
 
             uint256[] memory licenseTermsIds = licenseAttachmentWorkflows.registerPILTermsAndAttach({
                 ipId: ancestorIpId,
-                pilTermsData: commTermsData,
+                licenseTermsData: commTermsData,
                 sigAttachAndConfig: WorkflowStructs.SignatureData({
                     signer: testSender,
                     deadline: deadline,

--- a/test/utils/BaseTest.t.sol
+++ b/test/utils/BaseTest.t.sol
@@ -279,25 +279,52 @@ contract BaseTest is Test, DeployHelper {
     /*//////////////////////////////////////////////////////////////////////////
                                       HELPERS
     //////////////////////////////////////////////////////////////////////////*/
-
-    /// @dev Get the permission list for setting metadata and attaching license terms for the IP.
+    /// @dev Get the permission list for attaching license terms and setting licensing config for the IP.
     /// @param ipId The ID of the IP that the permissions are for.
     /// @param to The address of the periphery contract to receive the permission.
-    /// @return permissionList The list of permissions for setting metadata and attaching license terms.
-    function _getMetadataAndAttachTermsPermissionList(
+    /// @return permissionList The list of permissions for attaching license terms and setting licensing config.
+    function _getAttachTermsAndConfigPermissionList(
         address ipId,
         address to
     ) internal view returns (AccessPermission.Permission[] memory permissionList) {
         address[] memory modules = new address[](2);
         bytes4[] memory selectors = new bytes4[](2);
         permissionList = new AccessPermission.Permission[](2);
+        modules[0] = licensingModuleAddr;
+        modules[1] = licensingModuleAddr;
+        selectors[0] = ILicensingModule.attachLicenseTerms.selector;
+        selectors[1] = ILicensingModule.setLicensingConfig.selector;
+        for (uint256 i = 0; i < 2; i++) {
+            permissionList[i] = AccessPermission.Permission({
+                ipAccount: ipId,
+                signer: to,
+                to: modules[i],
+                func: selectors[i],
+                permission: AccessPermission.ALLOW
+            });
+        }
+    }
+
+    /// @dev Get the permission list for setting metadata and attaching license terms for the IP.
+    /// @param ipId The ID of the IP that the permissions are for.
+    /// @param to The address of the periphery contract to receive the permission.
+    /// @return permissionList The list of permissions for setting metadata, attaching license terms, and
+    /// setting licensing config.
+    function _getMetadataAndAttachTermsAndConfigPermissionList(
+        address ipId,
+        address to
+    ) internal view returns (AccessPermission.Permission[] memory permissionList) {
+        address[] memory modules = new address[](3);
+        bytes4[] memory selectors = new bytes4[](3);
+        permissionList = new AccessPermission.Permission[](3);
 
         modules[0] = coreMetadataModuleAddr;
         modules[1] = licensingModuleAddr;
+        modules[2] = licensingModuleAddr;
         selectors[0] = ICoreMetadataModule.setAll.selector;
         selectors[1] = ILicensingModule.attachLicenseTerms.selector;
-
-        for (uint256 i = 0; i < 2; i++) {
+        selectors[2] = ILicensingModule.setLicensingConfig.selector;
+        for (uint256 i = 0; i < 3; i++) {
             permissionList[i] = AccessPermission.Permission({
                 ipAccount: ipId,
                 signer: to,

--- a/test/workflows/DerivativeWorkflows.t.sol
+++ b/test/workflows/DerivativeWorkflows.t.sol
@@ -7,6 +7,7 @@ import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { ICoreMetadataModule } from "@storyprotocol/core/interfaces/modules/metadata/ICoreMetadataModule.sol";
 import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
 import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingModule.sol";
+import { Licensing } from "@storyprotocol/core/lib/Licensing.sol";
 import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
 
 // contracts
@@ -20,35 +21,71 @@ contract DerivativeWorkflowsTest is BaseTest {
     using Strings for uint256;
 
     address internal ipIdParent;
-
+    WorkflowStructs.PILTermsData[] internal nonCommTermsData;
+    WorkflowStructs.PILTermsData[] internal commTermsData;
     function setUp() public override {
         super.setUp();
+        nonCommTermsData.push(
+            WorkflowStructs.PILTermsData({
+                terms: PILFlavors.nonCommercialSocialRemixing(),
+                licensingConfig: Licensing.LicensingConfig({
+                    isSet: true,
+                    mintingFee: 0,
+                    licensingHook: address(0),
+                    hookData: "",
+                    commercialRevShare: 0,
+                    disabled: false,
+                    expectMinimumGroupRewardShare: 0,
+                    expectGroupRewardPool: address(evenSplitGroupPool)
+                })
+            })
+        );
+
+        commTermsData.push(
+            WorkflowStructs.PILTermsData({
+                terms: PILFlavors.commercialRemix({
+                    mintingFee: 100 * 10 ** mockToken.decimals(),
+                    commercialRevShare: 10 * 10 ** 6, // 10%
+                    royaltyPolicy: address(royaltyPolicyLAP),
+                    currencyToken: address(mockToken)
+                }),
+                licensingConfig: Licensing.LicensingConfig({
+                    isSet: true,
+                    mintingFee: 100 * 10 ** mockToken.decimals(),
+                    licensingHook: address(0),
+                    hookData: "",
+                    commercialRevShare: 10 * 10 ** 6,
+                    disabled: false,
+                    expectMinimumGroupRewardShare: 0,
+                    expectGroupRewardPool: address(evenSplitGroupPool)
+                })
+            })
+        );
     }
 
     modifier withNonCommercialParentIp() {
-        (ipIdParent, , ) = licenseAttachmentWorkflows.mintAndRegisterIpAndAttachPILTerms({
-            spgNftContract: address(nftContract),
-            recipient: caller,
-            ipMetadata: ipMetadataDefault,
-            terms: PILFlavors.nonCommercialSocialRemixing(),
-            allowDuplicates: true
-        });
+        {
+            (ipIdParent, , ) = licenseAttachmentWorkflows.mintAndRegisterIpAndAttachPILTerms({
+                spgNftContract: address(nftContract),
+                recipient: caller,
+                ipMetadata: ipMetadataDefault,
+                pilTermsData: nonCommTermsData,
+                allowDuplicates: true
+            });
+        }
         _;
     }
 
     modifier withCommercialParentIp() {
-        (ipIdParent, , ) = licenseAttachmentWorkflows.mintAndRegisterIpAndAttachPILTerms({
-            spgNftContract: address(nftContract),
-            recipient: caller,
-            ipMetadata: ipMetadataDefault,
-            terms: PILFlavors.commercialRemix({
-                mintingFee: 100 * 10 ** mockToken.decimals(),
-                commercialRevShare: 10 * 10 ** 6, // 10%
-                royaltyPolicy: address(royaltyPolicyLAP),
-                currencyToken: address(mockToken)
-            }),
-            allowDuplicates: true
-        });
+        {
+            (ipIdParent, , ) = licenseAttachmentWorkflows.mintAndRegisterIpAndAttachPILTerms({
+                spgNftContract: address(nftContract),
+                recipient: caller,
+                ipMetadata: ipMetadataDefault,
+                pilTermsData: commTermsData,
+                allowDuplicates: true
+            });
+        }
         _;
     }
 

--- a/test/workflows/DerivativeWorkflows.t.sol
+++ b/test/workflows/DerivativeWorkflows.t.sol
@@ -21,12 +21,12 @@ contract DerivativeWorkflowsTest is BaseTest {
     using Strings for uint256;
 
     address internal ipIdParent;
-    WorkflowStructs.PILTermsData[] internal nonCommTermsData;
-    WorkflowStructs.PILTermsData[] internal commTermsData;
+    WorkflowStructs.LicenseTermsData[] internal nonCommTermsData;
+    WorkflowStructs.LicenseTermsData[] internal commTermsData;
     function setUp() public override {
         super.setUp();
         nonCommTermsData.push(
-            WorkflowStructs.PILTermsData({
+            WorkflowStructs.LicenseTermsData({
                 terms: PILFlavors.nonCommercialSocialRemixing(),
                 licensingConfig: Licensing.LicensingConfig({
                     isSet: true,
@@ -42,7 +42,7 @@ contract DerivativeWorkflowsTest is BaseTest {
         );
 
         commTermsData.push(
-            WorkflowStructs.PILTermsData({
+            WorkflowStructs.LicenseTermsData({
                 terms: PILFlavors.commercialRemix({
                     mintingFee: 100 * 10 ** mockToken.decimals(),
                     commercialRevShare: 10 * 10 ** 6, // 10%
@@ -69,7 +69,7 @@ contract DerivativeWorkflowsTest is BaseTest {
                 spgNftContract: address(nftContract),
                 recipient: caller,
                 ipMetadata: ipMetadataDefault,
-                pilTermsData: nonCommTermsData,
+                licenseTermsData: nonCommTermsData,
                 allowDuplicates: true
             });
         }
@@ -82,7 +82,7 @@ contract DerivativeWorkflowsTest is BaseTest {
                 spgNftContract: address(nftContract),
                 recipient: caller,
                 ipMetadata: ipMetadataDefault,
-                pilTermsData: commTermsData,
+                licenseTermsData: commTermsData,
                 allowDuplicates: true
             });
         }

--- a/test/workflows/LicenseAttachmentWorkflows.t.sol
+++ b/test/workflows/LicenseAttachmentWorkflows.t.sol
@@ -28,11 +28,11 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
 
     mapping(uint256 index => IPAsset) internal ipAsset;
 
-    WorkflowStructs.PILTermsData[] internal commTermsData;
+    WorkflowStructs.LicenseTermsData[] internal commTermsData;
 
     function setUp() public override {
         super.setUp();
-        _setUpPILTermsData();
+        _setUpLicenseTermsData();
     }
 
     modifier withIp(address owner) {
@@ -60,7 +60,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
             spgNftContract: address(nftContract),
             recipient: caller,
             ipMetadata: ipMetadataDefault,
-            pilTermsData: commTermsData,
+            licenseTermsData: commTermsData,
             allowDuplicates: true
         });
 
@@ -76,7 +76,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
             spgNftContract: address(nftContract),
             recipient: caller,
             ipMetadata: ipMetadataDefault,
-            pilTermsData: commTermsData,
+            licenseTermsData: commTermsData,
             allowDuplicates: false
         });
     }
@@ -97,7 +97,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
 
         uint256[] memory licenseTermsIds = licenseAttachmentWorkflows.registerPILTermsAndAttach({
             ipId: ipId,
-            pilTermsData: commTermsData,
+            licenseTermsData: commTermsData,
             sigAttachAndConfig: WorkflowStructs.SignatureData({
                 signer: u.alice,
                 deadline: deadline,
@@ -118,7 +118,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
                 spgNftContract: address(nftContract),
                 recipient: caller,
                 ipMetadata: ipMetadataEmpty,
-                pilTermsData: commTermsData,
+                licenseTermsData: commTermsData,
                 allowDuplicates: true
             });
         assertTrue(ipAssetRegistry.isRegistered(ipId1));
@@ -132,7 +132,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
                 spgNftContract: address(nftContract),
                 recipient: caller,
                 ipMetadata: ipMetadataDefault,
-                pilTermsData: commTermsData,
+                licenseTermsData: commTermsData,
                 allowDuplicates: true
             });
         assertTrue(ipAssetRegistry.isRegistered(ipId2));
@@ -173,7 +173,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
             nftContract: address(nftContract),
             tokenId: tokenId,
             ipMetadata: ipMetadataDefault,
-            pilTermsData: commTermsData,
+            licenseTermsData: commTermsData,
             sigMetadataAndAttachAndConfig: WorkflowStructs.SignatureData({
                 signer: u.alice,
                 deadline: deadline,
@@ -204,7 +204,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
 
         uint256[] memory licenseTermsIds1 = licenseAttachmentWorkflows.registerPILTermsAndAttach({
             ipId: ipId,
-            pilTermsData: commTermsData,
+            licenseTermsData: commTermsData,
             sigAttachAndConfig: WorkflowStructs.SignatureData({
                 signer: u.alice,
                 deadline: deadline,
@@ -223,7 +223,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
         // attach the same license terms to the IP again, but it shouldn't revert
         uint256[] memory licenseTermsIds2 = licenseAttachmentWorkflows.registerPILTermsAndAttach({
             ipId: ipId,
-            pilTermsData: commTermsData,
+            licenseTermsData: commTermsData,
             sigAttachAndConfig: WorkflowStructs.SignatureData({
                 signer: u.alice,
                 deadline: deadline,
@@ -247,7 +247,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
                 spgNftContract: address(nftContract),
                 recipient: caller,
                 ipMetadata: ipMetadataDefault,
-                pilTermsData: commTermsData,
+                licenseTermsData: commTermsData,
                 allowDuplicates: true
             });
 
@@ -288,7 +288,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
         vm.expectRevert(CoreErrors.LicensingModule__DerivativesCannotAddLicenseTerms.selector);
         licenseAttachmentWorkflows.registerPILTermsAndAttach({
             ipId: ipIdChild,
-            pilTermsData: commTermsData,
+            licenseTermsData: commTermsData,
             sigAttachAndConfig: WorkflowStructs.SignatureData({
                 signer: u.alice,
                 deadline: deadline,
@@ -306,11 +306,11 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
         }
     }
 
-    function _setUpPILTermsData() internal {
+    function _setUpLicenseTermsData() internal {
         uint256 testMintFee = 100 * 10 ** mockToken.decimals();
 
         commTermsData.push(
-            WorkflowStructs.PILTermsData({
+            WorkflowStructs.LicenseTermsData({
                 terms: PILFlavors.commercialUse({
                     mintingFee: testMintFee,
                     currencyToken: address(mockToken),
@@ -330,7 +330,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
         );
 
         commTermsData.push(
-            WorkflowStructs.PILTermsData({
+            WorkflowStructs.LicenseTermsData({
                 terms: PILFlavors.commercialUse({
                     mintingFee: testMintFee,
                     currencyToken: address(mockToken),
@@ -350,7 +350,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
         );
 
         commTermsData.push(
-            WorkflowStructs.PILTermsData({
+            WorkflowStructs.LicenseTermsData({
                 terms: PILFlavors.commercialRemix({
                     mintingFee: testMintFee,
                     commercialRevShare: 5_000_000, // 5%
@@ -371,7 +371,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
         );
 
         commTermsData.push(
-            WorkflowStructs.PILTermsData({
+            WorkflowStructs.LicenseTermsData({
                 terms: PILFlavors.commercialRemix({
                     mintingFee: testMintFee,
                     commercialRevShare: 8_000_000, // 8%

--- a/test/workflows/LicenseAttachmentWorkflows.t.sol
+++ b/test/workflows/LicenseAttachmentWorkflows.t.sol
@@ -8,6 +8,7 @@ import { Errors as CoreErrors } from "@storyprotocol/core/lib/Errors.sol";
 import { ICoreMetadataModule } from "@storyprotocol/core/interfaces/modules/metadata/ICoreMetadataModule.sol";
 import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
 import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingModule.sol";
+import { Licensing } from "@storyprotocol/core/lib/Licensing.sol";
 import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
 
 // contracts
@@ -27,8 +28,11 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
 
     mapping(uint256 index => IPAsset) internal ipAsset;
 
+    WorkflowStructs.PILTermsData[] internal commTermsData;
+
     function setUp() public override {
         super.setUp();
+        _setUpPILTermsData();
     }
 
     modifier withIp(address owner) {
@@ -52,14 +56,13 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
         whenCallerHasMinterRole
         withEnoughTokens(address(licenseAttachmentWorkflows))
     {
-        (address ipId1, uint256 tokenId1, uint256 licenseTermsId1) = licenseAttachmentWorkflows
-            .mintAndRegisterIpAndAttachPILTerms({
-                spgNftContract: address(nftContract),
-                recipient: caller,
-                ipMetadata: ipMetadataDefault,
-                terms: PILFlavors.nonCommercialSocialRemixing(),
-                allowDuplicates: true
-            });
+        licenseAttachmentWorkflows.mintAndRegisterIpAndAttachPILTerms({
+            spgNftContract: address(nftContract),
+            recipient: caller,
+            ipMetadata: ipMetadataDefault,
+            pilTermsData: commTermsData,
+            allowDuplicates: true
+        });
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -73,7 +76,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
             spgNftContract: address(nftContract),
             recipient: caller,
             ipMetadata: ipMetadataDefault,
-            terms: PILFlavors.nonCommercialSocialRemixing(),
+            pilTermsData: commTermsData,
             allowDuplicates: false
         });
     }
@@ -82,11 +85,9 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
         address payable ipId = ipAsset[1].ipId;
         uint256 deadline = block.timestamp + 1000;
 
-        (bytes memory signature, , ) = _getSetPermissionSigForPeriphery({
+        (bytes memory signature, , ) = _getSetBatchPermissionSigForPeriphery({
             ipId: ipId,
-            to: address(licenseAttachmentWorkflows),
-            module: address(licensingModule),
-            selector: ILicensingModule.attachLicenseTerms.selector,
+            permissionList: _getAttachTermsAndConfigPermissionList(ipId, address(licenseAttachmentWorkflows)),
             deadline: deadline,
             state: IIPAccount(ipId).state(),
             signerSk: sk.alice
@@ -94,17 +95,16 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
 
         uint256 ltAmt = pilTemplate.totalRegisteredLicenseTerms();
 
-        uint256 licenseTermsId = licenseAttachmentWorkflows.registerPILTermsAndAttach({
+        uint256[] memory licenseTermsIds = licenseAttachmentWorkflows.registerPILTermsAndAttach({
             ipId: ipId,
-            terms: PILFlavors.commercialUse({
-                mintingFee: 100,
-                currencyToken: address(mockToken),
-                royaltyPolicy: address(royaltyPolicyLAP)
-            }),
-            sigAttach: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: signature })
+            pilTermsData: commTermsData,
+            sigAttachAndConfig: WorkflowStructs.SignatureData({
+                signer: u.alice,
+                deadline: deadline,
+                signature: signature
+            })
         });
-
-        assertEq(licenseTermsId, ltAmt + 1);
+        _assertAttachedLicenseTerms(ipId, licenseTermsIds);
     }
 
     function test_LicenseAttachmentWorkflows_mintAndRegisterIpAndAttachPILTerms()
@@ -113,36 +113,33 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
         whenCallerHasMinterRole
         withEnoughTokens(address(licenseAttachmentWorkflows))
     {
-        (address ipId1, uint256 tokenId1, uint256 licenseTermsId1) = licenseAttachmentWorkflows
+        (address ipId1, uint256 tokenId1, uint256[] memory licenseTermsIds1) = licenseAttachmentWorkflows
             .mintAndRegisterIpAndAttachPILTerms({
                 spgNftContract: address(nftContract),
                 recipient: caller,
                 ipMetadata: ipMetadataEmpty,
-                terms: PILFlavors.nonCommercialSocialRemixing(),
+                pilTermsData: commTermsData,
                 allowDuplicates: true
             });
         assertTrue(ipAssetRegistry.isRegistered(ipId1));
         assertEq(tokenId1, 1);
-        assertEq(licenseTermsId1, 1);
         assertEq(nftContract.tokenURI(tokenId1), string.concat(testBaseURI, tokenId1.toString()));
         assertMetadata(ipId1, ipMetadataEmpty);
-        (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId1, 0);
-        assertEq(licenseTemplate, address(pilTemplate));
-        assertEq(licenseTermsId, licenseTermsId1);
+        _assertAttachedLicenseTerms(ipId1, licenseTermsIds1);
 
-        (address ipId2, uint256 tokenId2, uint256 licenseTermsId2) = licenseAttachmentWorkflows
+        (address ipId2, uint256 tokenId2, uint256[] memory licenseTermsIds2) = licenseAttachmentWorkflows
             .mintAndRegisterIpAndAttachPILTerms({
                 spgNftContract: address(nftContract),
                 recipient: caller,
                 ipMetadata: ipMetadataDefault,
-                terms: PILFlavors.nonCommercialSocialRemixing(),
+                pilTermsData: commTermsData,
                 allowDuplicates: true
             });
         assertTrue(ipAssetRegistry.isRegistered(ipId2));
         assertEq(tokenId2, 2);
-        assertEq(licenseTermsId1, licenseTermsId2);
         assertEq(nftContract.tokenURI(tokenId2), string.concat(testBaseURI, ipMetadataDefault.nftMetadataURI));
         assertMetadata(ipId2, ipMetadataDefault);
+        _assertAttachedLicenseTerms(ipId2, licenseTermsIds2);
     }
 
     function test_LicenseAttachmentWorkflows_registerIpAndAttachPILTerms()
@@ -161,34 +158,32 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
 
         uint256 deadline = block.timestamp + 1000;
 
-        (bytes memory sigMetadata, bytes32 expectedState, ) = _getSetPermissionSigForPeriphery({
+        (bytes memory sigMetadataAndAttachAndConfig, , ) = _getSetBatchPermissionSigForPeriphery({
             ipId: ipId,
-            to: address(licenseAttachmentWorkflows),
-            module: address(coreMetadataModule),
-            selector: ICoreMetadataModule.setAll.selector,
+            permissionList: _getMetadataAndAttachTermsAndConfigPermissionList(
+                ipId,
+                address(licenseAttachmentWorkflows)
+            ),
             deadline: deadline,
             state: bytes32(0),
             signerSk: sk.alice
         });
 
-        (bytes memory sigAttach, , ) = _getSetPermissionSigForPeriphery({
-            ipId: ipId,
-            to: address(licenseAttachmentWorkflows),
-            module: address(licensingModule),
-            selector: ILicensingModule.attachLicenseTerms.selector,
-            deadline: deadline,
-            state: expectedState,
-            signerSk: sk.alice
-        });
-
-        licenseAttachmentWorkflows.registerIpAndAttachPILTerms({
+        (, uint256[] memory licenseTermsIds) = licenseAttachmentWorkflows.registerIpAndAttachPILTerms({
             nftContract: address(nftContract),
             tokenId: tokenId,
             ipMetadata: ipMetadataDefault,
-            terms: PILFlavors.nonCommercialSocialRemixing(),
-            sigMetadata: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: sigMetadata }),
-            sigAttach: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: sigAttach })
+            pilTermsData: commTermsData,
+            sigMetadataAndAttachAndConfig: WorkflowStructs.SignatureData({
+                signer: u.alice,
+                deadline: deadline,
+                signature: sigMetadataAndAttachAndConfig
+            })
         });
+
+        assertTrue(ipAssetRegistry.isRegistered(ipId));
+        assertMetadata(ipId, ipMetadataDefault);
+        _assertAttachedLicenseTerms(ipId, licenseTermsIds);
     }
 
     function test_LicenseAttachmentWorkflows_registerPILTermsAndAttach_idempotency()
@@ -199,48 +194,46 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
         address payable ipId = ipAsset[1].ipId;
         uint256 deadline = block.timestamp + 1000;
 
-        (bytes memory signature1, , ) = _getSetPermissionSigForPeriphery({
+        (bytes memory signature1, , ) = _getSetBatchPermissionSigForPeriphery({
             ipId: ipId,
-            to: address(licenseAttachmentWorkflows),
-            module: address(licensingModule),
-            selector: ILicensingModule.attachLicenseTerms.selector,
+            permissionList: _getAttachTermsAndConfigPermissionList(ipId, address(licenseAttachmentWorkflows)),
             deadline: deadline,
             state: IIPAccount(ipId).state(),
             signerSk: sk.alice
         });
 
-        uint256 licenseTermsId1 = licenseAttachmentWorkflows.registerPILTermsAndAttach({
+        uint256[] memory licenseTermsIds1 = licenseAttachmentWorkflows.registerPILTermsAndAttach({
             ipId: ipId,
-            terms: PILFlavors.commercialUse({
-                mintingFee: 100,
-                currencyToken: address(mockToken),
-                royaltyPolicy: address(royaltyPolicyLAP)
-            }),
-            sigAttach: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: signature1 })
+            pilTermsData: commTermsData,
+            sigAttachAndConfig: WorkflowStructs.SignatureData({
+                signer: u.alice,
+                deadline: deadline,
+                signature: signature1
+            })
         });
 
-        (bytes memory signature2, , ) = _getSetPermissionSigForPeriphery({
+        (bytes memory signature2, , ) = _getSetBatchPermissionSigForPeriphery({
             ipId: ipId,
-            to: address(licenseAttachmentWorkflows),
-            module: address(licensingModule),
-            selector: ILicensingModule.attachLicenseTerms.selector,
+            permissionList: _getAttachTermsAndConfigPermissionList(ipId, address(licenseAttachmentWorkflows)),
             deadline: deadline,
             state: IIPAccount(ipId).state(),
             signerSk: sk.alice
         });
 
         // attach the same license terms to the IP again, but it shouldn't revert
-        uint256 licenseTermsId2 = licenseAttachmentWorkflows.registerPILTermsAndAttach({
+        uint256[] memory licenseTermsIds2 = licenseAttachmentWorkflows.registerPILTermsAndAttach({
             ipId: ipId,
-            terms: PILFlavors.commercialUse({
-                mintingFee: 100,
-                currencyToken: address(mockToken),
-                royaltyPolicy: address(royaltyPolicyLAP)
-            }),
-            sigAttach: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: signature2 })
+            pilTermsData: commTermsData,
+            sigAttachAndConfig: WorkflowStructs.SignatureData({
+                signer: u.alice,
+                deadline: deadline,
+                signature: signature2
+            })
         });
 
-        assertEq(licenseTermsId1, licenseTermsId2);
+        for (uint256 i = 0; i < licenseTermsIds1.length; i++) {
+            assertEq(licenseTermsIds1[i], licenseTermsIds2[i]);
+        }
     }
 
     function test_revert_registerPILTermsAndAttach_DerivativesCannotAddLicenseTerms()
@@ -249,12 +242,12 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
         whenCallerHasMinterRole
         withEnoughTokens(address(licenseAttachmentWorkflows))
     {
-        (address ipIdParent, , uint256 licenseTermsIdParent) = licenseAttachmentWorkflows
+        (address ipIdParent, , uint256[] memory licenseTermsIdsParent) = licenseAttachmentWorkflows
             .mintAndRegisterIpAndAttachPILTerms({
                 spgNftContract: address(nftContract),
                 recipient: caller,
                 ipMetadata: ipMetadataDefault,
-                terms: PILFlavors.nonCommercialSocialRemixing(),
+                pilTermsData: commTermsData,
                 allowDuplicates: true
             });
 
@@ -262,8 +255,10 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
         parentIpIds[0] = ipIdParent;
 
         uint256[] memory licenseTermsIds = new uint256[](1);
-        licenseTermsIds[0] = licenseTermsIdParent;
+        licenseTermsIds[0] = licenseTermsIdsParent[3];
 
+        mockToken.mint(address(caller), 100 * 10 ** mockToken.decimals());
+        mockToken.approve(address(derivativeWorkflows), 100 * 10 ** mockToken.decimals());
         (address ipIdChild, ) = derivativeWorkflows.mintAndRegisterIpAndMakeDerivative({
             spgNftContract: address(nftContract),
             derivData: WorkflowStructs.MakeDerivative({
@@ -281,13 +276,11 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
 
         uint256 deadline = block.timestamp + 1000;
 
-        (bytes memory signature, , ) = _getSetPermissionSigForPeriphery({
+        (bytes memory signature, , ) = _getSetBatchPermissionSigForPeriphery({
             ipId: ipIdChild,
-            to: address(licenseAttachmentWorkflows),
-            module: address(licensingModule),
-            selector: ILicensingModule.attachLicenseTerms.selector,
+            permissionList: _getAttachTermsAndConfigPermissionList(ipIdChild, address(licenseAttachmentWorkflows)),
             deadline: deadline,
-            state: IIPAccount(payable(ipIdChild)).state(),
+            state: bytes32(0),
             signerSk: sk.alice
         });
 
@@ -295,12 +288,107 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
         vm.expectRevert(CoreErrors.LicensingModule__DerivativesCannotAddLicenseTerms.selector);
         licenseAttachmentWorkflows.registerPILTermsAndAttach({
             ipId: ipIdChild,
-            terms: PILFlavors.commercialUse({
-                mintingFee: 100,
-                currencyToken: address(mockToken),
-                royaltyPolicy: address(royaltyPolicyLAP)
-            }),
-            sigAttach: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: signature })
+            pilTermsData: commTermsData,
+            sigAttachAndConfig: WorkflowStructs.SignatureData({
+                signer: u.alice,
+                deadline: deadline,
+                signature: signature
+            })
         });
+    }
+
+    function _assertAttachedLicenseTerms(address ipId, uint256[] memory licenseTermsIds) internal {
+        for (uint256 i = 0; i < commTermsData.length; i++) {
+            (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId, i);
+            assertEq(licenseTemplate, address(pilTemplate));
+            assertEq(licenseTermsId, licenseTermsIds[i]);
+            assertEq(pilTemplate.getLicenseTermsId(commTermsData[i].terms), licenseTermsIds[i]);
+        }
+    }
+
+    function _setUpPILTermsData() internal {
+        uint256 testMintFee = 100 * 10 ** mockToken.decimals();
+
+        commTermsData.push(
+            WorkflowStructs.PILTermsData({
+                terms: PILFlavors.commercialUse({
+                    mintingFee: testMintFee,
+                    currencyToken: address(mockToken),
+                    royaltyPolicy: address(royaltyPolicyLAP)
+                }),
+                licensingConfig: Licensing.LicensingConfig({
+                    isSet: true,
+                    mintingFee: testMintFee,
+                    licensingHook: address(0),
+                    hookData: "",
+                    commercialRevShare: 0,
+                    disabled: false,
+                    expectMinimumGroupRewardShare: 0,
+                    expectGroupRewardPool: address(evenSplitGroupPool)
+                })
+            })
+        );
+
+        commTermsData.push(
+            WorkflowStructs.PILTermsData({
+                terms: PILFlavors.commercialUse({
+                    mintingFee: testMintFee,
+                    currencyToken: address(mockToken),
+                    royaltyPolicy: address(royaltyPolicyLRP)
+                }),
+                licensingConfig: Licensing.LicensingConfig({
+                    isSet: false,
+                    mintingFee: testMintFee,
+                    licensingHook: address(0),
+                    hookData: "",
+                    commercialRevShare: 0,
+                    disabled: false,
+                    expectMinimumGroupRewardShare: 0,
+                    expectGroupRewardPool: address(evenSplitGroupPool)
+                })
+            })
+        );
+
+        commTermsData.push(
+            WorkflowStructs.PILTermsData({
+                terms: PILFlavors.commercialRemix({
+                    mintingFee: testMintFee,
+                    commercialRevShare: 5_000_000, // 5%
+                    royaltyPolicy: address(royaltyPolicyLRP),
+                    currencyToken: address(mockToken)
+                }),
+                licensingConfig: Licensing.LicensingConfig({
+                    isSet: true,
+                    mintingFee: testMintFee,
+                    licensingHook: address(0),
+                    hookData: "",
+                    commercialRevShare: 5_000_000, // 5%
+                    disabled: false,
+                    expectMinimumGroupRewardShare: 0,
+                    expectGroupRewardPool: address(evenSplitGroupPool)
+                })
+            })
+        );
+
+        commTermsData.push(
+            WorkflowStructs.PILTermsData({
+                terms: PILFlavors.commercialRemix({
+                    mintingFee: testMintFee,
+                    commercialRevShare: 8_000_000, // 8%
+                    royaltyPolicy: address(royaltyPolicyLAP),
+                    currencyToken: address(mockToken)
+                }),
+                licensingConfig: Licensing.LicensingConfig({
+                    isSet: true,
+                    mintingFee: testMintFee,
+                    licensingHook: address(0),
+                    hookData: "",
+                    commercialRevShare: 8_000_000, // 8%
+                    disabled: false,
+                    expectMinimumGroupRewardShare: 0,
+                    expectGroupRewardPool: address(evenSplitGroupPool)
+                })
+            })
+        );
     }
 }

--- a/test/workflows/RoyaltyWorkflows.t.sol
+++ b/test/workflows/RoyaltyWorkflows.t.sol
@@ -32,7 +32,7 @@ contract RoyaltyWorkflowsTest is BaseTest {
     uint256 internal defaultMintingFeeC = 500 ether;
     uint32 internal defaultCommRevShareC = 20 * 10 ** 6; // 20%
 
-    WorkflowStructs.PILTermsData[] internal commTermsData;
+    WorkflowStructs.LicenseTermsData[] internal commTermsData;
 
     uint256 internal amountLicenseTokensToMint = 1;
 
@@ -229,7 +229,7 @@ contract RoyaltyWorkflowsTest is BaseTest {
         // set permission for licensing module to attach license terms to ancestor IP
         {
             commTermsData.push(
-                WorkflowStructs.PILTermsData({
+                WorkflowStructs.LicenseTermsData({
                     terms: PILFlavors.commercialRemix({
                         mintingFee: defaultMintingFeeA,
                         commercialRevShare: defaultCommRevShareA,
@@ -249,7 +249,7 @@ contract RoyaltyWorkflowsTest is BaseTest {
                 })
             );
             commTermsData.push(
-                WorkflowStructs.PILTermsData({
+                WorkflowStructs.LicenseTermsData({
                     terms: PILFlavors.commercialRemix({
                         mintingFee: defaultMintingFeeC,
                         commercialRevShare: defaultCommRevShareC,
@@ -283,7 +283,7 @@ contract RoyaltyWorkflowsTest is BaseTest {
             // register and attach Terms A and C to ancestor IP
             uint256[] memory licenseTermsIds = licenseAttachmentWorkflows.registerPILTermsAndAttach({
                 ipId: ancestorIpId,
-                pilTermsData: commTermsData,
+                licenseTermsData: commTermsData,
                 sigAttachAndConfig: WorkflowStructs.SignatureData({
                     signer: u.admin,
                     deadline: deadline,

--- a/test/workflows/RoyaltyWorkflows.t.sol
+++ b/test/workflows/RoyaltyWorkflows.t.sol
@@ -4,8 +4,8 @@ pragma solidity 0.8.26;
 // external
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
+import { Licensing } from "@storyprotocol/core/lib/Licensing.sol";
 import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
-
 // contracts
 import { WorkflowStructs } from "../../contracts/lib/WorkflowStructs.sol";
 
@@ -31,6 +31,8 @@ contract RoyaltyWorkflowsTest is BaseTest {
     MockERC20 internal mockTokenC;
     uint256 internal defaultMintingFeeC = 500 ether;
     uint32 internal defaultCommRevShareC = 20 * 10 ** 6; // 20%
+
+    WorkflowStructs.PILTermsData[] internal commTermsData;
 
     uint256 internal amountLicenseTokensToMint = 1;
 
@@ -226,50 +228,70 @@ contract RoyaltyWorkflowsTest is BaseTest {
 
         // set permission for licensing module to attach license terms to ancestor IP
         {
-            (bytes memory signatureA, , ) = _getSetPermissionSigForPeriphery({
+            commTermsData.push(
+                WorkflowStructs.PILTermsData({
+                    terms: PILFlavors.commercialRemix({
+                        mintingFee: defaultMintingFeeA,
+                        commercialRevShare: defaultCommRevShareA,
+                        royaltyPolicy: address(royaltyPolicyLRP),
+                        currencyToken: address(mockTokenA)
+                    }),
+                    licensingConfig: Licensing.LicensingConfig({
+                        isSet: true,
+                        mintingFee: defaultMintingFeeA,
+                        licensingHook: address(0),
+                        hookData: "",
+                        commercialRevShare: defaultCommRevShareA,
+                        disabled: false,
+                        expectMinimumGroupRewardShare: 0,
+                        expectGroupRewardPool: evenSplitGroupPoolAddr
+                    })
+                })
+            );
+            commTermsData.push(
+                WorkflowStructs.PILTermsData({
+                    terms: PILFlavors.commercialRemix({
+                        mintingFee: defaultMintingFeeC,
+                        commercialRevShare: defaultCommRevShareC,
+                        royaltyPolicy: address(royaltyPolicyLAP),
+                        currencyToken: address(mockTokenC)
+                    }),
+                    licensingConfig: Licensing.LicensingConfig({
+                        isSet: true,
+                        mintingFee: defaultMintingFeeC,
+                        licensingHook: address(0),
+                        hookData: "",
+                        commercialRevShare: defaultCommRevShareC,
+                        disabled: false,
+                        expectMinimumGroupRewardShare: 0,
+                        expectGroupRewardPool: evenSplitGroupPoolAddr
+                    })
+                })
+            );
+
+            (bytes memory signature, , ) = _getSetBatchPermissionSigForPeriphery({
                 ipId: ancestorIpId,
-                to: address(licenseAttachmentWorkflows),
-                module: address(licensingModule),
-                selector: licensingModule.attachLicenseTerms.selector,
+                permissionList: _getAttachTermsAndConfigPermissionList(
+                    ancestorIpId,
+                    address(licenseAttachmentWorkflows)
+                ),
                 deadline: deadline,
-                state: IIPAccount(payable(ancestorIpId)).state(),
+                state: bytes32(0),
                 signerSk: sk.admin
             });
 
             // register and attach Terms A and C to ancestor IP
-            commRemixTermsIdA = licenseAttachmentWorkflows.registerPILTermsAndAttach({
+            uint256[] memory licenseTermsIds = licenseAttachmentWorkflows.registerPILTermsAndAttach({
                 ipId: ancestorIpId,
-                terms: PILFlavors.commercialRemix({
-                    mintingFee: defaultMintingFeeA,
-                    commercialRevShare: defaultCommRevShareA,
-                    royaltyPolicy: address(royaltyPolicyLRP),
-                    currencyToken: address(mockTokenA)
-                }),
-                sigAttach: WorkflowStructs.SignatureData({ signer: u.admin, deadline: deadline, signature: signatureA })
+                pilTermsData: commTermsData,
+                sigAttachAndConfig: WorkflowStructs.SignatureData({
+                    signer: u.admin,
+                    deadline: deadline,
+                    signature: signature
+                })
             });
-        }
-
-        {
-            (bytes memory signatureC, , ) = _getSetPermissionSigForPeriphery({
-                ipId: ancestorIpId,
-                to: address(licenseAttachmentWorkflows),
-                module: address(licensingModule),
-                selector: licensingModule.attachLicenseTerms.selector,
-                deadline: deadline,
-                state: IIPAccount(payable(ancestorIpId)).state(),
-                signerSk: sk.admin
-            });
-
-            commRemixTermsIdC = licenseAttachmentWorkflows.registerPILTermsAndAttach({
-                ipId: ancestorIpId,
-                terms: PILFlavors.commercialRemix({
-                    mintingFee: defaultMintingFeeC,
-                    commercialRevShare: defaultCommRevShareC,
-                    royaltyPolicy: address(royaltyPolicyLAP),
-                    currencyToken: address(mockTokenC)
-                }),
-                sigAttach: WorkflowStructs.SignatureData({ signer: u.admin, deadline: deadline, signature: signatureC })
-            });
+            commRemixTermsIdA = licenseTermsIds[0];
+            commRemixTermsIdC = licenseTermsIds[1];
         }
 
         // register childIpA as derivative of ancestorIp under Terms A


### PR DESCRIPTION
## Description
<!-- Add a description of the changes that this PR introduces -->
This PR introduces support for multi-license attachment and the ability to set licensing configurations during IP registration. It also updates the periphery contracts to align with recent protocol core API changes. Furthermore, signature requirements in `LicenseAttachmentWorkflows` have been streamlined using `setBatchPermissions`.

### Key Changes
- Added `PILTermsData` and `LicenseData` in `WorkflowStructs` to consolidate licensing-related parameters.
- Modified `LicenseAttachmentWorkflows` functions to support an array of `PILTermsData` for registering and attaching multiple PIL terms and licensing configurations to IPs.
- Updated `GroupingWorkflows` functions to accept an array of `LicenseData` for attaching multiple licenses (license template, license terms ID, and licensing config) to IPs.
- Simplified signature requirements in `LicenseAttachmentWorkflows`, all functions now require at most one signature.

## Related Issue
<!-- The related Issue section can indicate which issue or task the Pull Request is related with -->
- Closes #119
- Closes #124 
- Closes #129
- Part of #31

## Notes
<!-- The Important Matters section can alert others to special requirements or matters that need extra attention -->
This PR introduces new interface changes. Backward compatibility will be addressed in a future PR (#131).