### PR TITLE
feat(licensing): add `maxRevenueShare` parameter to align with core protocol changes

### DIFF
--- a/contracts/lib/LicensingHelper.sol
+++ b/contracts/lib/LicensingHelper.sol
@@ -123,7 +123,8 @@ library LicensingHelper {
             licenseTemplate: derivData.licenseTemplate,
             royaltyContext: derivData.royaltyContext,
             maxMintingFee: derivData.maxMintingFee,
-            maxRts: derivData.maxRts
+            maxRts: derivData.maxRts,
+            maxRevenueShare: derivData.maxRevenueShare
         });
     }
 

--- a/contracts/lib/WorkflowStructs.sol
+++ b/contracts/lib/WorkflowStructs.sol
@@ -37,6 +37,7 @@ library WorkflowStructs {
     /// @param royaltyContext The context for royalty module, should be empty for Royalty Policy LAP.
     /// @param maxMintingFee The maximum minting fee that the caller is willing to pay. if set to 0 then no limit.
     /// @param maxRts The maximum number of royalty tokens that can be distributed to the external royalty policies.
+    /// @param maxRevenueShare The maximum revenue share percentage allowed for minting the License Tokens.
     struct MakeDerivative {
         address[] parentIpIds;
         address licenseTemplate;
@@ -44,6 +45,7 @@ library WorkflowStructs {
         bytes royaltyContext;
         uint256 maxMintingFee;
         uint32 maxRts;
+        uint32 maxRevenueShare;
     }
 
     /// @notice Struct for license data for license attachment on IP registration.

--- a/contracts/story-nft/BaseStoryNFT.sol
+++ b/contracts/story-nft/BaseStoryNFT.sol
@@ -125,6 +125,7 @@ abstract contract BaseStoryNFT is IStoryNFT, ERC721URIStorageUpgradeable, Ownabl
     /// @param royaltyContext The royalty context, should be empty for Royalty Policy LAP.
     /// @param maxMintingFee The maximum minting fee that the caller is willing to pay. if set to 0 then no limit.
     /// @param maxRts The maximum number of royalty tokens that can be distributed to the external royalty policies.
+    /// @param maxRevenueShare The maximum revenue share percentage allowed for minting the License Tokens.
     function _makeDerivative(
         address ipId,
         address[] memory parentIpIds,
@@ -132,7 +133,8 @@ abstract contract BaseStoryNFT is IStoryNFT, ERC721URIStorageUpgradeable, Ownabl
         uint256[] memory licenseTermsIds,
         bytes memory royaltyContext,
         uint256 maxMintingFee,
-        uint32 maxRts
+        uint32 maxRts,
+        uint32 maxRevenueShare
     ) internal virtual {
         LICENSING_MODULE.registerDerivative({
             childIpId: ipId,
@@ -141,7 +143,8 @@ abstract contract BaseStoryNFT is IStoryNFT, ERC721URIStorageUpgradeable, Ownabl
             licenseTemplate: licenseTemplate,
             royaltyContext: royaltyContext,
             maxMintingFee: maxMintingFee,
-            maxRts: maxRts
+            maxRts: maxRts,
+            maxRevenueShare: maxRevenueShare
         });
     }
 

--- a/contracts/story-nft/OrgNFT.sol
+++ b/contracts/story-nft/OrgNFT.sol
@@ -153,7 +153,8 @@ contract OrgNFT is IOrgNFT, ERC721URIStorageUpgradeable, AccessManagedUpgradeabl
             licenseTemplate: LICENSE_TEMPLATE,
             royaltyContext: "",
             maxMintingFee: 0,
-            maxRts: 0
+            maxRts: 0,
+            maxRevenueShare: 0
         });
 
         _safeTransfer(address(this), recipient, orgTokenId);

--- a/contracts/story-nft/StoryBadgeNFT.sol
+++ b/contracts/story-nft/StoryBadgeNFT.sol
@@ -178,7 +178,7 @@ contract StoryBadgeNFT is IStoryBadgeNFT, BaseOrgStoryNFT, CachableNFT, ERC721Ho
         licenseTermsIds[0] = DEFAULT_LICENSE_TERMS_ID;
 
         // Make the badge a derivative of the organization IP
