### PR TITLE
chore: update deploy helper to align with core protocol updates

### DIFF
--- a/script/utils/DeployHelper.sol
+++ b/script/utils/DeployHelper.sol
@@ -714,7 +714,7 @@ contract DeployHelper is
 
         // licenseToken
         impl = address(0); // Make sure we don't deploy wrong impl
-        impl = address(new LicenseToken(address(licensingModule), address(disputeModule)));
+        impl = address(new LicenseToken(address(licensingModule), address(disputeModule), address(licenseRegistry)));
         licenseToken = LicenseToken(
             TestProxyHelper.deployUUPSProxy(
                 create3Deployer,
@@ -821,7 +821,8 @@ contract DeployHelper is
                 address(licenseRegistry),
                 address(licenseToken),
                 address(groupNFT),
-                address(royaltyModule)
+                address(royaltyModule),
+                address(disputeModule)
             )
         );
         groupingModule = GroupingModule(

--- a/yarn.lock
+++ b/yarn.lock
@@ -432,7 +432,7 @@
 
 "@story-protocol/protocol-core@github:storyprotocol/protocol-core-v1#main":
   version "1.1.0"
-  resolved "https://codeload.github.com/storyprotocol/protocol-core-v1/tar.gz/bd1d8ce8da09c6ea66159c11f9abc4d36fd4f25b"
+  resolved "https://codeload.github.com/storyprotocol/protocol-core-v1/tar.gz/9c2347c653db766b18539504b96a3070ff4b30c5"
   dependencies:
     "@openzeppelin/contracts" "5.0.2"
     "@openzeppelin/contracts-upgradeable" "5.0.2"
@@ -485,9 +485,9 @@
   integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
 "@types/node@*":
-  version "22.10.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.10.1.tgz#41ffeee127b8975a05f8c4f83fb89bcb2987d766"
-  integrity sha512-qKgsUwfHZV2WCWLAnVP1JqnpE6Im6h3Y0+fYgMTasNQ7V++CBX5OT1as0g0f+OyubbFqhf6XVNIsmN4IIhEgGQ==
+  version "22.10.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.10.2.tgz#a485426e6d1fdafc7b0d4c7b24e2c78182ddabb9"
+  integrity sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==
   dependencies:
     undici-types "~6.20.0"
 


### PR DESCRIPTION
## Description
<!-- Add a description of the changes that this PR introduces -->
This PR updates the deployment helper to accommodate changes from the core protocol updates:  
- [PR#340](https://github.com/storyprotocol/protocol-core-v1/pull/340)  
- [PR#344](https://github.com/storyprotocol/protocol-core-v1/pull/344)  
The changes introduce additional constructor parameters for the `LicenseToken` and `GroupingModule` contracts. 