### PR TITLE
chore: add missing comments for upgrade safety and update documentation

### DIFF
--- a/contracts/BaseWorkflow.sol
+++ b/contracts/BaseWorkflow.sol
@@ -16,23 +16,30 @@ import { Errors } from "./lib/Errors.sol";
 /// @notice The base contract for all Story Protocol Periphery workflows.
 abstract contract BaseWorkflow {
     /// @notice The address of the Access Controller.
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     IAccessController public immutable ACCESS_CONTROLLER;
 
     /// @notice The address of the Core Metadata Module.
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     ICoreMetadataModule public immutable CORE_METADATA_MODULE;
 
     /// @notice The address of the IP Asset Registry.
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     IIPAssetRegistry public immutable IP_ASSET_REGISTRY;
 
     /// @notice The address of the Licensing Module.
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     ILicensingModule public immutable LICENSING_MODULE;
 
     /// @notice The address of the License Registry.
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     ILicenseRegistry public immutable LICENSE_REGISTRY;
 
     /// @notice The address of the PIL License Template.
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     IPILicenseTemplate public immutable PIL_TEMPLATE;
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(
         address accessController,
         address coreMetadataModule,

--- a/contracts/hooks/TotalLicenseTokenLimitHook.sol
+++ b/contracts/hooks/TotalLicenseTokenLimitHook.sol
@@ -12,8 +12,12 @@ import { ILicenseTemplate } from "@storyprotocol/core/interfaces/modules/licensi
 contract TotalLicenseTokenLimitHook is BaseModule, AccessControlled, ILicensingHook {
     string public constant override name = "TotalLicenseTokenLimitHook";
 
+    /// @notice The address of the License Registry.
     ILicenseRegistry public immutable LICENSE_REGISTRY;
+
+    /// @notice The address of the License Token.
     ILicenseToken public immutable LICENSE_TOKEN;
+
     // keccak256(licensorIpId, licenseTemplate, licenseTermsId) => totalLicenseTokenLimit
     mapping(bytes32 => uint256) public totalLicenseTokenLimit;
 

--- a/contracts/story-nft/BaseOrgStoryNFT.sol
+++ b/contracts/story-nft/BaseOrgStoryNFT.sol
@@ -30,6 +30,7 @@ abstract contract BaseOrgStoryNFT is IOrgStoryNFT, BaseStoryNFT {
     bytes32 private constant BaseOrgStoryNFTStorageLocation =
         0x52eea8b3c549d1bd8b986d98314c387ab153ca0f32b6949d51f32dbd11b07900;
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(
         address ipAssetRegistry,
         address licensingModule,

--- a/contracts/story-nft/BaseStoryNFT.sol
+++ b/contracts/story-nft/BaseStoryNFT.sol
@@ -45,6 +45,7 @@ abstract contract BaseStoryNFT is IStoryNFT, ERC721URIStorageUpgradeable, Ownabl
     bytes32 private constant BaseStoryNFTStorageLocation =
         0x81ed94d7560ff7bef5060a232718049e514c358c346e3254b876807a753c0e00;
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(address ipAssetRegistry, address licensingModule, address coreMetadataModule) {
         if (ipAssetRegistry == address(0) || licensingModule == address(0) || coreMetadataModule == address(0))
             revert StoryNFT__ZeroAddressParam();

--- a/contracts/story-nft/StoryBadgeNFT.sol
+++ b/contracts/story-nft/StoryBadgeNFT.sol
@@ -48,6 +48,7 @@ contract StoryBadgeNFT is IStoryBadgeNFT, BaseOrgStoryNFT, CachableNFT, ERC721Ho
     bytes32 private constant StoryBadgeNFTStorageLocation =
         0x00c5d7dc46f601fb1120e8b9ebb4fdf899cffbfddad19ced3e4dad5853224400;
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(
         address ipAssetRegistry,
         address licensingModule,

--- a/contracts/workflows/DerivativeWorkflows.sol
+++ b/contracts/workflows/DerivativeWorkflows.sol
@@ -48,9 +48,11 @@ contract DerivativeWorkflows is
         0xd52de5238bdb22c2473ee7a9de2482cc2f392e6aae2d3cca6798fa8abd456f00;
 
     /// @notice The address of the Royalty Module.
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     IRoyaltyModule public immutable ROYALTY_MODULE;
 
     /// @notice The address of the License Token.
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     ILicenseToken public immutable LICENSE_TOKEN;
 
     /// @custom:oz-upgrades-unsafe-allow constructor

--- a/contracts/workflows/GroupingWorkflows.sol
+++ b/contracts/workflows/GroupingWorkflows.sol
@@ -47,12 +47,15 @@ contract GroupingWorkflows is
         0xa8ddbb5f662015e2b3d6b4c61921979ad3d3d1d19e338b1c4ba6a196b10c6400;
 
     /// @notice The address of the Grouping Module.
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     IGroupingModule public immutable GROUPING_MODULE;
 
     /// @notice The address of the Group NFT contract.
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     GroupNFT public immutable GROUP_NFT;
 
     /// @notice The address of the Royalty Module.
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     RoyaltyModule public immutable ROYALTY_MODULE;
 
     /// @custom:oz-upgrades-unsafe-allow constructor

--- a/contracts/workflows/RoyaltyWorkflows.sol
+++ b/contracts/workflows/RoyaltyWorkflows.sol
@@ -23,6 +23,7 @@ contract RoyaltyWorkflows is IRoyaltyWorkflows, MulticallUpgradeable, AccessMana
     using ERC165Checker for address;
 
     /// @notice The address of the Royalty Module.
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     IRoyaltyModule public immutable ROYALTY_MODULE;
 
     /// @custom:oz-upgrades-unsafe-allow constructor

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -14,11 +14,11 @@
 ### [License Attachment Workflows](../contracts/interfaces/workflows/ILicenseAttachmentWorkflows.sol)
 
 - `registerPILTermsAndAttach`:
-  - Registers PIL terms → Attaches them to an IP
+  - Registers multiple PIL terms → Attaches them to an IP → Sets the licensing configuration for each of the attached PIL terms
 - `registerIpAndAttachPILTerms`:
-  - Registers an IP → Registers PIL terms → Attaches them to the IP
+  - Registers an IP → Registers multiple PIL terms → Attaches them to the IP → Sets the licensing configuration for each of the attached PIL terms
 - `mintAndRegisterIpAndAttachPILTerms`:
-  - Mints a NFT → Registers it as an IP → Registers PIL terms → Attaches them to the IP
+  - Mints a NFT → Registers it as an IP → Registers multiple PIL terms → Attaches them to the IP → Sets the licensing configuration for each of the attached PIL terms
 
 ### [Derivative Workflows](../contracts/interfaces/workflows/IDerivativeWorkflows.sol)
 
@@ -36,11 +36,11 @@
 - `mintAndRegisterIpAndAttachLicenseAndAddToGroup`:
   - Mints a NFT → Registers it as an IP → Attaches the given license terms to the IP → Adds the IP to a group IP
 - `registerIpAndAttachLicenseAndAddToGroup`:
-  - Registers an IP → Attaches the given license terms to the IP → Adds the IP to a group IP
+  - Registers an IP → Attaches the given license terms to the IP → Sets the licensing configuration for the attached license terms → Adds the IP to a group IP
 - `registerGroupAndAttachLicense`:
-  - Registers a group IP → Attaches the given license terms to the group IP
+  - Registers a group IP → Attaches the given license terms to the group IP → Sets the licensing configuration for the attached license terms
 - `registerGroupAndAttachLicenseAndAddIps`:
-  - Registers a group IP → Attaches the given license terms to the group IP → Adds existing IPs to the group IP
+  - Registers a group IP → Attaches the given license terms to the group IP → Sets the licensing configuration for the attached license terms → Adds existing IPs to the group IP
 - `collectRoyaltiesAndClaimReward`:
   - Collects revenue tokens to the group's reward pool → Distributes the rewards to each given member IP's royalty vault
 
@@ -51,3 +51,20 @@
 
 - `claimAllRevenue`:
   - Transfers all avaiable royalties from various royalty policies to the royalty vault of the ancestor IP -> Claims all the revenue in each currency token from the ancestor IP's royalty vault to the claimer.
+
+### [Royalty Token Distribution Workflows](../contracts/interfaces/workflows/IRoyaltyTokenDistributionWorkflows.sol)
+
+- `mintAndRegisterIpAndAttachPILTermsAndDistributeRoyaltyTokens`:
+  - Mints a NFT → Registers it as an IP → Attaches PIL terms to the IP → Sets the licensing configuration for the attached PIL terms → Distributes specified amounts of royalty tokens to recipients
+
+- `mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens`:
+  - Mints a NFT → Registers it as an IP → Registers the IP as a derivative of another IP → Triggers the deployment of the IP's royalty vault → Distributes specified amounts of royalty tokens to recipients
+
+- `registerIpAndAttachPILTermsAndDeployRoyaltyVault`:
+  - Registers an IP → Attaches PIL terms to the IP → Sets the licensing configuration for the attached PIL terms → Triggers the deployment of the IP's royalty vault
+
+- `registerIpAndMakeDerivativeAndDeployRoyaltyVault`:
+  - Registers an IP → Registers the IP as a derivative of another IP → Triggers the deployment of the IP's royalty vault
+
+- `distributeRoyaltyTokens`:
+  - Distributes specified amounts of royalty tokens to recipients


### PR DESCRIPTION
This PR introduces the following changes:  
- Adds missing annotations for OpenZeppelin upgrade safety check:  
  - `/// @custom:oz-upgrades-unsafe-allow constructor`  
  - `/// @custom:oz-upgrades-unsafe-allow state-variable-immutable`  

- Updates `WORKFLOWs.md` to:  
  - Include the newly added `RoyaltyTokenDistributionWorkflows`.  
  - Reflect recent changes to `LicenseAttachmentWorkflows`.  