-        _makeDerivative(ipId, parentIpIds, PIL_TEMPLATE, licenseTermsIds, "", 0, 0);
+        _makeDerivative(ipId, parentIpIds, PIL_TEMPLATE, licenseTermsIds, "", 0, 0, 0);
     }
 
     /// @notice Transfers an NFT from one address to another.

--- a/contracts/workflows/GroupingWorkflows.sol
+++ b/contracts/workflows/GroupingWorkflows.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.26;
 // solhint-disable-next-line max-line-length
 import { AccessManagedUpgradeable } from "@openzeppelin/contracts-upgradeable/access/manager/AccessManagedUpgradeable.sol";
 import { ERC165Checker } from "@openzeppelin/contracts/utils/introspection/ERC165Checker.sol";
+import { ERC721Holder } from "@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol";
 import { MulticallUpgradeable } from "@openzeppelin/contracts-upgradeable/utils/MulticallUpgradeable.sol";
 import { UUPSUpgradeable } from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 
@@ -30,7 +31,8 @@ contract GroupingWorkflows is
     BaseWorkflow,
     MulticallUpgradeable,
     AccessManagedUpgradeable,
-    UUPSUpgradeable
+    UUPSUpgradeable,
+    ERC721Holder
 {
     using ERC165Checker for address;
 
@@ -292,7 +294,8 @@ contract GroupingWorkflows is
                     amount: 1,
                     receiver: msg.sender,
                     royaltyContext: "",
-                    maxMintingFee: 0
+                    maxMintingFee: 0,
+                    maxRevenueShare: 0
                 });
             }
         }

--- a/contracts/workflows/RoyaltyTokenDistributionWorkflows.sol
+++ b/contracts/workflows/RoyaltyTokenDistributionWorkflows.sol
@@ -339,7 +339,8 @@ contract RoyaltyTokenDistributionWorkflows is
                 amount: 1,
                 receiver: msg.sender,
                 royaltyContext: "",
-                maxMintingFee: 0
+                maxMintingFee: 0,
+                maxRevenueShare: 0
             });
 
             // set the licensing configuration to disable the temporary license

--- a/script/utils/DeployHelper.sol
+++ b/script/utils/DeployHelper.sol
@@ -592,6 +592,7 @@ contract DeployHelper is
         impl = address(0); // Make sure we don't deploy wrong impl
         impl = address(
             new LicenseRegistry(
+                address(ipAssetRegistry),
                 _getDeployedAddress(type(LicensingModule).name),
                 _getDeployedAddress(type(DisputeModule).name),
                 address(ipGraphACL)

--- a/test/hooks/LockLicenseHook.t.sol
+++ b/test/hooks/LockLicenseHook.t.sol
@@ -55,7 +55,8 @@ contract LockLicenseHookTest is BaseTest {
             amount: 1,
             receiver: u.bob,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
     }
 
@@ -101,7 +102,8 @@ contract LockLicenseHookTest is BaseTest {
             licenseTemplate: address(pilTemplate),
             royaltyContext: "",
             maxMintingFee: 0,
-            maxRts: 0 // non-commercial remixing does not require royalty tokens
+            maxRts: 0, // non-commercial remixing does not require royalty tokens
+            maxRevenueShare: 0
         });
     }
 

