### PR TITLE
fix(licensing): ensure empty license data arrays are rejected

### DIFF
--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -21,6 +21,9 @@ library Errors {
     /// @notice Zero address provided as a param to the LicenseAttachmentWorkflows.
     error LicenseAttachmentWorkflows__ZeroAddressParam();
 
+    /// @notice License terms data list is empty.
+    error LicenseAttachmentWorkflows__NoLicenseTermsData();
+
     ////////////////////////////////////////////////////////////////////////////
     //                         DerivativeWorkflows                            //
     ////////////////////////////////////////////////////////////////////////////
@@ -40,6 +43,9 @@ library Errors {
 
     /// @notice Zero address provided as a param to the GroupingWorkflows.
     error GroupingWorkflows__ZeroAddressParam();
+
+    /// @notice License data list is empty.
+    error GroupingWorkflows__NoLicenseData();
 
     ////////////////////////////////////////////////////////////////////////////
     //                              Royalty Workflows                         //

--- a/contracts/workflows/GroupingWorkflows.sol
+++ b/contracts/workflows/GroupingWorkflows.sol
@@ -136,6 +136,8 @@ contract GroupingWorkflows is
         WorkflowStructs.SignatureData calldata sigAddToGroup,
         bool allowDuplicates
     ) external onlyMintAuthorized(spgNftContract) returns (address ipId, uint256 tokenId) {
+        if (licensesData.length == 0) revert Errors.GroupingWorkflows__NoLicenseData();
+
         tokenId = ISPGNFT(spgNftContract).mintByPeriphery({
             to: address(this),
             payer: msg.sender,
@@ -184,6 +186,8 @@ contract GroupingWorkflows is
         WorkflowStructs.SignatureData calldata sigMetadataAndAttachAndConfig,
         WorkflowStructs.SignatureData calldata sigAddToGroup
     ) external returns (address ipId) {
+        if (licensesData.length == 0) revert Errors.GroupingWorkflows__NoLicenseData();
+
         ipId = IP_ASSET_REGISTRY.register(block.chainid, nftContract, tokenId);
 
         address[] memory modules = new address[](3);

--- a/contracts/workflows/LicenseAttachmentWorkflows.sol
+++ b/contracts/workflows/LicenseAttachmentWorkflows.sol
@@ -99,6 +99,8 @@ contract LicenseAttachmentWorkflows is
         WorkflowStructs.LicenseTermsData[] calldata licenseTermsData,
         WorkflowStructs.SignatureData calldata sigAttachAndConfig
     ) external returns (uint256[] memory licenseTermsIds) {
+        if (licenseTermsData.length == 0) revert Errors.LicenseAttachmentWorkflows__NoLicenseTermsData();
+
         address[] memory modules = new address[](2);
         bytes4[] memory selectors = new bytes4[](2);
         modules[0] = address(LICENSING_MODULE);
@@ -138,6 +140,8 @@ contract LicenseAttachmentWorkflows is
         onlyMintAuthorized(spgNftContract)
         returns (address ipId, uint256 tokenId, uint256[] memory licenseTermsIds)
     {
+        if (licenseTermsData.length == 0) revert Errors.LicenseAttachmentWorkflows__NoLicenseTermsData();
+
         tokenId = ISPGNFT(spgNftContract).mintByPeriphery({
             to: address(this),
             payer: msg.sender,
@@ -172,6 +176,8 @@ contract LicenseAttachmentWorkflows is
         WorkflowStructs.LicenseTermsData[] calldata licenseTermsData,
         WorkflowStructs.SignatureData calldata sigMetadataAndAttachAndConfig
     ) external returns (address ipId, uint256[] memory licenseTermsIds) {
+        if (licenseTermsData.length == 0) revert Errors.LicenseAttachmentWorkflows__NoLicenseTermsData();
+
         ipId = IP_ASSET_REGISTRY.register(block.chainid, nftContract, tokenId);
 
         address[] memory modules = new address[](3);

--- a/test/workflows/GroupingWorkflows.t.sol
+++ b/test/workflows/GroupingWorkflows.t.sol
@@ -540,6 +540,42 @@ contract GroupingWorkflowsTest is BaseTest, ERC721Holder {
         }
     }
 
+    function test_GroupingWorkflows_revert_NoLicenseData() public {
+        vm.expectRevert(Errors.GroupingWorkflows__NoLicenseData.selector);
+        groupingWorkflows.mintAndRegisterIpAndAttachLicenseAndAddToGroup({
+            spgNftContract: address(spgNftPublic),
+            groupId: groupId,
+            recipient: minter,
+            ipMetadata: ipMetadataDefault,
+            licensesData: new WorkflowStructs.LicenseData[](0),
+            sigAddToGroup: WorkflowStructs.SignatureData({
+                signer: groupOwner,
+                deadline: block.timestamp + 1000,
+                signature: new bytes(0)
+            }),
+            allowDuplicates: true
+        });
+
+        vm.expectRevert(Errors.GroupingWorkflows__NoLicenseData.selector);
+        groupingWorkflows.registerIpAndAttachLicenseAndAddToGroup({
+            nftContract: address(mockNft),
+            tokenId: 0,
+            groupId: groupId,
+            licensesData: new WorkflowStructs.LicenseData[](0),
+            ipMetadata: ipMetadataDefault,
+            sigMetadataAndAttachAndConfig: WorkflowStructs.SignatureData({
+                signer: minter,
+                deadline: block.timestamp + 1000,
+                signature: new bytes(0)
+            }),
+            sigAddToGroup: WorkflowStructs.SignatureData({
+                signer: groupOwner,
+                deadline: block.timestamp + 1000,
+                signature: new bytes(0)
+            })
+        });
+    }
+
     // setup a group IPA for testing
     function _setupGroup() internal {
         // register a group and attach default PIL terms to it

--- a/test/workflows/LicenseAttachmentWorkflows.t.sol
+++ b/test/workflows/LicenseAttachmentWorkflows.t.sol
@@ -236,7 +236,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
         }
     }
 
-    function test_revert_registerPILTermsAndAttach_DerivativesCannotAddLicenseTerms()
+    function test_LicenseAttachmentWorkflows_registerPILTermsAndAttach_revert_DerivativesCannotAddLicenseTerms()
         public
         withCollection
         whenCallerHasMinterRole
@@ -294,6 +294,41 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
                 signer: u.alice,
                 deadline: deadline,
                 signature: signature
+            })
+        });
+    }
+
+    function test_LicenseAttachmentWorkflows_revert_NoLicenseData() public {
+        vm.expectRevert(Errors.LicenseAttachmentWorkflows__NoLicenseTermsData.selector);
+        licenseAttachmentWorkflows.registerPILTermsAndAttach({
+            ipId: ipAsset[1].ipId,
+            licenseTermsData: new WorkflowStructs.LicenseTermsData[](0),
+            sigAttachAndConfig: WorkflowStructs.SignatureData({
+                signer: u.alice,
+                deadline: block.timestamp + 1000,
+                signature: new bytes(0)
+            })
+        });
+
+        vm.expectRevert(Errors.LicenseAttachmentWorkflows__NoLicenseTermsData.selector);
+        licenseAttachmentWorkflows.mintAndRegisterIpAndAttachPILTerms({
+            spgNftContract: address(spgNftPublic),
+            recipient: u.alice,
+            ipMetadata: ipMetadataDefault,
+            licenseTermsData: new WorkflowStructs.LicenseTermsData[](0),
+            allowDuplicates: true
+        });
+
+        vm.expectRevert(Errors.LicenseAttachmentWorkflows__NoLicenseTermsData.selector);
+        licenseAttachmentWorkflows.registerIpAndAttachPILTerms({
+            nftContract: address(nftContract),
+            tokenId: 0,
+            ipMetadata: ipMetadataDefault,
+            licenseTermsData: new WorkflowStructs.LicenseTermsData[](0),
+            sigMetadataAndAttachAndConfig: WorkflowStructs.SignatureData({
+                signer: u.alice,
+                deadline: block.timestamp + 1000,
+                signature: new bytes(0)
             })
         });
     }


### PR DESCRIPTION
## Description
This PR introduces checks to ensure functions with multi-license attachment features properly handle empty license data arrays. The affected functions will now revert if the provided license data array is empty.
The updated functions include:  
- `mintAndRegisterIpAndAttachLicenseAndAddToGroup`  
- `registerIpAndAttachLicenseAndAddToGroup`  
- `registerPILTermsAndAttach`  
- `mintAndRegisterIpAndAttachPILTerms`  
- `registerIpAndAttachPILTerms`


## Test Plan
New test cases have been added to confirm that each of the affected functions reverts when an empty license data array is passed.  