### PR TITLE
feat: introduce `RoyaltyTokenDistributionWorkflows` to `main` for royalty token distribution upon IP registration  

### DIFF
--- a/contracts/SPGNFT.sol
+++ b/contracts/SPGNFT.sol
@@ -41,16 +41,24 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
     bytes32 private constant SPGNFTStorageLocation = 0x66c08f80d8d0ae818983b725b864514cf274647be6eb06de58ff94d1defb6d00;
 
     /// @dev The address of the DerivativeWorkflows contract.
+       /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     address public immutable DERIVATIVE_WORKFLOWS_ADDRESS;
 
     /// @dev The address of the GroupingWorkflows contract.
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     address public immutable GROUPING_WORKFLOWS_ADDRESS;
 
     /// @dev The address of the LicenseAttachmentWorkflows contract.
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     address public immutable LICENSE_ATTACHMENT_WORKFLOWS_ADDRESS;
 
     /// @dev The address of the RegistrationWorkflows contract.
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     address public immutable REGISTRATION_WORKFLOWS_ADDRESS;
+
+    /// @dev The address of the RoyaltyTokenDistributionWorkflows contract.
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
+    address public immutable ROYALTY_TOKEN_DISTRIBUTION_WORKFLOWS_ADDRESS;
 
     /// @notice Modifier to restrict access to workflow contracts.
     modifier onlyPeriphery() {
@@ -58,7 +66,8 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
             msg.sender != DERIVATIVE_WORKFLOWS_ADDRESS &&
             msg.sender != GROUPING_WORKFLOWS_ADDRESS &&
             msg.sender != LICENSE_ATTACHMENT_WORKFLOWS_ADDRESS &&
-            msg.sender != REGISTRATION_WORKFLOWS_ADDRESS
+            msg.sender != REGISTRATION_WORKFLOWS_ADDRESS &&
+            msg.sender != ROYALTY_TOKEN_DISTRIBUTION_WORKFLOWS_ADDRESS
         ) revert Errors.SPGNFT__CallerNotPeripheryContract();
         _;
     }
@@ -68,20 +77,22 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
         address derivativeWorkflows,
         address groupingWorkflows,
         address licenseAttachmentWorkflows,
-        address registrationWorkflows
+        address registrationWorkflows,
+        address royaltyTokenDistributionWorkflows
     ) {
         if (
             derivativeWorkflows == address(0) ||
             groupingWorkflows == address(0) ||
             licenseAttachmentWorkflows == address(0) ||
-            registrationWorkflows == address(0)
+            registrationWorkflows == address(0) ||
+            royaltyTokenDistributionWorkflows == address(0)
         ) revert Errors.SPGNFT__ZeroAddressParam();
 
         DERIVATIVE_WORKFLOWS_ADDRESS = derivativeWorkflows;
         GROUPING_WORKFLOWS_ADDRESS = groupingWorkflows;
         LICENSE_ATTACHMENT_WORKFLOWS_ADDRESS = licenseAttachmentWorkflows;
         REGISTRATION_WORKFLOWS_ADDRESS = registrationWorkflows;
-
+        ROYALTY_TOKEN_DISTRIBUTION_WORKFLOWS_ADDRESS = royaltyTokenDistributionWorkflows;
         _disableInitializers();
     }
 
@@ -344,6 +355,8 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
         _grantRole(SPGNFTLib.MINTER_ROLE, LICENSE_ATTACHMENT_WORKFLOWS_ADDRESS);
         _grantRole(SPGNFTLib.ADMIN_ROLE, REGISTRATION_WORKFLOWS_ADDRESS);
         _grantRole(SPGNFTLib.MINTER_ROLE, REGISTRATION_WORKFLOWS_ADDRESS);
+        _grantRole(SPGNFTLib.ADMIN_ROLE, ROYALTY_TOKEN_DISTRIBUTION_WORKFLOWS_ADDRESS);
+        _grantRole(SPGNFTLib.MINTER_ROLE, ROYALTY_TOKEN_DISTRIBUTION_WORKFLOWS_ADDRESS);
     }
 
     //

--- a/contracts/SPGNFT.sol
+++ b/contracts/SPGNFT.sol
@@ -41,7 +41,7 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
     bytes32 private constant SPGNFTStorageLocation = 0x66c08f80d8d0ae818983b725b864514cf274647be6eb06de58ff94d1defb6d00;
 
     /// @dev The address of the DerivativeWorkflows contract.
-       /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     address public immutable DERIVATIVE_WORKFLOWS_ADDRESS;
 
     /// @dev The address of the GroupingWorkflows contract.