--- a/test/hooks/TotalLicenseTokenLimitHook.t.sol
+++ b/test/hooks/TotalLicenseTokenLimitHook.t.sol
@@ -79,7 +79,8 @@ contract TotalLicenseTokenLimitHookTest is BaseTest {
             amount: 10,
             receiver: u.alice,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
         licensingModule.mintLicenseTokens({
             licensorIpId: ipId2,
@@ -88,7 +89,8 @@ contract TotalLicenseTokenLimitHookTest is BaseTest {
             amount: 20,
             receiver: u.alice,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
         licensingModule.mintLicenseTokens({
             licensorIpId: ipId3,
@@ -97,7 +99,8 @@ contract TotalLicenseTokenLimitHookTest is BaseTest {
             amount: 10,
             receiver: u.alice,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
 
         vm.expectRevert(
@@ -115,7 +118,8 @@ contract TotalLicenseTokenLimitHookTest is BaseTest {
             amount: 5,
             receiver: u.alice,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
 
         vm.expectRevert(
@@ -133,7 +137,8 @@ contract TotalLicenseTokenLimitHookTest is BaseTest {
             amount: 5,
             receiver: u.alice,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
     }
 
@@ -212,7 +217,8 @@ contract TotalLicenseTokenLimitHookTest is BaseTest {
             amount: 10,
             receiver: u.alice,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
 
         vm.expectRevert(

--- a/test/integration/workflows/DerivativeIntegration.t.sol
+++ b/test/integration/workflows/DerivativeIntegration.t.sol
@@ -56,7 +56,8 @@ contract DerivativeIntegration is BaseIntegration {
                 licenseTermsIds: parentLicenseTermIds,
                 royaltyContext: "",
                 maxMintingFee: 0,
-                maxRts: revShare
+                maxRts: revShare,
+                maxRevenueShare: 0
             }),
             ipMetadata: testIpMetadata,
             recipient: testSender,
@@ -130,7 +131,8 @@ contract DerivativeIntegration is BaseIntegration {
                 licenseTermsIds: parentLicenseTermIds,
                 royaltyContext: "",
                 maxMintingFee: 0,
-                maxRts: revShare
+                maxRts: revShare,
+                maxRevenueShare: 0
             }),
             ipMetadata: testIpMetadata,
             sigMetadata: WorkflowStructs.SignatureData({
@@ -177,7 +179,8 @@ contract DerivativeIntegration is BaseIntegration {
             amount: 1,
             receiver: testSender,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
 
         // Need so that derivative workflows can transfer the license tokens
@@ -244,7 +247,8 @@ contract DerivativeIntegration is BaseIntegration {
             amount: 1,
             receiver: testSender,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
 
         uint256[] memory licenseTokenIds = new uint256[](1);
@@ -329,7 +333,8 @@ contract DerivativeIntegration is BaseIntegration {
                     licenseTermsIds: parentLicenseTermIds,
                     royaltyContext: "",
                     maxMintingFee: 0,
-                    maxRts: revShare
+                    maxRts: revShare,
+                    maxRevenueShare: 0
                 }),
                 testIpMetadata,
                 testSender

--- a/test/integration/workflows/GroupingIntegration.t.sol
+++ b/test/integration/workflows/GroupingIntegration.t.sol
@@ -233,7 +233,8 @@ contract GroupingIntegration is BaseIntegration {
                 licenseTemplate: testLicensesData[0].licenseTemplate,
                 royaltyContext: "",
                 maxMintingFee: 0,
-                maxRts: revShare
+                maxRts: revShare,
+                maxRevenueShare: 0
             }),
             ipMetadata: testIpMetadata,
             recipient: testSender,
@@ -250,7 +251,8 @@ contract GroupingIntegration is BaseIntegration {
                 licenseTemplate: testLicensesData[0].licenseTemplate,
                 royaltyContext: "",
                 maxMintingFee: 0,
-                maxRts: revShare
+                maxRts: revShare,
+                maxRevenueShare: 0
             }),
             ipMetadata: testIpMetadata,
             recipient: testSender,

--- a/test/integration/workflows/RoyaltyIntegration.t.sol
+++ b/test/integration/workflows/RoyaltyIntegration.t.sol
@@ -244,7 +244,8 @@ contract RoyaltyIntegration is BaseIntegration {
                     licenseTermsIds: licenseTermsIds,
                     royaltyContext: "",
                     maxMintingFee: 0,
-                    maxRts: defaultCommRevShareA
+                    maxRts: defaultCommRevShareA,
+                    maxRevenueShare: 0
                 }),
                 ipMetadata: emptyIpMetadata,
                 sigMetadata: emptySigData,
@@ -285,7 +286,8 @@ contract RoyaltyIntegration is BaseIntegration {
                     licenseTermsIds: licenseTermsIds,
                     royaltyContext: "",
                     maxMintingFee: 0,
-                    maxRts: defaultCommRevShareA
+                    maxRts: defaultCommRevShareA,
+                    maxRevenueShare: 0
                 }),
                 ipMetadata: emptyIpMetadata,
                 sigMetadata: emptySigData,
@@ -326,7 +328,8 @@ contract RoyaltyIntegration is BaseIntegration {
                     licenseTermsIds: licenseTermsIds,
                     royaltyContext: "",
                     maxMintingFee: 0,
-                    maxRts: defaultCommRevShareC
+                    maxRts: defaultCommRevShareC,
+                    maxRevenueShare: 0
                 }),
                 ipMetadata: emptyIpMetadata,
                 sigMetadata: emptySigData,
@@ -370,7 +373,8 @@ contract RoyaltyIntegration is BaseIntegration {
                     licenseTermsIds: licenseTermsIds,
                     royaltyContext: "",
                     maxMintingFee: 0,
-                    maxRts: uint32(defaultCommRevShareA * parentIpIds.length)
+                    maxRts: uint32(defaultCommRevShareA * parentIpIds.length),
+                    maxRevenueShare: 0
                 }),
                 ipMetadata: emptyIpMetadata,
                 sigMetadata: emptySigData,
@@ -396,7 +400,8 @@ contract RoyaltyIntegration is BaseIntegration {
                 amount: amountLicenseTokensToMint,
                 receiver: testSender,
                 royaltyContext: "",
-                maxMintingFee: 0
+                maxMintingFee: 0,
+                maxRevenueShare: 0
             });
 
             // mint `amountLicenseTokensToMint` childIpC's license tokens
@@ -407,7 +412,8 @@ contract RoyaltyIntegration is BaseIntegration {
                 amount: amountLicenseTokensToMint,
                 receiver: testSender,
                 royaltyContext: "",
-                maxMintingFee: 0
+                maxMintingFee: 0,
+                maxRevenueShare: 0
             });
         }
     }

--- a/test/modules/tokenizer/TokenizerModule.t.sol
+++ b/test/modules/tokenizer/TokenizerModule.t.sol
@@ -266,7 +266,8 @@ contract TokenizerModuleTest is BaseTest {
                 licenseTermsIds: licenseIds,
                 royaltyContext: "",
                 maxMintingFee: 0,
-                maxRts: 0
+                maxRts: 0,
+                maxRevenueShare: 0
             }),
             recipient: u.alice,
             ipMetadata: ipMetadataDefault,

--- a/test/workflows/DerivativeWorkflows.t.sol
+++ b/test/workflows/DerivativeWorkflows.t.sol
@@ -118,7 +118,8 @@ contract DerivativeWorkflowsTest is BaseTest {
                 licenseTermsIds: licenseTermsIds,
                 royaltyContext: "",
                 maxMintingFee: 0,
-                maxRts: revShare
+                maxRts: revShare,
+                maxRevenueShare: 0
             }),
             ipMetadata: ipMetadataDefault,
             recipient: caller,
@@ -142,7 +143,8 @@ contract DerivativeWorkflowsTest is BaseTest {
                 licenseTermsIds: licenseTermsIds,
                 royaltyContext: "",
                 maxMintingFee: 0,
-                maxRts: revShare
+                maxRts: revShare,
+                maxRevenueShare: 0
             }),
             ipMetadata: ipMetadataDefault,
             recipient: caller,
