### PR TITLE
Introduce Tokenizer Module

### DIFF
--- a/contracts/modules/tokenizer/OwnerableERC20.sol
+++ b/contracts/modules/tokenizer/OwnerableERC20.sol
@@ -10,5 +10,4 @@ contract OwnerableERC20 is ERC20 {
     function mint(address to, uint256 amount) external {
         _mint(to, amount);
     }
-
 }

--- a/contracts/modules/tokenizer/OwnerableERC20.sol
+++ b/contracts/modules/tokenizer/OwnerableERC20.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract OwnerableERC20 is ERC20 {
+    constructor() ERC20("MockERC20", "MERC20") {}
+
+    // can only mint by owner
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+}

--- a/contracts/modules/tokenizer/TokenizerModule.sol
+++ b/contracts/modules/tokenizer/TokenizerModule.sol
@@ -3,8 +3,6 @@ pragma solidity 0.8.26;
 
 import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
 import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
-import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
-import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
 import { BaseModule } from "@storyprotocol/core/modules/BaseModule.sol";
 import { AccessControlled } from "@storyprotocol/core/access/AccessControlled.sol";
@@ -32,9 +30,5 @@ contract TokenizerModule is BaseModule, AccessControlled {
 
     function whitelistTokenTemplate(address tokenTemplate, bool allowed) external {}
 
-    function tokenize(
-        address ipId,
-        address tokenTemplate,
-        bytes initData
-    ) external verifyPermission(ipId) {}
+    function tokenize(address ipId, address tokenTemplate, bytes initData) external verifyPermission(ipId) {}
 }

--- a/contracts/modules/tokenizer/TokenizerModule.sol
+++ b/contracts/modules/tokenizer/TokenizerModule.sol
@@ -30,5 +30,5 @@ contract TokenizerModule is BaseModule, AccessControlled {
 
     function whitelistTokenTemplate(address tokenTemplate, bool allowed) external {}
 
-    function tokenize(address ipId, address tokenTemplate, bytes initData) external verifyPermission(ipId) {}
+    function tokenize(address ipId, address tokenTemplate, bytes calldata initData) external verifyPermission(ipId) {}
 }

--- a/contracts/modules/tokenizer/TokenizerModule.sol
+++ b/contracts/modules/tokenizer/TokenizerModule.sol
@@ -31,4 +31,8 @@ contract TokenizerModule is BaseModule, AccessControlled {
     function whitelistTokenTemplate(address tokenTemplate, bool allowed) external {}
 
     function tokenize(address ipId, address tokenTemplate, bytes calldata initData) external verifyPermission(ipId) {}
+
+    function name() external pure override returns (string memory) {
+        return "TOKENIZER_MODULE";
+    }
 }

--- a/contracts/modules/tokenizer/TokenizerModule.sol
+++ b/contracts/modules/tokenizer/TokenizerModule.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity 0.8.26;
+
+import { Strings } from "@openzeppelin/contracts/utils/Strings.sol";
+import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+import { ReentrancyGuardUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardUpgradeable.sol";
+import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+
+import { BaseModule } from "@storyprotocol/core/modules/BaseModule.sol";
+import { AccessControlled } from "@storyprotocol/core/access/AccessControlled.sol";
+import { IDisputeModule } from "@storyprotocol/core/interfaces/modules/dispute/IDisputeModule.sol";
+
+/// @title Tokenizer Module
+/// @notice Tokenizer module is the main entry point for the IPA Tokenization and Fractionalization.
+/// It is responsible for:
+/// - Tokenize an IPA
+/// - Whitelist ERC20 Token Templates
+contract TokenizerModule is BaseModule, AccessControlled {
+    using ERC165Checker for address;
+    using Strings for *;
+
+    /// @notice Returns the protocol-wide dispute module
+    IDisputeModule public immutable DISPUTE_MODULE;
+
+    constructor(
+        address accessController,
+        address ipAssetRegistry,
+        address disputeModule
+    ) AccessControlled(accessController, ipAssetRegistry) {
+        DISPUTE_MODULE = IDisputeModule(disputeModule);
+    }
+
+    function whitelistTokenTemplate(address tokenTemplate, bool allowed) external {}
+
+    function tokenize(
+        address ipId,
+        address tokenTemplate,
+        bytes initData
+    ) external verifyPermission(ipId) {}
+}


### PR DESCRIPTION
**Description:**
This PR introduces the `TokenizerModule` to the project. The `TokenizerModule` is designed to handle the tokenization and fractionalization of IP assets (IPA). It includes functionalities for whitelisting ERC20 token templates and tokenizing IP assets. The module integrates with the protocol-wide dispute module to ensure proper handling of disputes.

**Key Changes:**
- Added `TokenizerModule` contract.
- Integrated with the `AccessControlled` and `BaseModule` for access control and base functionalities.

**Interfaces:**
- `whitelistTokenTemplate(address tokenTemplate, bool allowed)`: Allows whitelisting or blacklisting of ERC20 token templates.
- `tokenize(address ipId, address tokenTemplate, bytes initData)`: Handles the tokenization of IP assets using the specified token template and initialization data.