--- a/contracts/interfaces/workflows/IRoyaltyTokenDistributionWorkflows.sol
+++ b/contracts/interfaces/workflows/IRoyaltyTokenDistributionWorkflows.sol
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+import { WorkflowStructs } from "../../lib/WorkflowStructs.sol";
+
+/// @title Royalty Token Distribution Workflows Interface
+/// @notice Interface for IP royalty token distribution workflows.
+interface IRoyaltyTokenDistributionWorkflows {
+    /// @notice Mint an NFT and register the IP, attach PIL terms, and distribute royalty tokens.
+    /// @param spgNftContract The address of the SPG NFT contract.
+    /// @param recipient The address to receive the NFT.
+    /// @param ipMetadata The metadata for the IP.
+    /// @param licenseTermsData The PIL terms and licensing configuration data to attach to the IP.
+    /// @param royaltyShares Authors of the IP and their shares of the royalty tokens, see {WorkflowStructs.RoyaltyShare}.
+    /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
+    /// @return ipId The ID of the registered IP.
+    /// @return tokenId The ID of the minted NFT.
+    /// @return licenseTermsId The ID of the attached PIL terms.
+    function mintAndRegisterIpAndAttachPILTermsAndDistributeRoyaltyTokens(
+        address spgNftContract,
+        address recipient,
+        WorkflowStructs.IPMetadata calldata ipMetadata,
+        WorkflowStructs.LicenseTermsData calldata licenseTermsData,
+        WorkflowStructs.RoyaltyShare[] calldata royaltyShares,
+        bool allowDuplicates
+    ) external returns (address ipId, uint256 tokenId, uint256 licenseTermsId);
+
+    /// @notice Mint an NFT and register the IP, make a derivative, and distribute royalty tokens.
+    /// @param spgNftContract The address of the SPG NFT contract.
+    /// @param recipient The address to receive the NFT.
+    /// @param ipMetadata The metadata for the IP.
+    /// @param derivData The data for the derivative, see {WorkflowStructs.MakeDerivative}.
+    /// @param royaltyShares Authors of the IP and their shares of the royalty tokens, see {WorkflowStructs.RoyaltyShare}.
+    /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
+    /// @return ipId The ID of the registered IP.
+    /// @return tokenId The ID of the minted NFT.
+    function mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens(
+        address spgNftContract,
+        address recipient,
+        WorkflowStructs.IPMetadata calldata ipMetadata,
+        WorkflowStructs.MakeDerivative calldata derivData,
+        WorkflowStructs.RoyaltyShare[] calldata royaltyShares,
+        bool allowDuplicates
+    ) external returns (address ipId, uint256 tokenId);
+
+    /// @notice Register an IP, attach PIL terms, and deploy a royalty vault.
+    /// @param nftContract The address of the NFT contract.
+    /// @param tokenId The ID of the NFT.
+    /// @param ipMetadata The metadata for the IP.
+    /// @param licenseTermsData The PIL terms and licensing configuration data to attach to the IP.
+    /// @param sigMetadataAndAttachAndConfig Signature data for setAll (metadata), attachLicenseTerms, and
+    /// setLicensingConfig to the IP via the Core Metadata Module and Licensing Module.
+    /// @return ipId The ID of the registered IP.
+    /// @return licenseTermsId The ID of the attached PIL terms.
+    /// @return ipRoyaltyVault The address of the deployed royalty vault.
+    function registerIpAndAttachPILTermsAndDeployRoyaltyVault(
+        address nftContract,
+        uint256 tokenId,
+        WorkflowStructs.IPMetadata calldata ipMetadata,
+        WorkflowStructs.LicenseTermsData calldata licenseTermsData,
+        WorkflowStructs.SignatureData calldata sigMetadataAndAttachAndConfig
+    ) external returns (address ipId, uint256 licenseTermsId, address ipRoyaltyVault);
+
+    /// @notice Register an IP, make a derivative, and deploy a royalty vault.
+    /// @param nftContract The address of the NFT contract.
+    /// @param tokenId The ID of the NFT.
+    /// @param ipMetadata The metadata for the IP.
+    /// @param derivData The data for the derivative, see {WorkflowStructs.MakeDerivative}.
+    /// @param sigMetadataAndRegister Signature data for setAll (metadata) and registerDerivative to the IP via
+    /// the Core Metadata Module and Licensing Module.
+    /// @return ipId The ID of the registered IP.
+    /// @return ipRoyaltyVault The address of the deployed royalty vault.
+    function registerIpAndMakeDerivativeAndDeployRoyaltyVault(
+        address nftContract,
+        uint256 tokenId,
+        WorkflowStructs.IPMetadata calldata ipMetadata,
+        WorkflowStructs.MakeDerivative calldata derivData,
+        WorkflowStructs.SignatureData calldata sigMetadataAndRegister
+    ) external returns (address ipId, address ipRoyaltyVault);
+
+    /// @notice Distribute royalty tokens to the authors of the IP.
+    /// @param ipId The ID of the IP.
+    /// @param royaltyShares Authors of the IP and their shares of the royalty tokens, see {WorkflowStructs.RoyaltyShare}.
+    /// @param sigApproveRoyaltyTokens The signature data for approving the royalty tokens.
+    function distributeRoyaltyTokens(
+        address ipId,
+        WorkflowStructs.RoyaltyShare[] calldata royaltyShares,
+        WorkflowStructs.SignatureData calldata sigApproveRoyaltyTokens
+    ) external;
+}

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -44,8 +44,23 @@ library Errors {
     ////////////////////////////////////////////////////////////////////////////
     //                              Royalty Workflows                         //
     ////////////////////////////////////////////////////////////////////////////
-    /// @notice Zero address provided as a param to the GroupingWorkflows.
+    /// @notice Zero address provided as a param to the RoyaltyWorkflows.
     error RoyaltyWorkflows__ZeroAddressParam();
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                   Royalty Token Distribution Workflows                 //
+    ////////////////////////////////////////////////////////////////////////////
+    /// @notice Zero address provided as a param to the RoyaltyTokenDistributionWorkflows.
+    error RoyaltyTokenDistributionWorkflows__ZeroAddressParam();
+
+    /// @notice Total percentage exceed the current balance of the IP account.
+    error RoyaltyTokenDistributionWorkflows__TotalSharesExceedsIPAccountBalance(
+        uint32 totalShares,
+        uint32 ipAccountBalance
+    );
+
+    /// @notice Royalty vault not deployed.
+    error RoyaltyTokenDistributionWorkflows__RoyaltyVaultNotDeployed();
 
     ////////////////////////////////////////////////////////////////////////////
     //                               SPGNFT                                   //

--- a/contracts/lib/LicensingHelper.sol
+++ b/contracts/lib/LicensingHelper.sol
@@ -93,12 +93,7 @@ library LicensingHelper {
         Licensing.LicensingConfig memory licensingConfig
     ) internal {
         attachLicenseTerms(ipId, licensingModule, licenseTemplate, licenseTermsId);
-        ILicensingModule(licensingModule).setLicensingConfig(
-            ipId,
-            licenseTemplate,
-            licenseTermsId,
-            licensingConfig
-        );
+        ILicensingModule(licensingModule).setLicensingConfig(ipId, licenseTemplate, licenseTermsId, licensingConfig);
     }
 
     /// @dev Collects mint fees and registers a derivative.

--- a/contracts/lib/LicensingHelper.sol
+++ b/contracts/lib/LicensingHelper.sol
@@ -1,16 +1,62 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { Errors as CoreErrors } from "@storyprotocol/core/lib/Errors.sol";
 import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingModule.sol";
+import { ILicenseTemplate } from "@storyprotocol/core/interfaces/modules/licensing/ILicenseTemplate.sol";
 import { IPILicenseTemplate } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
 import { Licensing } from "@storyprotocol/core/lib/Licensing.sol";
+import { PILTerms } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import { WorkflowStructs } from "./WorkflowStructs.sol";
 
 /// @title Periphery Licensing Helper Library
 /// @notice Library for all licensing related helper functions for Periphery contracts.
 library LicensingHelper {
+    using SafeERC20 for IERC20;
+
+    /// @dev Registers PIL License Terms and attaches them to the given IP.
+    /// @param ipId The ID of the IP.
+    /// @param pilTemplate The address of the PIL License Template.
+    /// @param licensingModule The address of the Licensing Module.
+    /// @param terms The PIL terms to be attached to the IP.
+    /// @return licenseTermsId The ID of the registered PIL terms.
+    function registerPILTermsAndAttach(
+        address ipId,
+        address pilTemplate,
+        address licensingModule,
+        PILTerms memory terms
+    ) internal returns (uint256 licenseTermsId) {
+        licenseTermsId = IPILicenseTemplate(pilTemplate).registerLicenseTerms(terms);
+        attachLicenseTerms(ipId, licensingModule, pilTemplate, licenseTermsId);
+    }
+
+    /// @dev Attaches license terms to the given IP, does nothing if the license terms are already attached.
+    /// @param ipId The ID of the IP.
+    /// @param licensingModule The address of the Licensing Module.
+    /// @param licenseTemplate The address of the license template.
+    /// @param licenseTermsId The ID of the license terms to be attached.
+    function attachLicenseTerms(
+        address ipId,
+        address licensingModule,
+        address licenseTemplate,
+        uint256 licenseTermsId
+    ) internal {
+        try ILicensingModule(licensingModule).attachLicenseTerms(ipId, licenseTemplate, licenseTermsId) {
+            // license terms are attached successfully.
+            return;
+        } catch (bytes memory reason) {
+            // if the error is not that the license terms are already attached, revert with the original error
+            if (CoreErrors.LicenseRegistry__LicenseTermsAlreadyAttached.selector != bytes4(reason)) {
+                assembly {
+                    revert(add(reason, 32), mload(reason))
+                }
+            }
+        }
+    }
+
     /// @dev Registers PIL License Terms and attaches them to the given IP and sets their licensing configurations.
     /// @param ipId The ID of the IP.
     /// @param pilTemplate The address of the PIL License Template.
@@ -46,21 +92,110 @@ library LicensingHelper {
         uint256 licenseTermsId,
         Licensing.LicensingConfig memory licensingConfig
     ) internal {
-        try ILicensingModule(licensingModule).attachLicenseTerms(ipId, licenseTemplate, licenseTermsId) {
-            // license terms are attached successfully, now we set the licensing config
-            ILicensingModule(licensingModule).setLicensingConfig(
-                ipId,
-                licenseTemplate,
-                licenseTermsId,
-                licensingConfig
-            );
-        } catch (bytes memory reason) {
-            // if the error is not that the license terms are already attached, revert with the original error
-            if (CoreErrors.LicenseRegistry__LicenseTermsAlreadyAttached.selector != bytes4(reason)) {
-                assembly {
-                    revert(add(reason, 32), mload(reason))
-                }
+        attachLicenseTerms(ipId, licensingModule, licenseTemplate, licenseTermsId);
+        ILicensingModule(licensingModule).setLicensingConfig(
+            ipId,
+            licenseTemplate,
+            licenseTermsId,
+            licensingConfig
+        );
+    }
+
+    /// @dev Collects mint fees and registers a derivative.
+    /// @param childIpId The ID of the child IP.
+    /// @param royaltyModule The address of the Royalty Module.
+    /// @param licensingModule The address of the Licensing Module.
+    /// @param derivData The derivative data to be used for registerDerivative.
+    function collectMintFeesAndMakeDerivative(
+        address childIpId,
+        address royaltyModule,
+        address licensingModule,
+        WorkflowStructs.MakeDerivative calldata derivData
+    ) internal {
+        collectMintFeesAndSetApproval(
+            msg.sender,
+            royaltyModule,
+            licensingModule,
+            derivData.licenseTemplate,
+            derivData.parentIpIds,
+            derivData.licenseTermsIds
+        );
+
+        ILicensingModule(licensingModule).registerDerivative({
+            childIpId: childIpId,
+            parentIpIds: derivData.parentIpIds,
+            licenseTermsIds: derivData.licenseTermsIds,
+            licenseTemplate: derivData.licenseTemplate,
+            royaltyContext: derivData.royaltyContext,
+            maxMintingFee: derivData.maxMintingFee,
+            maxRts: derivData.maxRts
+        });
+    }
+
+    /// @dev Collect mint fees for all parent IPs from the payer and set approval for Royalty Module to spend mint fees.
+    /// @param payerAddress The address of the payer for the license mint fees.
+    /// @param royaltyModule The address of the Royalty Module.
+    /// @param licensingModule The address of the Licensing Module.
+    /// @param licenseTemplate The address of the license template.
+    /// @param parentIpIds The IDs of all the parent IPs.
+    /// @param licenseTermsIds The IDs of the license terms for each corresponding parent IP.
+    function collectMintFeesAndSetApproval(
+        address payerAddress,
+        address royaltyModule,
+        address licensingModule,
+        address licenseTemplate,
+        address[] calldata parentIpIds,
+        uint256[] calldata licenseTermsIds
+    ) private {
+        ILicenseTemplate lct = ILicenseTemplate(licenseTemplate);
+        (address royaltyPolicy, , , address mintFeeCurrencyToken) = lct.getRoyaltyPolicy(licenseTermsIds[0]);
+
+        if (royaltyPolicy != address(0)) {
+            // Get total mint fee for all parent IPs
+            uint256 totalMintFee = aggregateMintFees({
+                payerAddress: payerAddress,
+                licensingModule: licensingModule,
+                licenseTemplate: licenseTemplate,
+                parentIpIds: parentIpIds,
+                licenseTermsIds: licenseTermsIds
+            });
+
+            if (totalMintFee != 0) {
+                // Transfer mint fee from payer to this contract
+                IERC20(mintFeeCurrencyToken).safeTransferFrom(payerAddress, address(this), totalMintFee);
+
+                // Approve Royalty Policy to spend mint fee
+                IERC20(mintFeeCurrencyToken).forceApprove(royaltyModule, totalMintFee);
             }
+        }
+    }
+
+    /// @dev Aggregate license mint fees for all parent IPs.
+    /// @param payerAddress The address of the payer for the license mint fees.
+    /// @param licensingModule The address of the Licensing Module.
+    /// @param licenseTemplate The address of the license template.
+    /// @param parentIpIds The IDs of all the parent IPs.
+    /// @param licenseTermsIds The IDs of the license terms for each corresponding parent IP.
+    /// @return totalMintFee The sum of license mint fees across all parent IPs.
+    function aggregateMintFees(
+        address payerAddress,
+        address licensingModule,
+        address licenseTemplate,
+        address[] calldata parentIpIds,
+        uint256[] calldata licenseTermsIds
+    ) private view returns (uint256 totalMintFee) {
+        uint256 mintFee;
+
+        for (uint256 i = 0; i < parentIpIds.length; i++) {
+            (, mintFee) = ILicensingModule(licensingModule).predictMintingLicenseFee({
+                licensorIpId: parentIpIds[i],
+                licenseTemplate: licenseTemplate,
+                licenseTermsId: licenseTermsIds[i],
+                amount: 1,
+                receiver: payerAddress,
+                royaltyContext: ""
+            });
+            totalMintFee += mintFee;
         }
     }
 }

--- a/contracts/lib/WorkflowStructs.sol
+++ b/contracts/lib/WorkflowStructs.sol
@@ -63,4 +63,12 @@ library WorkflowStructs {
         PILTerms terms;
         Licensing.LicensingConfig licensingConfig;
     }
+
+    /// @notice Struct for royalty shares information for royalty token distribution.
+    /// @param recipient The address of the recipient of the royalty shares.
+    /// @param percentage The percentage of the royalty share, 100_000_000 represents 100%.
+    struct RoyaltyShare {
+        address recipient;
+        uint32 percentage;
+    }
 }

--- a/contracts/workflows/RoyaltyTokenDistributionWorkflows.sol
+++ b/contracts/workflows/RoyaltyTokenDistributionWorkflows.sol
@@ -1,0 +1,452 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+// solhint-disable-next-line max-line-length
+import { AccessManagedUpgradeable } from "@openzeppelin/contracts-upgradeable/access/manager/AccessManagedUpgradeable.sol";
+import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { MulticallUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/MulticallUpgradeable.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
+import { ICoreMetadataModule } from "@storyprotocol/core/interfaces/modules/metadata/ICoreMetadataModule.sol";
+import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
+import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingModule.sol";
+import { IRoyaltyModule } from "@storyprotocol/core/interfaces/modules/royalty/IRoyaltyModule.sol";
+import { Licensing } from "@storyprotocol/core/lib/Licensing.sol";
+import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
+
+import { BaseWorkflow } from "../BaseWorkflow.sol";
+import { Errors } from "../lib/Errors.sol";
+import { IRoyaltyTokenDistributionWorkflows } from "../interfaces/workflows/IRoyaltyTokenDistributionWorkflows.sol";
+import { ISPGNFT } from "../interfaces/ISPGNFT.sol";
+import { LicensingHelper } from "../lib/LicensingHelper.sol";
+import { MetadataHelper } from "../lib/MetadataHelper.sol";
+import { PermissionHelper } from "../lib/PermissionHelper.sol";
+import { WorkflowStructs } from "../lib/WorkflowStructs.sol";
+
+/// @title Royalty Token Distribution Workflows
+/// @notice Each workflow bundles multiple core protocol operations into a single function to enable
+/// royalty token distribution upon IP registration in the Story Proof-of-Creativity Protocol.
+contract RoyaltyTokenDistributionWorkflows is
+    IRoyaltyTokenDistributionWorkflows,
+    BaseWorkflow,
+    MulticallUpgradeable,
+    AccessManagedUpgradeable,
+    UUPSUpgradeable
+{
+    using ERC165Checker for address;
+
+    /// @dev Storage structure for the RoyaltyTokenDistributionWorkflows
+    /// @param nftContractBeacon The address of the NFT contract beacon.
+    /// @custom:storage-location erc7201:story-protocol-periphery.RoyaltyTokenDistributionWorkflows
+    struct RoyaltyTokenDistributionWorkflowsStorage {
+        address nftContractBeacon;
+    }
+
+    // solhint-disable-next-line max-line-length
+    // keccak256(abi.encode(uint256(keccak256("story-protocol-periphery.RoyaltyTokenDistributionWorkflows")) - 1)) & ~bytes32(uint256(0xff));
+    bytes32 private constant RoyaltyTokenDistributionWorkflowsStorageLocation =
+        0x49f5a60a01a4171ac277a9cd523bb469bbf7cf89b7349fb34e8335e241d25600;
+
+    /// @notice The address of the Royalty Module.
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
+    IRoyaltyModule public immutable ROYALTY_MODULE;
+
+    /// @notice The address of the Liquid Absolute Percentage (LAP) Royalty Policy.
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
+    address public immutable ROYALTY_POLICY_LAP;
+
+    /// @notice The address of the Wrapped IP (WIP) token contract.
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
+    address public immutable WIP;
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor(
+        address accessController,
+        address coreMetadataModule,
+        address ipAssetRegistry,
+        address licenseRegistry,
+        address licensingModule,
+        address pilTemplate,
+        address royaltyModule,
+        address royaltyPolicyLAP,
+        address wip
+    )
+        BaseWorkflow(
+            accessController,
+            coreMetadataModule,
+            ipAssetRegistry,
+            licenseRegistry,
+            licensingModule,
+            pilTemplate
+        )
+    {
+        if (
+            accessController == address(0) ||
+            coreMetadataModule == address(0) ||
+            ipAssetRegistry == address(0) ||
+            licenseRegistry == address(0) ||
+            licensingModule == address(0) ||
+            pilTemplate == address(0) ||
+            royaltyModule == address(0) ||
+            royaltyPolicyLAP == address(0) ||
+            wip == address(0)
+        ) revert Errors.RoyaltyTokenDistributionWorkflows__ZeroAddressParam();
+
+        ROYALTY_MODULE = IRoyaltyModule(royaltyModule);
+        ROYALTY_POLICY_LAP = royaltyPolicyLAP;
+        WIP = wip;
+
+        _disableInitializers();
+    }
+
+    /// @dev Initializes the contract.
+    /// @param accessManager The address of the protocol access manager.
+    function initialize(address accessManager) external initializer {
+        if (accessManager == address(0)) revert Errors.RoyaltyTokenDistributionWorkflows__ZeroAddressParam();
+        __AccessManaged_init(accessManager);
+        __UUPSUpgradeable_init();
+    }
+
+    /// @dev Sets the NFT contract beacon address.
+    /// @param newNftContractBeacon The address of the new NFT contract beacon.
+    function setNftContractBeacon(address newNftContractBeacon) external restricted {
+        if (newNftContractBeacon == address(0)) revert Errors.RoyaltyTokenDistributionWorkflows__ZeroAddressParam();
+        RoyaltyTokenDistributionWorkflowsStorage storage $ = _getRoyaltyTokenDistributionWorkflowsStorage();
+        $.nftContractBeacon = newNftContractBeacon;
+    }
+
+    /// @notice Mint an NFT and register the IP, attach PIL terms, and distribute royalty tokens.
+    /// @param spgNftContract The address of the SPG NFT contract.
+    /// @param recipient The address to receive the NFT.
+    /// @param ipMetadata The metadata for the IP.
+    /// @param licenseTermsData The PIL terms and licensing configuration data to attach to the IP.
+    /// @param royaltyShares Authors of the IP and their shares of the royalty tokens, see {WorkflowStructs.RoyaltyShare}.
+    /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
+    /// @return ipId The ID of the registered IP.
+    /// @return tokenId The ID of the minted NFT.
+    /// @return licenseTermsId The ID of the attached PIL terms.
+    function mintAndRegisterIpAndAttachPILTermsAndDistributeRoyaltyTokens(
+        address spgNftContract,
+        address recipient,
+        WorkflowStructs.IPMetadata calldata ipMetadata,
+        WorkflowStructs.LicenseTermsData calldata licenseTermsData,
+        WorkflowStructs.RoyaltyShare[] calldata royaltyShares,
+        bool allowDuplicates
+    ) external onlyMintAuthorized(spgNftContract) returns (address ipId, uint256 tokenId, uint256 licenseTermsId) {
+        tokenId = ISPGNFT(spgNftContract).mintByPeriphery({
+            to: address(this),
+            payer: msg.sender,
+            nftMetadataURI: ipMetadata.nftMetadataURI,
+            nftMetadataHash: ipMetadata.nftMetadataHash,
+            allowDuplicates: allowDuplicates
+        });
+
+        ipId = IP_ASSET_REGISTRY.register(block.chainid, spgNftContract, tokenId);
+        MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);
+
+        licenseTermsId = LicensingHelper.registerPILTermsAndAttachAndSetConfigs({
+            ipId: ipId,
+            pilTemplate: address(PIL_TEMPLATE),
+            licensingModule: address(LICENSING_MODULE),
+            licenseTermsData: licenseTermsData
+        });
+
+        _deployRoyaltyVault(ipId);
+        _distributeRoyaltyTokens({
+            ipId: ipId,
+            royaltyShares: royaltyShares,
+            sigApproveRoyaltyTokens: WorkflowStructs.SignatureData(address(0), 0, "") // no signature required.
+        });
+
+        ISPGNFT(spgNftContract).safeTransferFrom(address(this), recipient, tokenId, "");
+    }
+
+    /// @notice Mint an NFT and register the IP, make a derivative, and distribute royalty tokens.
+    /// @param spgNftContract The address of the SPG NFT contract.
+    /// @param recipient The address to receive the NFT.
+    /// @param ipMetadata The metadata for the IP.
+    /// @param derivData The data for the derivative, see {WorkflowStructs.MakeDerivative}.
+    /// @param royaltyShares Authors of the IP and their shares of the royalty tokens, see {WorkflowStructs.RoyaltyShare}.
+    /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
+    /// @return ipId The ID of the registered IP.
+    /// @return tokenId The ID of the minted NFT.
+    function mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens(
+        address spgNftContract,
+        address recipient,
+        WorkflowStructs.IPMetadata calldata ipMetadata,
+        WorkflowStructs.MakeDerivative calldata derivData,
+        WorkflowStructs.RoyaltyShare[] calldata royaltyShares,
+        bool allowDuplicates
+    ) external onlyMintAuthorized(spgNftContract) returns (address ipId, uint256 tokenId) {
+        tokenId = ISPGNFT(spgNftContract).mintByPeriphery({
+            to: address(this),
+            payer: msg.sender,
+            nftMetadataURI: ipMetadata.nftMetadataURI,
+            nftMetadataHash: ipMetadata.nftMetadataHash,
+            allowDuplicates: allowDuplicates
+        });
+
+        ipId = IP_ASSET_REGISTRY.register(block.chainid, spgNftContract, tokenId);
+
+        MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);
+
+        LicensingHelper.collectMintFeesAndMakeDerivative({
+            childIpId: ipId,
+            royaltyModule: address(ROYALTY_MODULE),
+            licensingModule: address(LICENSING_MODULE),
+            derivData: derivData
+        });
+
+        _deployRoyaltyVault(ipId);
+        _distributeRoyaltyTokens({
+            ipId: ipId,
+            royaltyShares: royaltyShares,
+            sigApproveRoyaltyTokens: WorkflowStructs.SignatureData(address(0), 0, "") // no signature required.
+        });
+
+        ISPGNFT(spgNftContract).safeTransferFrom(address(this), recipient, tokenId, "");
+    }
+
+    /// @notice Register an IP, attach PIL terms, and deploy a royalty vault.
+    /// @param nftContract The address of the NFT contract.
+    /// @param tokenId The ID of the NFT.
+    /// @param ipMetadata The metadata for the IP.
+    /// @param licenseTermsData The PIL terms and licensing configuration data to attach to the IP.
+    /// @param sigMetadataAndAttachAndConfig Signature data for setAll (metadata), attachLicenseTerms, and
+    /// setLicensingConfig to the IP via the Core Metadata Module and Licensing Module.
+    /// @return ipId The ID of the registered IP.
+    /// @return licenseTermsId The ID of the attached PIL terms.
+    /// @return ipRoyaltyVault The address of the deployed royalty vault.
+    function registerIpAndAttachPILTermsAndDeployRoyaltyVault(
+        address nftContract,
+        uint256 tokenId,
+        WorkflowStructs.IPMetadata calldata ipMetadata,
+        WorkflowStructs.LicenseTermsData calldata licenseTermsData,
+        WorkflowStructs.SignatureData calldata sigMetadataAndAttachAndConfig
+    ) external returns (address ipId, uint256 licenseTermsId, address ipRoyaltyVault) {
+        ipId = IP_ASSET_REGISTRY.register(block.chainid, nftContract, tokenId);
+
+        address[] memory modules = new address[](3);
+        bytes4[] memory selectors = new bytes4[](3);
+        modules[0] = address(CORE_METADATA_MODULE);
+        modules[1] = address(LICENSING_MODULE);
+        modules[2] = address(LICENSING_MODULE);
+        selectors[0] = ICoreMetadataModule.setAll.selector;
+        selectors[1] = ILicensingModule.attachLicenseTerms.selector;
+        selectors[2] = ILicensingModule.setLicensingConfig.selector;
+        PermissionHelper.setBatchPermissionForModules({
+            ipId: ipId,
+            accessController: address(ACCESS_CONTROLLER),
+            modules: modules,
+            selectors: selectors,
+            sigData: sigMetadataAndAttachAndConfig
+        });
+
+        MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);
+
+        licenseTermsId = LicensingHelper.registerPILTermsAndAttachAndSetConfigs({
+            ipId: ipId,
+            pilTemplate: address(PIL_TEMPLATE),
+            licensingModule: address(LICENSING_MODULE),
+            licenseTermsData: licenseTermsData
+        });
+
+        ipRoyaltyVault = _deployRoyaltyVault(ipId);
+    }
+
+    /// @notice Register an IP, make a derivative, and deploy a royalty vault.
+    /// @param nftContract The address of the NFT contract.
+    /// @param tokenId The ID of the NFT.
+    /// @param ipMetadata The metadata for the IP.
+    /// @param derivData The data for the derivative, see {WorkflowStructs.MakeDerivative}.
+    /// @param sigMetadataAndRegister Signature data for setAll (metadata) and registerDerivative to the IP via
+    /// the Core Metadata Module and Licensing Module.
+    /// @return ipId The ID of the registered IP.
+    /// @return ipRoyaltyVault The address of the deployed royalty vault.
+    function registerIpAndMakeDerivativeAndDeployRoyaltyVault(
+        address nftContract,
+        uint256 tokenId,
+        WorkflowStructs.IPMetadata calldata ipMetadata,
+        WorkflowStructs.MakeDerivative calldata derivData,
+        WorkflowStructs.SignatureData calldata sigMetadataAndRegister
+    ) external returns (address ipId, address ipRoyaltyVault) {
+        ipId = IP_ASSET_REGISTRY.register(block.chainid, nftContract, tokenId);
+
+        address[] memory modules = new address[](2);
+        bytes4[] memory selectors = new bytes4[](2);
+        modules[0] = address(CORE_METADATA_MODULE);
+        modules[1] = address(LICENSING_MODULE);
+        selectors[0] = ICoreMetadataModule.setAll.selector;
+        selectors[1] = ILicensingModule.registerDerivative.selector;
+        PermissionHelper.setBatchPermissionForModules({
+            ipId: ipId,
+            accessController: address(ACCESS_CONTROLLER),
+            modules: modules,
+            selectors: selectors,
+            sigData: sigMetadataAndRegister
+        });
+
+        MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);
+
+        LicensingHelper.collectMintFeesAndMakeDerivative({
+            childIpId: ipId,
+            royaltyModule: address(ROYALTY_MODULE),
+            licensingModule: address(LICENSING_MODULE),
+            derivData: derivData
+        });
+
+        ipRoyaltyVault = _deployRoyaltyVault(ipId);
+    }
+
+    /// @notice Distribute royalty tokens to the authors of the IP.
+    /// @param ipId The ID of the IP.
+    /// @param royaltyShares Authors of the IP and their shares of the royalty tokens, see {WorkflowStructs.RoyaltyShare}.
+    /// @param sigApproveRoyaltyTokens The signature data for approving the royalty tokens.
+    function distributeRoyaltyTokens(
+        address ipId,
+        WorkflowStructs.RoyaltyShare[] calldata royaltyShares,
+        WorkflowStructs.SignatureData calldata sigApproveRoyaltyTokens
+    ) external {
+        _distributeRoyaltyTokens(ipId, royaltyShares, sigApproveRoyaltyTokens);
+    }
+
+    /// @dev Deploys a royalty vault for the IP.
+    /// @param ipId The ID of the IP.
+    /// @return ipRoyaltyVault The address of the deployed royalty vault.
+    function _deployRoyaltyVault(
+        address ipId
+    ) internal returns (address ipRoyaltyVault) {
+        if (ROYALTY_MODULE.ipRoyaltyVaults(ipId) == address(0)) {
+            // attach a temporary commercial license to the IP for the royalty vault deployment
+            uint256 licenseTermsId = LicensingHelper.registerPILTermsAndAttach({
+                ipId: ipId,
+                pilTemplate: address(PIL_TEMPLATE),
+                licensingModule: address(LICENSING_MODULE),
+                terms: PILFlavors.commercialUse({
+                    mintingFee: 0,
+                    currencyToken: WIP,
+                    royaltyPolicy: ROYALTY_POLICY_LAP
+                })
+            });
+
+            uint256[] memory licenseTermsIds = new uint256[](1);
+            licenseTermsIds[0] = licenseTermsId;
+
+            // mint a license token to trigger the royalty vault deployment
+            LICENSING_MODULE.mintLicenseTokens({
+                licensorIpId: ipId,
+                licenseTemplate: address(PIL_TEMPLATE),
+                licenseTermsId: licenseTermsId,
+                amount: 1,
+                receiver: msg.sender,
+                royaltyContext: "",
+                maxMintingFee: 0
+            });
+
+            // set the licensing configuration to disable the temporary license
+            LICENSING_MODULE.setLicensingConfig({
+                ipId: ipId,
+                licenseTemplate: address(PIL_TEMPLATE),
+                licenseTermsId: licenseTermsId,
+                licensingConfig: Licensing.LicensingConfig({
+                    isSet: true,
+                    mintingFee: 0,
+                    licensingHook: address(0),
+                    hookData: "",
+                    commercialRevShare: 0,
+                    disabled: true,
+                    expectMinimumGroupRewardShare: 0,
+                    expectGroupRewardPool: address(0)
+                })
+            });
+        }
+
+        ipRoyaltyVault = ROYALTY_MODULE.ipRoyaltyVaults(ipId);
+        if (ipRoyaltyVault == address(0)) revert Errors.RoyaltyTokenDistributionWorkflows__RoyaltyVaultNotDeployed();
+    }
+
+    /// @dev Distributes royalty tokens to the authors of the IP.
+    /// @param ipId The ID of the IP.
+    /// @param royaltyShares Authors of the IP and their shares of the royalty tokens, see {WorkflowStructs.RoyaltyShare}.
+    /// @param sigApproveRoyaltyTokens The signature data for approving the royalty tokens.
+    function _distributeRoyaltyTokens(
+        address ipId,
+        WorkflowStructs.RoyaltyShare[] memory royaltyShares,
+        WorkflowStructs.SignatureData memory sigApproveRoyaltyTokens
+    ) internal {
+        address ipRoyaltyVault = ROYALTY_MODULE.ipRoyaltyVaults(ipId);
+        if (ipRoyaltyVault == address(0)) revert Errors.RoyaltyTokenDistributionWorkflows__RoyaltyVaultNotDeployed();
+
+        uint32 totalPercentages = _validateRoyaltyShares(ipId, ipRoyaltyVault, royaltyShares);
+
+        if (sigApproveRoyaltyTokens.signature.length > 0) {
+            IIPAccount(payable(ipId)).executeWithSig({
+                to: ipRoyaltyVault,
+                value: 0,
+                data: abi.encodeWithSelector(IERC20.approve.selector, address(this), uint256(totalPercentages)),
+                signer: sigApproveRoyaltyTokens.signer,
+                deadline: sigApproveRoyaltyTokens.deadline,
+                signature: sigApproveRoyaltyTokens.signature
+            });
+        } else {
+            IIPAccount(payable(ipId)).execute({
+                to: ipRoyaltyVault,
+                value: 0,
+                data: abi.encodeWithSelector(IERC20.approve.selector, address(this), uint256(totalPercentages))
+            });
+        }
+
+        // distribute the royalty tokens
+        for (uint256 i; i < royaltyShares.length; i++) {
+            IERC20(ipRoyaltyVault).transferFrom({
+                from: ipId,
+                to: royaltyShares[i].recipient,
+                value: royaltyShares[i].percentage
+            });
+        }
+    }
+
+    /// @dev Validates the royalty shares.
+    /// @param ipId The ID of the IP.
+    /// @param ipRoyaltyVault The address of the royalty vault.
+    /// @param royaltyShares Authors of the IP and their shares of the royalty tokens, see {WorkflowStructs.RoyaltyShare}.
+    /// @return totalPercentages The total percentages of the royalty shares.
+    function _validateRoyaltyShares(
+        address ipId,
+        address ipRoyaltyVault,
+        WorkflowStructs.RoyaltyShare[] memory royaltyShares
+    ) internal returns (uint32 totalPercentages) {
+        for (uint256 i; i < royaltyShares.length; i++) {
+            totalPercentages += royaltyShares[i].percentage;
+        }
+
+        uint32 ipRoyaltyVaultBalance = uint32(IERC20(ipRoyaltyVault).balanceOf(ipId));
+        if (totalPercentages > ipRoyaltyVaultBalance)
+            revert Errors.RoyaltyTokenDistributionWorkflows__TotalSharesExceedsIPAccountBalance(
+                totalPercentages,
+                ipRoyaltyVaultBalance
+            );
+
+        return totalPercentages;
+    }
+
+    //
+    // Upgrade
+    //
+
+    /// @dev Returns the storage struct of RoyaltyTokenDistributionWorkflows.
+    function _getRoyaltyTokenDistributionWorkflowsStorage()
+        private
+        pure
+        returns (RoyaltyTokenDistributionWorkflowsStorage storage $)
+    {
+        assembly {
+            $.slot := RoyaltyTokenDistributionWorkflowsStorageLocation
+        }
+    }
+
+    /// @dev Hook to authorize the upgrade according to UUPSUpgradeable
+    /// @param newImplementation The address of the new implementation
+    function _authorizeUpgrade(address newImplementation) internal override restricted {}
+}