@@ -211,7 +213,8 @@ contract DerivativeWorkflowsTest is BaseTest {
             amount: 1,
             receiver: caller,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
 
         // Need so that derivative workflows can transfer the license tokens
@@ -281,7 +284,8 @@ contract DerivativeWorkflowsTest is BaseTest {
             amount: 1,
             receiver: caller,
             royaltyContext: "",
-            maxMintingFee: 0
+            maxMintingFee: 0,
+            maxRevenueShare: 0
         });
 
         uint256[] memory licenseTokenIds = new uint256[](1);
@@ -380,7 +384,8 @@ contract DerivativeWorkflowsTest is BaseTest {
                     licenseTermsIds: licenseTermsIds,
                     royaltyContext: "",
                     maxMintingFee: 0,
-                    maxRts: revShare
+                    maxRts: revShare,
+                    maxRevenueShare: 0
                 }),
                 ipMetadataDefault,
                 caller,
@@ -434,7 +439,8 @@ contract DerivativeWorkflowsTest is BaseTest {
                 licenseTermsIds: licenseTermsIds,
                 royaltyContext: "",
                 maxMintingFee: 0,
-                maxRts: revShare
+                maxRts: revShare,
+                maxRevenueShare: 0
             }),
             ipMetadata: ipMetadataDefault,
             recipient: caller,
@@ -512,7 +518,8 @@ contract DerivativeWorkflowsTest is BaseTest {
                 licenseTermsIds: licenseTermsIds,
                 royaltyContext: "",
                 maxMintingFee: 0,
-                maxRts: revShare
+                maxRts: revShare,
+                maxRevenueShare: 0
             }),
             ipMetadata: ipMetadataDefault,
             sigMetadata: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: sigMetadata }),

--- a/test/workflows/LicenseAttachmentWorkflows.t.sol
+++ b/test/workflows/LicenseAttachmentWorkflows.t.sol
@@ -267,7 +267,8 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
                 licenseTermsIds: licenseTermsIds,
                 royaltyContext: "",
                 maxMintingFee: 0,
-                maxRts: 0 // non-commercial remixing does not require royalty tokens
+                maxRts: 0, // non-commercial remixing does not require royalty tokens
+                maxRevenueShare: 0
             }),
             ipMetadata: ipMetadataDefault,
             recipient: caller,

--- a/test/workflows/RoyaltyTokenDistributionWorkflows.t.sol
+++ b/test/workflows/RoyaltyTokenDistributionWorkflows.t.sol
@@ -318,7 +318,8 @@ contract RoyaltyTokenDistributionWorkflowsTest is BaseTest {
             licenseTermsIds: licenseTermsIdsParent,
             royaltyContext: "",
             maxMintingFee: 0,
-            maxRts: testCommRevShare
+            maxRts: testCommRevShare,
+            maxRevenueShare: 0
         });
 
         royaltyShares.push(

--- a/test/workflows/RoyaltyWorkflows.t.sol
+++ b/test/workflows/RoyaltyWorkflows.t.sol
@@ -262,7 +262,8 @@ contract RoyaltyWorkflowsTest is BaseTest {
                     licenseTermsIds: licenseTermsIds,
                     royaltyContext: "",
                     maxMintingFee: 0,
-                    maxRts: defaultCommRevShareA
+                    maxRts: defaultCommRevShareA,
+                    maxRevenueShare: 0
                 }),
                 ipMetadata: emptyIpMetadata,
                 sigMetadata: emptySigData,
@@ -304,7 +305,8 @@ contract RoyaltyWorkflowsTest is BaseTest {
                     licenseTermsIds: licenseTermsIds,
                     royaltyContext: "",
                     maxMintingFee: 0,
-                    maxRts: defaultCommRevShareA
+                    maxRts: defaultCommRevShareA,
+                    maxRevenueShare: 0
                 }),
                 ipMetadata: emptyIpMetadata,
                 sigMetadata: emptySigData,
@@ -346,7 +348,8 @@ contract RoyaltyWorkflowsTest is BaseTest {
                     licenseTermsIds: licenseTermsIds,
                     royaltyContext: "",
                     maxMintingFee: 0,
-                    maxRts: defaultCommRevShareC
+                    maxRts: defaultCommRevShareC,
+                    maxRevenueShare: 0
                 }),
                 ipMetadata: emptyIpMetadata,
                 sigMetadata: emptySigData,
@@ -391,7 +394,8 @@ contract RoyaltyWorkflowsTest is BaseTest {
                     licenseTermsIds: licenseTermsIds,
                     royaltyContext: "",
                     maxMintingFee: 0,
-                    maxRts: uint32(defaultCommRevShareA * parentIpIds.length)
+                    maxRts: uint32(defaultCommRevShareA * parentIpIds.length),
+                    maxRevenueShare: 0
                 }),
                 ipMetadata: emptyIpMetadata,
                 sigMetadata: emptySigData,