--- a/contracts/workflows/RoyaltyTokenDistributionWorkflows.sol
+++ b/contracts/workflows/RoyaltyTokenDistributionWorkflows.sol
@@ -314,9 +314,7 @@ contract RoyaltyTokenDistributionWorkflows is
     /// @dev Deploys a royalty vault for the IP.
     /// @param ipId The ID of the IP.
     /// @return ipRoyaltyVault The address of the deployed royalty vault.
-    function _deployRoyaltyVault(
-        address ipId
-    ) internal returns (address ipRoyaltyVault) {
+    function _deployRoyaltyVault(address ipId) internal returns (address ipRoyaltyVault) {
         if (ROYALTY_MODULE.ipRoyaltyVaults(ipId) == address(0)) {
             // attach a temporary commercial license to the IP for the royalty vault deployment
             uint256 licenseTermsId = LicensingHelper.registerPILTermsAndAttach({

--- a/script/upgrade/UpgradeSPGNFT.s.sol
+++ b/script/upgrade/UpgradeSPGNFT.s.sol
@@ -36,7 +36,8 @@ contract UpgradeSPGNFT is UpgradeHelper {
             address(derivativeWorkflows),
             address(groupingWorkflows),
             address(licenseAttachmentWorkflows),
-            address(registrationWorkflows)
+            address(registrationWorkflows),
+            address(royaltyTokenDistributionWorkflows)
         );
         spgNftImplAddr = address(spgNftImpl);
         console2.log("SPGNFTImpl deployed to: ", spgNftImplAddr);

--- a/script/utils/StoryProtocolCoreAddressManager.sol
+++ b/script/utils/StoryProtocolCoreAddressManager.sol
@@ -22,6 +22,7 @@ contract StoryProtocolCoreAddressManager is Script {
     address internal royaltyPolicyLAPAddr;
     address internal royaltyPolicyLRPAddr;
     address internal evenSplitGroupPoolAddr;
+    address internal wipAddr;
 
     function _readStoryProtocolCoreAddresses() internal {
         string memory root = vm.projectRoot();
@@ -51,5 +52,6 @@ contract StoryProtocolCoreAddressManager is Script {
         royaltyPolicyLAPAddr = json.readAddress(".main.RoyaltyPolicyLAP");
         royaltyPolicyLRPAddr = json.readAddress(".main.RoyaltyPolicyLRP");
         evenSplitGroupPoolAddr = json.readAddress(".main.EvenSplitGroupPool");
+        wipAddr = json.readAddress(".main.WIP");
     }
 }

--- a/script/utils/StoryProtocolPeripheryAddressManager.sol
+++ b/script/utils/StoryProtocolPeripheryAddressManager.sol
@@ -12,6 +12,7 @@ contract StoryProtocolPeripheryAddressManager is Script {
     address internal licenseAttachmentWorkflowsAddr;
     address internal registrationWorkflowsAddr;
     address internal royaltyWorkflowsAddr;
+    address internal royaltyTokenDistributionWorkflowsAddr;
     address internal spgNftBeaconAddr;
     address internal spgNftImplAddr;
     address internal defaultOrgStoryNftTemplateAddr;
@@ -31,6 +32,7 @@ contract StoryProtocolPeripheryAddressManager is Script {
         licenseAttachmentWorkflowsAddr = json.readAddress(".main.LicenseAttachmentWorkflows");
         registrationWorkflowsAddr = json.readAddress(".main.RegistrationWorkflows");
         royaltyWorkflowsAddr = json.readAddress(".main.RoyaltyWorkflows");
+        royaltyTokenDistributionWorkflowsAddr = json.readAddress(".main.RoyaltyTokenDistributionWorkflows");
         spgNftBeaconAddr = json.readAddress(".main.SPGNFTBeacon");
         spgNftImplAddr = json.readAddress(".main.SPGNFTImpl");
         defaultOrgStoryNftTemplateAddr = json.readAddress(".main.DefaultOrgStoryNFTTemplate");

--- a/script/utils/upgrades/UpgradeHelper.s.sol
+++ b/script/utils/upgrades/UpgradeHelper.s.sol
@@ -13,6 +13,7 @@ import { GroupingWorkflows } from "../../../contracts/workflows/GroupingWorkflow
 import { LicenseAttachmentWorkflows } from "../../../contracts/workflows/LicenseAttachmentWorkflows.sol";
 import { RegistrationWorkflows } from "../../../contracts/workflows/RegistrationWorkflows.sol";
 import { RoyaltyWorkflows } from "../../../contracts/workflows/RoyaltyWorkflows.sol";
+import { RoyaltyTokenDistributionWorkflows } from "../../../contracts/workflows/RoyaltyTokenDistributionWorkflows.sol";
 import { SPGNFT } from "../../../contracts/SPGNFT.sol";
 
 // script
@@ -37,6 +38,7 @@ contract UpgradeHelper is
     LicenseAttachmentWorkflows internal licenseAttachmentWorkflows;
     RegistrationWorkflows internal registrationWorkflows;
     RoyaltyWorkflows internal royaltyWorkflows;
+    RoyaltyTokenDistributionWorkflows internal royaltyTokenDistributionWorkflows;
 
     /// @dev SPGNFT contracts
     SPGNFT internal spgNftImpl;
@@ -53,6 +55,9 @@ contract UpgradeHelper is
         licenseAttachmentWorkflows = LicenseAttachmentWorkflows(licenseAttachmentWorkflowsAddr);
         registrationWorkflows = RegistrationWorkflows(registrationWorkflowsAddr);
         royaltyWorkflows = RoyaltyWorkflows(royaltyWorkflowsAddr);
+        royaltyTokenDistributionWorkflows = RoyaltyTokenDistributionWorkflows(
+            royaltyTokenDistributionWorkflowsAddr
+        );
 
         spgNftImpl = SPGNFT(spgNftImplAddr);
         spgNftBeacon = UpgradeableBeacon(spgNftBeaconAddr);
@@ -68,31 +73,33 @@ contract UpgradeHelper is
     }
 
     function _writeAllAddresses() internal {
-        string[] memory contractKeys = new string[](11);
+        string[] memory contractKeys = new string[](12);
         contractKeys[0] = "DerivativeWorkflows";
         contractKeys[1] = "GroupingWorkflows";
         contractKeys[2] = "LicenseAttachmentWorkflows";
         contractKeys[3] = "RegistrationWorkflows";
         contractKeys[4] = "RoyaltyWorkflows";
-        contractKeys[5] = "SPGNFTBeacon";
-        contractKeys[6] = "SPGNFTImpl";
-        contractKeys[7] = "DefaultOrgStoryNFTTemplate";
-        contractKeys[8] = "DefaultOrgStoryNFTBeacon";
-        contractKeys[9] = "OrgNFT";
-        contractKeys[10] = "OrgStoryNFTFactory";
+        contractKeys[5] = "RoyaltyTokenDistributionWorkflows";
+        contractKeys[6] = "SPGNFTBeacon";
+        contractKeys[7] = "SPGNFTImpl";
+        contractKeys[8] = "DefaultOrgStoryNFTTemplate";
+        contractKeys[9] = "DefaultOrgStoryNFTBeacon";
+        contractKeys[10] = "OrgNFT";
+        contractKeys[11] = "OrgStoryNFTFactory";
 
-        address[] memory addresses = new address[](11);
+        address[] memory addresses = new address[](12);
         addresses[0] = derivativeWorkflowsAddr;
         addresses[1] = groupingWorkflowsAddr;
         addresses[2] = licenseAttachmentWorkflowsAddr;
         addresses[3] = registrationWorkflowsAddr;
         addresses[4] = royaltyWorkflowsAddr;
-        addresses[5] = spgNftBeaconAddr;
-        addresses[6] = spgNftImplAddr;
-        addresses[7] = defaultOrgStoryNftTemplateAddr;
-        addresses[8] = defaultOrgStoryNftBeaconAddr;
-        addresses[9] = orgNftAddr;
-        addresses[10] = orgStoryNftFactoryAddr;
+        addresses[5] = royaltyTokenDistributionWorkflowsAddr;
+        addresses[6] = spgNftBeaconAddr;
+        addresses[7] = spgNftImplAddr;
+        addresses[8] = defaultOrgStoryNftTemplateAddr;
+        addresses[9] = defaultOrgStoryNftBeaconAddr;
+        addresses[10] = orgNftAddr;
+        addresses[11] = orgStoryNftFactoryAddr;
 
         for (uint256 i = 0; i < contractKeys.length; i++) {
             _writeAddress(contractKeys[i], addresses[i]);

--- a/test/SPGNFT.t.sol
+++ b/test/SPGNFT.t.sol
@@ -47,7 +47,8 @@ contract SPGNFTTest is BaseTest {
                 address(derivativeWorkflows),
                 address(groupingWorkflows),
                 address(licenseAttachmentWorkflows),
-                address(registrationWorkflows)
+                address(registrationWorkflows),
+                address(royaltyTokenDistributionWorkflows)
             )
         );
         address NFT_CONTRACT_BEACON = address(new UpgradeableBeacon(testSpgNftImpl, deployer));
@@ -88,7 +89,8 @@ contract SPGNFTTest is BaseTest {
                 address(derivativeWorkflows),
                 address(groupingWorkflows),
                 address(licenseAttachmentWorkflows),
-                address(registrationWorkflows)
+                address(registrationWorkflows),
+                address(royaltyTokenDistributionWorkflows)
             )
         );
         address NFT_CONTRACT_BEACON = address(new UpgradeableBeacon(testSpgNftImpl, deployer));

--- a/test/utils/BaseTest.t.sol
+++ b/test/utils/BaseTest.t.sol
@@ -119,6 +119,7 @@ contract BaseTest is Test, DeployHelper {
         groupingWorkflows.setNftContractBeacon(address(spgNftBeacon));
         licenseAttachmentWorkflows.setNftContractBeacon(address(spgNftBeacon));
         registrationWorkflows.setNftContractBeacon(address(spgNftBeacon));
+        royaltyTokenDistributionWorkflows.setNftContractBeacon(address(spgNftBeacon));
         vm.stopPrank();
     }
 
@@ -279,6 +280,32 @@ contract BaseTest is Test, DeployHelper {
     /*//////////////////////////////////////////////////////////////////////////
                                       HELPERS
     //////////////////////////////////////////////////////////////////////////*/
+    /// @dev Get the permission list for setting metadata and registering a derivative for the IP.
+    /// @param ipId The ID of the IP that the permissions are for.
+    /// @param to The address of the periphery contract to receive the permission.
+    /// @return permissionList The list of permissions for setting metadata and registering a derivative.
+    function _getMetadataAndDerivativeRegistrationPermissionList(
+        address ipId,
+        address to
+    ) internal view returns (AccessPermission.Permission[] memory permissionList) {
+        address[] memory modules = new address[](2);
+        bytes4[] memory selectors = new bytes4[](2);
+        permissionList = new AccessPermission.Permission[](2);
+        modules[0] = coreMetadataModuleAddr;
+        modules[1] = licensingModuleAddr;
+        selectors[0] = ICoreMetadataModule.setAll.selector;
+        selectors[1] = ILicensingModule.registerDerivative.selector;
+        for (uint256 i = 0; i < 2; i++) {
+            permissionList[i] = AccessPermission.Permission({
+                ipAccount: ipId,
+                signer: to,
+                to: modules[i],
+                func: selectors[i],
+                permission: AccessPermission.ALLOW
+            });
+        }
+    }
+
     /// @dev Get the permission list for attaching license terms and setting licensing config for the IP.
     /// @param ipId The ID of the IP that the permissions are for.
     /// @param to The address of the periphery contract to receive the permission.

--- a/test/workflows/LicenseAttachmentWorkflows.t.sol
+++ b/test/workflows/LicenseAttachmentWorkflows.t.sol
@@ -303,6 +303,22 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
             assertEq(licenseTemplate, address(pilTemplate));
             assertEq(licenseTermsId, licenseTermsIds[i]);
             assertEq(pilTemplate.getLicenseTermsId(commTermsData[i].terms), licenseTermsIds[i]);
+            Licensing.LicensingConfig memory licensingConfig = licenseRegistry.getLicensingConfig(
+                ipId,
+                licenseTemplate,
+                licenseTermsId
+            );
+            assertEq(licensingConfig.isSet, commTermsData[i].licensingConfig.isSet);
+            assertEq(licensingConfig.mintingFee, commTermsData[i].licensingConfig.mintingFee);
+            assertEq(licensingConfig.licensingHook, commTermsData[i].licensingConfig.licensingHook);
+            assertEq(licensingConfig.hookData, commTermsData[i].licensingConfig.hookData);
+            assertEq(licensingConfig.commercialRevShare, commTermsData[i].licensingConfig.commercialRevShare);
+            assertEq(licensingConfig.disabled, commTermsData[i].licensingConfig.disabled);
+            assertEq(licensingConfig.expectGroupRewardPool, commTermsData[i].licensingConfig.expectGroupRewardPool);
+            assertEq(
+                licensingConfig.expectMinimumGroupRewardShare,
+                commTermsData[i].licensingConfig.expectMinimumGroupRewardShare
+            );
         }
     }
 
@@ -337,7 +353,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
                     royaltyPolicy: address(royaltyPolicyLRP)
                 }),
                 licensingConfig: Licensing.LicensingConfig({
-                    isSet: false,
+                    isSet: true,
                     mintingFee: testMintFee,
                     licensingHook: address(0),
                     hookData: "",

--- a/test/workflows/RoyaltyTokenDistributionWorkflows.t.sol
+++ b/test/workflows/RoyaltyTokenDistributionWorkflows.t.sol
@@ -130,7 +130,6 @@ contract RoyaltyTokenDistributionWorkflowsTest is BaseTest {
             });
         vm.stopPrank();
 
-
         (bytes memory signatureApproveRoyaltyTokens, ) = _getSigForExecuteWithSig({
             ipId: ipId,
             to: ipRoyaltyVault,
@@ -352,10 +351,7 @@ contract RoyaltyTokenDistributionWorkflowsTest is BaseTest {
     }
 
     function _assertAttachedLicenseTerms(address ipId, uint256 licenseTermsId) private {
-        (address licenseTemplate, uint256 licenseTermsIdAttached) = licenseRegistry.getAttachedLicenseTerms(
-            ipId,
-            0
-        );
+        (address licenseTemplate, uint256 licenseTermsIdAttached) = licenseRegistry.getAttachedLicenseTerms(ipId, 0);
         assertEq(licenseTermsId, licenseTermsIdAttached);
         assertEq(licenseTemplate, address(pilTemplate));
         assertEq(licenseTermsIdAttached, pilTemplate.getLicenseTermsId(commRemixTermsData.terms));

--- a/test/workflows/RoyaltyTokenDistributionWorkflows.t.sol
+++ b/test/workflows/RoyaltyTokenDistributionWorkflows.t.sol
@@ -1,0 +1,430 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
+
+// external
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
+import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
+import { Licensing } from "@storyprotocol/core/lib/Licensing.sol";
+import { MetaTx } from "@storyprotocol/core/lib/MetaTx.sol";
+import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
+
+// contracts
+import { Errors } from "../../contracts/lib/Errors.sol";
+import { WorkflowStructs } from "../../contracts/lib/WorkflowStructs.sol";
+
+// test
+import { BaseTest } from "../utils/BaseTest.t.sol";
+
+contract RoyaltyTokenDistributionWorkflowsTest is BaseTest {
+    using Strings for uint256;
+    using MessageHashUtils for bytes32;
+
+    uint256 private nftMintingFee;
+    uint256 private licenseMintingFee;
+
+    WorkflowStructs.LicenseTermsData private commRemixTermsData;
+    WorkflowStructs.RoyaltyShare[] private royaltyShares;
+    WorkflowStructs.MakeDerivative private derivativeData;
+
+    function setUp() public override {
+        super.setUp();
+        _setUpTest();
+    }
+
+    function test_RoyaltyTokenDistributionWorkflows_mintAndRegisterIpAndAttachPILTermsAndDistributeRoyaltyTokens()
+        public
+    {
+        vm.startPrank(u.alice);
+        mockToken.mint(u.alice, nftMintingFee);
+        mockToken.approve(address(spgNftPublic), nftMintingFee);
+
+        (address ipId, uint256 tokenId, uint256 licenseTermsId) = royaltyTokenDistributionWorkflows
+            .mintAndRegisterIpAndAttachPILTermsAndDistributeRoyaltyTokens({
+                spgNftContract: address(spgNftPublic),
+                recipient: u.alice,
+                ipMetadata: ipMetadataDefault,
+                licenseTermsData: commRemixTermsData,
+                royaltyShares: royaltyShares,
+                allowDuplicates: true
+            });
+        vm.stopPrank();
+
+        assertTrue(ipAssetRegistry.isRegistered(ipId));
+        assertEq(tokenId, 2);
+        assertEq(spgNftPublic.tokenURI(tokenId), string.concat(testBaseURI, ipMetadataDefault.nftMetadataURI));
+        assertMetadata(ipId, ipMetadataDefault);
+        _assertAttachedLicenseTerms(ipId, licenseTermsId);
+        _assertRoyaltyTokenDistribution(ipId);
+    }
+
+    function test_RoyaltyTokenDistributionWorkflows_mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens()
+        public
+    {
+        vm.startPrank(u.alice);
+        mockToken.mint(u.alice, nftMintingFee + licenseMintingFee);
+        mockToken.approve(address(spgNftPublic), nftMintingFee);
+        mockToken.approve(address(royaltyTokenDistributionWorkflows), licenseMintingFee);
+
+        (address ipId, uint256 tokenId) = royaltyTokenDistributionWorkflows
+            .mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens({
+                spgNftContract: address(spgNftPublic),
+                recipient: u.alice,
+                ipMetadata: ipMetadataDefault,
+                derivData: derivativeData,
+                royaltyShares: royaltyShares,
+                allowDuplicates: true
+            });
+        vm.stopPrank();
+
+        assertEq(tokenId, 2);
+        assertEq(spgNftPublic.tokenURI(tokenId), string.concat(testBaseURI, ipMetadataDefault.nftMetadataURI));
+        assertEq(ipAssetRegistry.ipId(block.chainid, address(spgNftPublic), tokenId), ipId);
+        assertMetadata(ipId, ipMetadataDefault);
+        assertParentChild({
+            parentIpId: derivativeData.parentIpIds[0],
+            childIpId: ipId,
+            expectedParentCount: 1,
+            expectedParentIndex: 0
+        });
+        (address licenseTemplateAttached, uint256 licenseTermsIdAttached) = licenseRegistry.getAttachedLicenseTerms(
+            ipId,
+            0
+        );
+        assertEq(licenseTemplateAttached, address(pilTemplate));
+        assertEq(licenseTermsIdAttached, derivativeData.licenseTermsIds[0]);
+        _assertRoyaltyTokenDistribution(ipId);
+    }
+
+    function test_RoyaltyTokenDistributionWorkflows_registerIpAndAttachPILTermsAndDistributeRoyaltyTokens() public {
+        uint256 tokenId = mockNft.mint(u.alice);
+        address expectedIpId = ipAssetRegistry.ipId(block.chainid, address(mockNft), tokenId);
+
+        uint256 deadline = block.timestamp + 1000;
+
+        (bytes memory signatureMetadataAndAttachAndConfig, , ) = _getSetBatchPermissionSigForPeriphery({
+            ipId: expectedIpId,
+            permissionList: _getMetadataAndAttachTermsAndConfigPermissionList(
+                expectedIpId,
+                address(royaltyTokenDistributionWorkflows)
+            ),
+            deadline: deadline,
+            state: bytes32(0),
+            signerSk: sk.alice
+        });
+
+        // register IP, attach PIL terms, and deploy royalty vault
+        vm.startPrank(u.alice);
+        (address ipId, uint256 licenseTermsId, address ipRoyaltyVault) = royaltyTokenDistributionWorkflows
+            .registerIpAndAttachPILTermsAndDeployRoyaltyVault({
+                nftContract: address(mockNft),
+                tokenId: tokenId,
+                ipMetadata: ipMetadataDefault,
+                licenseTermsData: commRemixTermsData,
+                sigMetadataAndAttachAndConfig: WorkflowStructs.SignatureData({
+                    signer: u.alice,
+                    deadline: deadline,
+                    signature: signatureMetadataAndAttachAndConfig
+                })
+            });
+        vm.stopPrank();
+
+
+        (bytes memory signatureApproveRoyaltyTokens, ) = _getSigForExecuteWithSig({
+            ipId: ipId,
+            to: ipRoyaltyVault,
+            deadline: deadline,
+            state: IIPAccount(payable(ipId)).state(),
+            data: abi.encodeWithSelector(
+                IERC20.approve.selector,
+                address(royaltyTokenDistributionWorkflows),
+                95_000_000 // 95%
+            ),
+            signerSk: sk.alice
+        });
+
+        vm.startPrank(u.alice);
+        // distribute royalty tokens
+        royaltyTokenDistributionWorkflows.distributeRoyaltyTokens({
+            ipId: ipId,
+            royaltyShares: royaltyShares,
+            sigApproveRoyaltyTokens: WorkflowStructs.SignatureData({
+                signer: u.alice,
+                deadline: deadline,
+                signature: signatureApproveRoyaltyTokens
+            })
+        });
+        vm.stopPrank();
+
+        assertTrue(ipAssetRegistry.isRegistered(ipId));
+        assertMetadata(ipId, ipMetadataDefault);
+        _assertAttachedLicenseTerms(ipId, licenseTermsId);
+        _assertRoyaltyTokenDistribution(ipId);
+    }
+
+    function test_RoyaltyTokenDistributionWorkflows_registerIpAndMakeDerivativeAndDistributeRoyaltyTokens() public {
+        uint256 tokenId = mockNft.mint(u.alice);
+        address expectedIpId = ipAssetRegistry.ipId(block.chainid, address(mockNft), tokenId);
+
+        uint256 deadline = block.timestamp + 1000;
+
+        (bytes memory signatureMetadataAndRegister, , ) = _getSetBatchPermissionSigForPeriphery({
+            ipId: expectedIpId,
+            permissionList: _getMetadataAndDerivativeRegistrationPermissionList(
+                expectedIpId,
+                address(royaltyTokenDistributionWorkflows)
+            ),
+            deadline: deadline,
+            state: bytes32(0),
+            signerSk: sk.alice
+        });
+
+        // register IP, make derivative, and deploy royalty vault
+        vm.startPrank(u.alice);
+        mockToken.mint(u.alice, licenseMintingFee);
+        mockToken.approve(address(royaltyTokenDistributionWorkflows), licenseMintingFee);
+        (address ipId, address ipRoyaltyVault) = royaltyTokenDistributionWorkflows
+            .registerIpAndMakeDerivativeAndDeployRoyaltyVault({
+                nftContract: address(mockNft),
+                tokenId: tokenId,
+                ipMetadata: ipMetadataDefault,
+                derivData: derivativeData,
+                sigMetadataAndRegister: WorkflowStructs.SignatureData({
+                    signer: u.alice,
+                    deadline: deadline,
+                    signature: signatureMetadataAndRegister
+                })
+            });
+        vm.stopPrank();
+
+        // get signature for approving royalty tokens
+        (bytes memory signatureApproveRoyaltyTokens, ) = _getSigForExecuteWithSig({
+            ipId: ipId,
+            to: ipRoyaltyVault,
+            deadline: deadline,
+            state: IIPAccount(payable(ipId)).state(),
+            data: abi.encodeWithSelector(
+                IERC20.approve.selector,
+                address(royaltyTokenDistributionWorkflows),
+                95_000_000 // 95%
+            ),
+            signerSk: sk.alice
+        });
+
+        vm.startPrank(u.alice);
+        // distribute royalty tokens
+        royaltyTokenDistributionWorkflows.distributeRoyaltyTokens({
+            ipId: ipId,
+            royaltyShares: royaltyShares,
+            sigApproveRoyaltyTokens: WorkflowStructs.SignatureData({
+                signer: u.alice,
+                deadline: deadline,
+                signature: signatureApproveRoyaltyTokens
+            })
+        });
+        vm.stopPrank();
+
+        assertEq(ipAssetRegistry.ipId(block.chainid, address(mockNft), tokenId), ipId);
+        assertMetadata(ipId, ipMetadataDefault);
+        assertParentChild({
+            parentIpId: derivativeData.parentIpIds[0],
+            childIpId: ipId,
+            expectedParentCount: 1,
+            expectedParentIndex: 0
+        });
+        (address licenseTemplateAttached, uint256 licenseTermsIdAttached) = licenseRegistry.getAttachedLicenseTerms(
+            ipId,
+            0
+        );
+        assertEq(licenseTemplateAttached, address(pilTemplate));
+        assertEq(licenseTermsIdAttached, derivativeData.licenseTermsIds[0]);
+        _assertRoyaltyTokenDistribution(ipId);
+    }
+
+    function test_RoyaltyTokenDistributionWorkflows_revert_TotalSharesExceedsIPAccountBalance() public {
+        royaltyShares.push(
+            WorkflowStructs.RoyaltyShare({
+                recipient: u.dan,
+                percentage: 10_000_000 // 10%
+            })
+        );
+
+        vm.startPrank(u.alice);
+        mockToken.mint(u.alice, nftMintingFee);
+        mockToken.approve(address(spgNftPublic), nftMintingFee);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.RoyaltyTokenDistributionWorkflows__TotalSharesExceedsIPAccountBalance.selector,
+                95_000_000 + 10_000_000,
+                100_000_000
+            )
+        );
+        royaltyTokenDistributionWorkflows.mintAndRegisterIpAndAttachPILTermsAndDistributeRoyaltyTokens({
+            spgNftContract: address(spgNftPublic),
+            recipient: u.alice,
+            ipMetadata: ipMetadataDefault,
+            licenseTermsData: commRemixTermsData,
+            royaltyShares: royaltyShares,
+            allowDuplicates: true
+        });
+        vm.stopPrank();
+    }
+
+    function _setUpTest() private {
+        nftMintingFee = 1 * 10 ** mockToken.decimals();
+        licenseMintingFee = 1 * 10 ** mockToken.decimals();
+
+        uint32 testCommRevShare = 5 * 10 ** 6; // 5%
+
+        commRemixTermsData = WorkflowStructs.LicenseTermsData({
+            terms: PILFlavors.commercialRemix({
+                mintingFee: licenseMintingFee,
+                commercialRevShare: testCommRevShare,
+                royaltyPolicy: address(royaltyPolicyLAP),
+                currencyToken: address(mockToken)
+            }),
+            licensingConfig: Licensing.LicensingConfig({
+                isSet: true,
+                mintingFee: licenseMintingFee,
+                licensingHook: address(0),
+                hookData: "",
+                commercialRevShare: testCommRevShare, // 5%
+                disabled: false,
+                expectMinimumGroupRewardShare: 0,
+                expectGroupRewardPool: address(evenSplitGroupPool)
+            })
+        });
+
+        WorkflowStructs.LicenseTermsData[] memory licenseTermsDataParent = new WorkflowStructs.LicenseTermsData[](1);
+        licenseTermsDataParent[0] = commRemixTermsData;
+        address[] memory ipIdParent = new address[](1);
+        uint256[] memory licenseTermsIdsParent;
+        vm.startPrank(u.alice);
+        mockToken.mint(u.alice, licenseMintingFee);
+        mockToken.approve(address(spgNftPublic), licenseMintingFee);
+        (ipIdParent[0], , licenseTermsIdsParent) = licenseAttachmentWorkflows.mintAndRegisterIpAndAttachPILTerms({
+            spgNftContract: address(spgNftPublic),
+            recipient: u.alice,
+            ipMetadata: ipMetadataDefault,
+            licenseTermsData: licenseTermsDataParent,
+            allowDuplicates: true
+        });
+        vm.stopPrank();
+
+        derivativeData = WorkflowStructs.MakeDerivative({
+            parentIpIds: ipIdParent,
+            licenseTemplate: address(pilTemplate),
+            licenseTermsIds: licenseTermsIdsParent,
+            royaltyContext: "",
+            maxMintingFee: 0,
+            maxRts: testCommRevShare
+        });
+
+        royaltyShares.push(
+            WorkflowStructs.RoyaltyShare({
+                recipient: u.admin,
+                percentage: 50_000_000 // 50%
+            })
+        );
+
+        royaltyShares.push(
+            WorkflowStructs.RoyaltyShare({
+                recipient: u.alice,
+                percentage: 20_000_000 // 20%
+            })
+        );
+
+        royaltyShares.push(
+            WorkflowStructs.RoyaltyShare({
+                recipient: u.bob,
+                percentage: 20_000_000 // 20%
+            })
+        );
+
+        royaltyShares.push(
+            WorkflowStructs.RoyaltyShare({
+                recipient: u.carl,
+                percentage: 5_000_000 // 5%
+            })
+        );
+    }
+
+    function _assertAttachedLicenseTerms(address ipId, uint256 licenseTermsId) private {
+        (address licenseTemplate, uint256 licenseTermsIdAttached) = licenseRegistry.getAttachedLicenseTerms(
+            ipId,
+            0
+        );
+        assertEq(licenseTermsId, licenseTermsIdAttached);
+        assertEq(licenseTemplate, address(pilTemplate));
+        assertEq(licenseTermsIdAttached, pilTemplate.getLicenseTermsId(commRemixTermsData.terms));
+        Licensing.LicensingConfig memory licensingConfig = licenseRegistry.getLicensingConfig(
+            ipId,
+            licenseTemplate,
+            licenseTermsIdAttached
+        );
+        assertEq(licensingConfig.isSet, commRemixTermsData.licensingConfig.isSet);
+        assertEq(licensingConfig.mintingFee, commRemixTermsData.licensingConfig.mintingFee);
+        assertEq(licensingConfig.licensingHook, commRemixTermsData.licensingConfig.licensingHook);
+        assertEq(licensingConfig.hookData, commRemixTermsData.licensingConfig.hookData);
+        assertEq(licensingConfig.commercialRevShare, commRemixTermsData.licensingConfig.commercialRevShare);
+        assertEq(licensingConfig.disabled, commRemixTermsData.licensingConfig.disabled);
+        assertEq(licensingConfig.expectGroupRewardPool, commRemixTermsData.licensingConfig.expectGroupRewardPool);
+        assertEq(
+            licensingConfig.expectMinimumGroupRewardShare,
+            commRemixTermsData.licensingConfig.expectMinimumGroupRewardShare
+        );
+    }
+
+    /// @dev Assert that the royalty tokens have been distributed correctly.
+    /// @param ipId The ID of the IP whose royalty tokens to check.
+    function _assertRoyaltyTokenDistribution(address ipId) private {
+        address royaltyVault = royaltyModule.ipRoyaltyVaults(ipId);
+        IERC20 royaltyToken = IERC20(royaltyVault);
+
+        for (uint256 i; i < royaltyShares.length; i++) {
+            assertEq(royaltyToken.balanceOf(royaltyShares[i].recipient), royaltyShares[i].percentage);
+        }
+    }
+
+    /// @dev Get the signature for executing a function on behalf of the IP via {IIPAccount.executeWithSig}.
+    /// @param ipId The ID of the IP whose account will execute the function.
+    /// @param to The address of the contract to execute the function on.
+    /// @param deadline The deadline for the signature.
+    /// @param state IPAccount's internal nonce
+    /// @param data the call data for the function.
+    /// @param signerSk The secret key of the signer.
+    /// @return signature The signature for executing the function.
+    /// @return expectedState The expected IPAccount's state after executing the function.
+    function _getSigForExecuteWithSig(
+        address ipId,
+        address to,
+        uint256 deadline,
+        bytes32 state,
+        bytes memory data,
+        uint256 signerSk
+    ) internal view returns (bytes memory signature, bytes32 expectedState) {
+        expectedState = keccak256(
+            abi.encode(
+                state, // ipAccount.state()
+                abi.encodeWithSelector(
+                    IIPAccount.execute.selector,
+                    to, // to
+                    0, // value
+                    data
+                )
+            )
+        );
+
+        bytes32 digest = MessageHashUtils.toTypedDataHash(
+            MetaTx.calculateDomainSeparator(ipId),
+            MetaTx.getExecuteStructHash(
+                MetaTx.Execute({ to: to, value: 0, data: data, nonce: expectedState, deadline: deadline })
+            )
+        );
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerSk, digest);
+        signature = abi.encodePacked(r, s, v);
+    }
+}


### PR DESCRIPTION
## Description
<!-- Add a description of the changes that this PR introduces -->
This PR introduces `RoyaltyTokenDistributionWorkflows` to the main branch, along with several enhancements to its functionality. These changes build upon the version introduced in `release-v1.2.4` in #126 for periphery v1.2.  

### Key Changes
- Eliminated the need to pay extra license minting fees during IP royalty vault deployment. Achieved this by attaching a temporary commercial-use license with a minting fee of 0 and disabling the license immediately after deployment.  
- Leveraged `setBatchPermission` to reduce signature requirements. All functions now require at most one signature from the user.  
- Integrated the latest protocol core API.  
- Added the ability to set licensing configurations during license attachment.  

## Test Plan 
<!-- The test plan section indicates detailed steps on how to verify and test code changes. 
You can list the test cases or test steps that need to be performed.-->
Modified the existing tests to align with the changes, and all tests pass locally.

## Related Issue
<!-- The related Issue section can indicate which issue or task the Pull Request is related with -->
- Closes #122
- Closes #130
- Opens #135
- This PR introduces interface changes; a future PR (https://github.com/storyprotocol/protocol-periphery-v1/issues/131) will ensure backward compatibility with v1.2.4