@@ -419,7 +423,8 @@ contract RoyaltyWorkflowsTest is BaseTest {
                 amount: amountLicenseTokensToMint,
                 receiver: address(0xbeef),
                 royaltyContext: "",
-                maxMintingFee: 0
+                maxMintingFee: 0,
+                maxRevenueShare: 0
             });
 
             mockTokenC.mint(address(0xbeef), defaultMintingFeeC * amountLicenseTokensToMint);
@@ -433,7 +438,8 @@ contract RoyaltyWorkflowsTest is BaseTest {
                 amount: amountLicenseTokensToMint,
                 receiver: address(0xbeef),
                 royaltyContext: "",
-                maxMintingFee: 0
+                maxMintingFee: 0,
+                maxRevenueShare: 0
             });
             vm.stopPrank();
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -428,11 +428,11 @@
 
 "@story-protocol/create3-deployer@github:storyprotocol/create3-deployer#main":
   version "0.0.0"
-  resolved "https://codeload.github.com/storyprotocol/create3-deployer/tar.gz/094147bda866490dd1c3e8261bb3dfee65e7af54"
+  resolved "https://codeload.github.com/storyprotocol/create3-deployer/tar.gz/604d69eb093e0ec2e1e751892748b2508359d5ba"
 
 "@story-protocol/protocol-core@github:storyprotocol/protocol-core-v1#main":
   version "1.1.0"
-  resolved "https://codeload.github.com/storyprotocol/protocol-core-v1/tar.gz/9c2347c653db766b18539504b96a3070ff4b30c5"
+  resolved "https://codeload.github.com/storyprotocol/protocol-core-v1/tar.gz/34c5f2b10d3530129c91fb02bdfc4e4befaf354e"
   dependencies:
     "@openzeppelin/contracts" "5.0.2"
     "@openzeppelin/contracts-upgradeable" "5.0.2"
@@ -1578,10 +1578,10 @@ is-binary-path@~2.1.0:
   dependencies:
     binary-extensions "^2.0.0"
 
-is-core-module@^2.13.0:
-  version "2.15.1"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.15.1.tgz#a7363a25bee942fefab0de13bf6aa372c82dcc37"
-  integrity sha512-z0vtXSwucUJtANQWldhbtbt7BnL0vxiFjIdDLAatwhDYty2bad6s+rijD6Ri4YuYJubLzIJLUidCh09e1djEVQ==
+is-core-module@^2.16.0:
+  version "2.16.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.16.0.tgz#6c01ffdd5e33c49c1d2abfa93334a85cb56bd81c"
+  integrity sha512-urTSINYfAYgcbLb0yDQ6egFm6h3Mo1DcF9EkyXSRjjzdHbsulg01qhwWuXdOoUBuTkbQ80KDboXa0vFJ+BDH+g==
   dependencies:
     hasown "^2.0.2"
 
@@ -2191,11 +2191,11 @@ resolve@1.1.x:
   integrity sha512-9znBF0vBcaSN3W2j7wKvdERPwqTxSpCq+if5C0WoTCyV9n24rua28jeuQ2pL/HOf+yUe/Mef+H/5p60K0Id3bg==
 
 resolve@^1.1.6:
-  version "1.22.8"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.8.tgz#b6c87a9f2aa06dfab52e3d70ac8cde321fa5a48d"
-  integrity sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==
+  version "1.22.9"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.22.9.tgz#6da76e4cdc57181fa4471231400e8851d0a924f3"
+  integrity sha512-QxrmX1DzraFIi9PxdG5VkRfRwIgjwyud+z/iBwfRRrVmHc+P9Q7u2lSSpQ6bjr2gy5lrqIiU9vb6iAeGf2400A==
   dependencies:
-    is-core-module "^2.13.0"
+    is-core-module "^2.16.0"
     path-parse "^1.0.7"
     supports-preserve-symlinks-flag "^1.0.0"
 


### PR DESCRIPTION
## Description
This PR adds the `maxRevenueShare` parameter to functions and tests related to derivative registration and license token minting, aligning with changes introduced in Core Protocol [PR#364](https://github.com/storyprotocol/protocol-core-v1/pull/364).

The `maxRevenueShare` parameter enables users to define the maximum royalty percentage they are willing to accept when minting license tokens or registering derivatives to parent IPs. This enhancement improves user control and flexibility in licensing agreements.