### PR TITLE
feat(deriv): restore v1.2 compatibility to `DerivativeWorkflows`

### DIFF
--- a/contracts/interfaces/workflows/IDerivativeWorkflows.sol
+++ b/contracts/interfaces/workflows/IDerivativeWorkflows.sol
@@ -83,4 +83,50 @@ interface IDerivativeWorkflows {
         WorkflowStructs.SignatureData calldata sigMetadata,
         WorkflowStructs.SignatureData calldata sigRegister
     ) external returns (address ipId);
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                   DEPRECATED, WILL BE REMOVED IN V1.4                  //
+    ////////////////////////////////////////////////////////////////////////////
+
+    /// @notice Mint an NFT from a SPGNFT collection and register it as a derivative IP without license tokens.
+    /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
+    function mintAndRegisterIpAndMakeDerivative(
+        address spgNftContract,
+        WorkflowStructs.MakeDerivativeDEPR calldata derivData,
+        WorkflowStructs.IPMetadata calldata ipMetadata,
+        address recipient
+    ) external returns (address ipId, uint256 tokenId);
+
+    /// @notice Register the given NFT as a derivative IP with metadata without license tokens.
+    /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
+    function registerIpAndMakeDerivative(
+        address nftContract,
+        uint256 tokenId,
+        WorkflowStructs.MakeDerivativeDEPR calldata derivData,
+        WorkflowStructs.IPMetadata calldata ipMetadata,
+        WorkflowStructs.SignatureData calldata sigMetadata,
+        WorkflowStructs.SignatureData calldata sigRegister
+    ) external returns (address ipId);
+
+    /// @notice Mint an NFT from a SPGNFT collection and register it as a derivative IP using license tokens.
+    /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
+    function mintAndRegisterIpAndMakeDerivativeWithLicenseTokens(
+        address spgNftContract,
+        uint256[] calldata licenseTokenIds,
+        bytes calldata royaltyContext,
+        WorkflowStructs.IPMetadata calldata ipMetadata,
+        address recipient
+    ) external returns (address ipId, uint256 tokenId);
+
+    /// @notice Register the given NFT as a derivative IP using license tokens.
+    /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
+    function registerIpAndMakeDerivativeWithLicenseTokens(
+        address nftContract,
+        uint256 tokenId,
+        uint256[] calldata licenseTokenIds,
+        bytes calldata royaltyContext,
+        WorkflowStructs.IPMetadata calldata ipMetadata,
+        WorkflowStructs.SignatureData calldata sigMetadata,
+        WorkflowStructs.SignatureData calldata sigRegister
+    ) external returns (address ipId);
 }

--- a/contracts/lib/LicensingHelper.sol
+++ b/contracts/lib/LicensingHelper.sol
@@ -142,7 +142,7 @@ library LicensingHelper {
         address licenseTemplate,
         address[] calldata parentIpIds,
         uint256[] calldata licenseTermsIds
-    ) private {
+    ) internal {
         ILicenseTemplate lct = ILicenseTemplate(licenseTemplate);
         (address royaltyPolicy, , , address mintFeeCurrencyToken) = lct.getRoyaltyPolicy(licenseTermsIds[0]);
 

--- a/contracts/lib/WorkflowStructs.sol
+++ b/contracts/lib/WorkflowStructs.sol
@@ -73,4 +73,17 @@ library WorkflowStructs {
         address recipient;
         uint32 percentage;
     }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                   DEPRECATED, WILL BE REMOVED IN V1.4                  //
+    ////////////////////////////////////////////////////////////////////////////
+
+    /// @notice Struct for creating a derivative IP without license tokens.
+    /// @notice THIS VERSION OF THE STRUCT IS DEPRECATED, WILL BE REMOVED IN V1.4
+    struct MakeDerivativeDEPR {
+        address[] parentIpIds;
+        address licenseTemplate;
+        uint256[] licenseTermsIds;
+        bytes royaltyContext;
+    }
 }

--- a/contracts/workflows/DerivativeWorkflows.sol
+++ b/contracts/workflows/DerivativeWorkflows.sol
@@ -298,4 +298,166 @@ contract DerivativeWorkflows is
     /// @dev Hook to authorize the upgrade according to UUPSUpgradeable
     /// @param newImplementation The address of the new implementation
     function _authorizeUpgrade(address newImplementation) internal override restricted {}
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                   DEPRECATED, WILL BE REMOVED IN V1.4                  //
+    ////////////////////////////////////////////////////////////////////////////
+
+    /// @notice Mint an NFT from a SPGNFT collection and register it as a derivative IP without license tokens.
+    /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
+    function mintAndRegisterIpAndMakeDerivative(
+        address spgNftContract,
+        WorkflowStructs.MakeDerivativeDEPR calldata derivData,
+        WorkflowStructs.IPMetadata calldata ipMetadata,
+        address recipient
+    ) external onlyMintAuthorized(spgNftContract) returns (address ipId, uint256 tokenId) {
+        tokenId = ISPGNFT(spgNftContract).mintByPeriphery({
+            to: address(this),
+            payer: msg.sender,
+            nftMetadataURI: ipMetadata.nftMetadataURI,
+            nftMetadataHash: "",
+            allowDuplicates: true
+        });
+        ipId = IP_ASSET_REGISTRY.register(block.chainid, spgNftContract, tokenId);
+
+        MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);
+
+        LicensingHelper.collectMintFeesAndSetApproval(
+            msg.sender,
+            address(ROYALTY_MODULE),
+            address(LICENSING_MODULE),
+            derivData.licenseTemplate,
+            derivData.parentIpIds,
+            derivData.licenseTermsIds
+        );
+
+        LICENSING_MODULE.registerDerivative({
+            childIpId: ipId,
+            parentIpIds: derivData.parentIpIds,
+            licenseTermsIds: derivData.licenseTermsIds,
+            licenseTemplate: derivData.licenseTemplate,
+            royaltyContext: derivData.royaltyContext,
+            maxMintingFee: 0, // no limit
+            maxRts: ROYALTY_MODULE.maxPercent(), // no limit
+            maxRevenueShare: ROYALTY_MODULE.maxPercent() // no limit
+        });
+
+        ISPGNFT(spgNftContract).safeTransferFrom(address(this), recipient, tokenId, "");
+    }
+
+    /// @notice Register the given NFT as a derivative IP with metadata without license tokens.
+    /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
+    function registerIpAndMakeDerivative(
+        address nftContract,
+        uint256 tokenId,
+        WorkflowStructs.MakeDerivativeDEPR calldata derivData,
+        WorkflowStructs.IPMetadata calldata ipMetadata,
+        WorkflowStructs.SignatureData calldata sigMetadata,
+        WorkflowStructs.SignatureData calldata sigRegister
+    ) external returns (address ipId) {
+        ipId = IP_ASSET_REGISTRY.register(block.chainid, nftContract, tokenId);
+        MetadataHelper.setMetadataWithSig(
+            ipId,
+            address(CORE_METADATA_MODULE),
+            address(ACCESS_CONTROLLER),
+            ipMetadata,
+            sigMetadata
+        );
+
+        PermissionHelper.setPermissionForModule(
+            ipId,
+            address(LICENSING_MODULE),
+            address(ACCESS_CONTROLLER),
+            ILicensingModule.registerDerivative.selector,
+            sigRegister
+        );
+
+        LicensingHelper.collectMintFeesAndSetApproval(
+            msg.sender,
+            address(ROYALTY_MODULE),
+            address(LICENSING_MODULE),
+            derivData.licenseTemplate,
+            derivData.parentIpIds,
+            derivData.licenseTermsIds
+        );
+
+        LICENSING_MODULE.registerDerivative({
+            childIpId: ipId,
+            parentIpIds: derivData.parentIpIds,
+            licenseTermsIds: derivData.licenseTermsIds,
+            licenseTemplate: derivData.licenseTemplate,
+            royaltyContext: derivData.royaltyContext,
+            maxMintingFee: 0, // no limit
+            maxRts: ROYALTY_MODULE.maxPercent(), // no limit
+            maxRevenueShare: ROYALTY_MODULE.maxPercent() // no limit
+        });
+    }
+
+    /// @notice Mint an NFT from a collection and register it as a derivative IP using license tokens
+    /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
+    function mintAndRegisterIpAndMakeDerivativeWithLicenseTokens(
+        address spgNftContract,
+        uint256[] calldata licenseTokenIds,
+        bytes calldata royaltyContext,
+        WorkflowStructs.IPMetadata calldata ipMetadata,
+        address recipient
+    ) external onlyMintAuthorized(spgNftContract) returns (address ipId, uint256 tokenId) {
+        _collectLicenseTokens(licenseTokenIds, address(LICENSE_TOKEN));
+
+        tokenId = ISPGNFT(spgNftContract).mintByPeriphery({
+            to: address(this),
+            payer: msg.sender,
+            nftMetadataURI: ipMetadata.nftMetadataURI,
+            nftMetadataHash: "",
+            allowDuplicates: true
+        });
+        ipId = IP_ASSET_REGISTRY.register(block.chainid, spgNftContract, tokenId);
+        MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);
+
+        LICENSING_MODULE.registerDerivativeWithLicenseTokens(
+            ipId,
+            licenseTokenIds,
+            royaltyContext,
+            ROYALTY_MODULE.maxPercent()
+        );
+
+        ISPGNFT(spgNftContract).safeTransferFrom(address(this), recipient, tokenId, "");
+    }
+
+    /// @notice Register the given NFT as a derivative IP using license tokens.
+    /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
+    function registerIpAndMakeDerivativeWithLicenseTokens(
+        address nftContract,
+        uint256 tokenId,
+        uint256[] calldata licenseTokenIds,
+        bytes calldata royaltyContext,
+        WorkflowStructs.IPMetadata calldata ipMetadata,
+        WorkflowStructs.SignatureData calldata sigMetadata,
+        WorkflowStructs.SignatureData calldata sigRegister
+    ) external returns (address ipId) {
+        _collectLicenseTokens(licenseTokenIds, address(LICENSE_TOKEN));
+
+        ipId = IP_ASSET_REGISTRY.register(block.chainid, nftContract, tokenId);
+        MetadataHelper.setMetadataWithSig(
+            ipId,
+            address(CORE_METADATA_MODULE),
+            address(ACCESS_CONTROLLER),
+            ipMetadata,
+            sigMetadata
+        );
+
+        PermissionHelper.setPermissionForModule(
+            ipId,
+            address(LICENSING_MODULE),
+            address(ACCESS_CONTROLLER),
+            ILicensingModule.registerDerivativeWithLicenseTokens.selector,
+            sigRegister
+        );
+        LICENSING_MODULE.registerDerivativeWithLicenseTokens(
+            ipId,
+            licenseTokenIds,
+            royaltyContext,
+            ROYALTY_MODULE.maxPercent()
+        );
+    }
 }

--- a/test/integration/workflows/DerivativeIntegration.t.sol
+++ b/test/integration/workflows/DerivativeIntegration.t.sol
@@ -325,7 +325,11 @@ contract DerivativeIntegration is BaseIntegration {
         bytes[] memory data = new bytes[](numCalls);
         for (uint256 i = 0; i < numCalls; i++) {
             data[i] = abi.encodeWithSelector(
-                derivativeWorkflows.mintAndRegisterIpAndMakeDerivative.selector,
+                bytes4(
+                    keccak256(
+                        "mintAndRegisterIpAndMakeDerivative(address,(address[],address,uint256[],bytes,uint256,uint32,uint32),(string,bytes32,string,bytes32),address,bool)"
+                    )
+                ),
                 address(spgNftContract),
                 WorkflowStructs.MakeDerivative({
                     parentIpIds: parentIpIds,
@@ -337,7 +341,8 @@ contract DerivativeIntegration is BaseIntegration {
                     maxRevenueShare: 0
                 }),
                 testIpMetadata,
-                testSender
+                testSender,
+                true
             );
         }
 

--- a/test/workflows/DerivativeWorkflows.t.sol
+++ b/test/workflows/DerivativeWorkflows.t.sol
@@ -9,6 +9,7 @@ import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
 import { ILicensingModule } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingModule.sol";
 import { Licensing } from "@storyprotocol/core/lib/Licensing.sol";
 import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
+import { PILTerms } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
 
 // contracts
 import { Errors } from "../../contracts/lib/Errors.sol";
@@ -376,7 +377,11 @@ contract DerivativeWorkflowsTest is BaseTest {
         bytes[] memory data = new bytes[](10);
         for (uint256 i = 0; i < 10; i++) {
             data[i] = abi.encodeWithSelector(
-                derivativeWorkflows.mintAndRegisterIpAndMakeDerivative.selector,
+                bytes4(
+                    keccak256(
+                        "mintAndRegisterIpAndMakeDerivative(address,(address[],address,uint256[],bytes,uint256,uint32,uint32),(string,bytes32,string,bytes32),address,bool)"
+                    )
+                ),
                 address(nftContract),
                 WorkflowStructs.MakeDerivative({
                     parentIpIds: parentIpIds,
@@ -520,6 +525,368 @@ contract DerivativeWorkflowsTest is BaseTest {
                 maxMintingFee: 0,
                 maxRts: revShare,
                 maxRevenueShare: 0
+            }),
+            ipMetadata: ipMetadataDefault,
+            sigMetadata: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: sigMetadata }),
+            sigRegister: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: sigRegister })
+        });
+        assertEq(ipIdChildActual, ipIdChild);
+        assertTrue(ipAssetRegistry.isRegistered(ipIdChild));
+        assertEq(nftContract.tokenURI(tokenIdChild), string.concat(testBaseURI, ipMetadataDefault.nftMetadataURI));
+        assertMetadata(ipIdChild, ipMetadataDefault);
+        (address licenseTemplateChild, uint256 licenseTermsIdChild) = licenseRegistry.getAttachedLicenseTerms(
+            ipIdChild,
+            0
+        );
+        assertEq(licenseTemplateChild, licenseTemplateParent);
+        assertEq(licenseTermsIdChild, licenseTermsIdParent);
+        assertEq(IIPAccount(payable(ipIdChild)).owner(), caller);
+
+        assertParentChild({
+            parentIpId: ipIdParent,
+            childIpId: ipIdChild,
+            expectedParentCount: 1,
+            expectedParentIndex: 0
+        });
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                   DEPRECATED, WILL BE REMOVED IN V1.4                  //
+    ////////////////////////////////////////////////////////////////////////////
+
+    function test_DerivativeWorkflows_mintAndRegisterIpAndMakeDerivative_withNonCommercialLicense_DEPR()
+        public
+        withCollection
+        whenCallerHasMinterRole
+        withEnoughTokens(address(derivativeWorkflows))
+        withNonCommercialParentIp
+    {
+        _mintAndRegisterIpAndMakeDerivativeBaseTest_DEPR();
+    }
+
+    function test_DerivativeWorkflows_registerIpAndMakeDerivative_withNonCommercialLicense_DEPR()
+        public
+        withCollection
+        whenCallerHasMinterRole
+        withEnoughTokens(address(derivativeWorkflows))
+        withNonCommercialParentIp
+    {
+        _registerIpAndMakeDerivativeBaseTest_DEPR();
+    }
+
+    function test_DerivativeWorkflows_mintAndRegisterIpAndMakeDerivative_withCommercialLicense_DEPR()
+        public
+        withCollection
+        whenCallerHasMinterRole
+        withEnoughTokens(address(derivativeWorkflows))
+        withCommercialParentIp
+    {
+        _mintAndRegisterIpAndMakeDerivativeBaseTest_DEPR();
+    }
+
+    function test_DerivativeWorkflows_registerIpAndMakeDerivative_withCommercialLicense_DEPR()
+        public
+        withCollection
+        whenCallerHasMinterRole
+        withEnoughTokens(address(derivativeWorkflows))
+        withCommercialParentIp
+    {
+        _registerIpAndMakeDerivativeBaseTest_DEPR();
+    }
+
+    function test_DerivativeWorkflows_mintAndRegisterIpAndMakeDerivativeWithLicenseTokens_DEPR()
+        public
+        withCollection
+        whenCallerHasMinterRole
+        withEnoughTokens(address(derivativeWorkflows))
+        withNonCommercialParentIp
+    {
+        (address licenseTemplateParent, uint256 licenseTermsIdParent) = licenseRegistry.getAttachedLicenseTerms(
+            ipIdParent,
+            0
+        );
+
+        uint256 startLicenseTokenId = licensingModule.mintLicenseTokens({
+            licensorIpId: ipIdParent,
+            licenseTemplate: address(pilTemplate),
+            licenseTermsId: licenseTermsIdParent,
+            amount: 1,
+            receiver: caller,
+            royaltyContext: "",
+            maxMintingFee: 0,
+            maxRevenueShare: 0
+        });
+
+        // Need so that derivative workflows can transfer the license tokens
+        licenseToken.setApprovalForAll(address(derivativeWorkflows), true);
+
+        uint256[] memory licenseTokenIds = new uint256[](1);
+        licenseTokenIds[0] = startLicenseTokenId;
+
+        (address ipIdChild, uint256 tokenIdChild) = derivativeWorkflows
+            .mintAndRegisterIpAndMakeDerivativeWithLicenseTokens({
+                spgNftContract: address(nftContract),
+                licenseTokenIds: licenseTokenIds,
+                royaltyContext: "",
+                ipMetadata: ipMetadataDefault,
+                recipient: caller
+            });
+        assertTrue(ipAssetRegistry.isRegistered(ipIdChild));
+        assertEq(tokenIdChild, 2);
+        assertEq(nftContract.tokenURI(tokenIdChild), string.concat(testBaseURI, ipMetadataDefault.nftMetadataURI));
+        assertMetadata(ipIdChild, ipMetadataDefault);
+        (address licenseTemplateChild, uint256 licenseTermsIdChild) = licenseRegistry.getAttachedLicenseTerms(
+            ipIdChild,
+            0
+        );
+        assertEq(licenseTemplateChild, licenseTemplateParent);
+        assertEq(licenseTermsIdChild, licenseTermsIdParent);
+        assertEq(IIPAccount(payable(ipIdChild)).owner(), caller);
+
+        assertParentChild({
+            parentIpId: ipIdParent,
+            childIpId: ipIdChild,
+            expectedParentCount: 1,
+            expectedParentIndex: 0
+        });
+    }
+
+    function test_DerivativeWorkflows_registerIpAndMakeDerivativeWithLicenseTokens_DEPR()
+        public
+        withCollection
+        whenCallerHasMinterRole
+        withEnoughTokens(address(derivativeWorkflows))
+        withNonCommercialParentIp
+    {
+        (address licenseTemplateParent, uint256 licenseTermsIdParent) = licenseRegistry.getAttachedLicenseTerms(
+            ipIdParent,
+            0
+        );
+
+        uint256 tokenIdChild = nftContract.mint(
+            caller,
+            ipMetadataDefault.nftMetadataURI,
+            ipMetadataDefault.nftMetadataHash,
+            true
+        );
+        address ipIdChild = ipAssetRegistry.ipId(block.chainid, address(nftContract), tokenIdChild);
+
+        uint256 deadline = block.timestamp + 1000;
+
+        uint256 startLicenseTokenId = licensingModule.mintLicenseTokens({
+            licensorIpId: ipIdParent,
+            licenseTemplate: address(pilTemplate),
+            licenseTermsId: licenseTermsIdParent,
+            amount: 1,
+            receiver: caller,
+            royaltyContext: "",
+            maxMintingFee: 0,
+            maxRevenueShare: 0
+        });
+
+        uint256[] memory licenseTokenIds = new uint256[](1);
+        licenseTokenIds[0] = startLicenseTokenId;
+        licenseToken.approve(address(derivativeWorkflows), startLicenseTokenId);
+
+        (bytes memory sigMetadata, bytes32 expectedState, ) = _getSetPermissionSigForPeriphery({
+            ipId: ipIdChild,
+            to: address(derivativeWorkflows),
+            module: address(coreMetadataModule),
+            selector: ICoreMetadataModule.setAll.selector,
+            deadline: deadline,
+            state: bytes32(0),
+            signerSk: sk.alice
+        });
+        (bytes memory sigRegister, , ) = _getSetPermissionSigForPeriphery({
+            ipId: ipIdChild,
+            to: address(derivativeWorkflows),
+            module: address(licensingModule),
+            selector: ILicensingModule.registerDerivativeWithLicenseTokens.selector,
+            deadline: deadline,
+            state: expectedState,
+            signerSk: sk.alice
+        });
+
+        address ipIdChildActual = derivativeWorkflows.registerIpAndMakeDerivativeWithLicenseTokens({
+            nftContract: address(nftContract),
+            tokenId: tokenIdChild,
+            licenseTokenIds: licenseTokenIds,
+            royaltyContext: "",
+            ipMetadata: ipMetadataDefault,
+            sigMetadata: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: sigMetadata }),
+            sigRegister: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: sigRegister })
+        });
+        assertEq(ipIdChildActual, ipIdChild);
+        assertTrue(ipAssetRegistry.isRegistered(ipIdChild));
+        assertMetadata(ipIdChild, ipMetadataDefault);
+        (address licenseTemplateChild, uint256 licenseTermsIdChild) = licenseRegistry.getAttachedLicenseTerms(
+            ipIdChild,
+            0
+        );
+        assertEq(licenseTemplateChild, licenseTemplateParent);
+        assertEq(licenseTermsIdChild, licenseTermsIdParent);
+
+        assertParentChild({
+            parentIpId: ipIdParent,
+            childIpId: ipIdChild,
+            expectedParentCount: 1,
+            expectedParentIndex: 0
+        });
+    }
+
+    function test_SPG_multicall_mintAndRegisterIpAndMakeDerivative_DEPR()
+        public
+        withCollection
+        whenCallerHasMinterRole
+        withEnoughTokens(address(derivativeWorkflows))
+        withNonCommercialParentIp
+    {
+        (address licenseTemplateParent, uint256 licenseTermsIdParent) = licenseRegistry.getAttachedLicenseTerms(
+            ipIdParent,
+            0
+        );
+        address[] memory parentIpIds = new address[](1);
+        parentIpIds[0] = ipIdParent;
+
+        uint256[] memory licenseTermsIds = new uint256[](1);
+        licenseTermsIds[0] = licenseTermsIdParent;
+
+        bytes[] memory data = new bytes[](10);
+        for (uint256 i = 0; i < 10; i++) {
+            data[i] = abi.encodeWithSelector(
+                bytes4(
+                    keccak256(
+                        "mintAndRegisterIpAndMakeDerivative(address,(address[],address,uint256[],bytes),(string,bytes32,string,bytes32),address)"
+                    )
+                ),
+                address(nftContract),
+                WorkflowStructs.MakeDerivativeDEPR({
+                    parentIpIds: parentIpIds,
+                    licenseTemplate: address(pilTemplate),
+                    licenseTermsIds: licenseTermsIds,
+                    royaltyContext: ""
+                }),
+                ipMetadataDefault,
+                caller
+            );
+        }
+
+        bytes[] memory results = derivativeWorkflows.multicall(data);
+
+        for (uint256 i = 0; i < 10; i++) {
+            (address ipIdChild, uint256 tokenIdChild) = abi.decode(results[i], (address, uint256));
+            assertTrue(ipAssetRegistry.isRegistered(ipIdChild));
+            assertEq(tokenIdChild, i + 2);
+            assertEq(nftContract.tokenURI(tokenIdChild), string.concat(testBaseURI, ipMetadataDefault.nftMetadataURI));
+            assertMetadata(ipIdChild, ipMetadataDefault);
+            (address licenseTemplateChild, uint256 licenseTermsIdChild) = licenseRegistry.getAttachedLicenseTerms(
+                ipIdChild,
+                0
+            );
+            assertEq(licenseTemplateChild, licenseTemplateParent);
+            assertEq(licenseTermsIdChild, licenseTermsIdParent);
+            assertEq(IIPAccount(payable(ipIdChild)).owner(), caller);
+            assertParentChild({
+                parentIpId: ipIdParent,
+                childIpId: ipIdChild,
+                expectedParentCount: 1,
+                expectedParentIndex: 0
+            });
+        }
+    }
+
+    function _mintAndRegisterIpAndMakeDerivativeBaseTest_DEPR() internal {
+        (address licenseTemplateParent, uint256 licenseTermsIdParent) = licenseRegistry.getAttachedLicenseTerms(
+            ipIdParent,
+            0
+        );
+
+        address[] memory parentIpIds = new address[](1);
+        parentIpIds[0] = ipIdParent;
+
+        uint256[] memory licenseTermsIds = new uint256[](1);
+        licenseTermsIds[0] = licenseTermsIdParent;
+
+        (address ipIdChild, uint256 tokenIdChild) = derivativeWorkflows.mintAndRegisterIpAndMakeDerivative({
+            spgNftContract: address(nftContract),
+            derivData: WorkflowStructs.MakeDerivativeDEPR({
+                parentIpIds: parentIpIds,
+                licenseTemplate: address(pilTemplate),
+                licenseTermsIds: licenseTermsIds,
+                royaltyContext: ""
+            }),
+            ipMetadata: ipMetadataDefault,
+            recipient: caller
+        });
+        assertTrue(ipAssetRegistry.isRegistered(ipIdChild));
+        assertEq(tokenIdChild, 2);
+        assertEq(nftContract.tokenURI(tokenIdChild), string.concat(testBaseURI, ipMetadataDefault.nftMetadataURI));
+        assertMetadata(ipIdChild, ipMetadataDefault);
+        (address licenseTemplateChild, uint256 licenseTermsIdChild) = licenseRegistry.getAttachedLicenseTerms(
+            ipIdChild,
+            0
+        );
+        assertEq(licenseTemplateChild, licenseTemplateParent);
+        assertEq(licenseTermsIdChild, licenseTermsIdParent);
+        assertEq(IIPAccount(payable(ipIdChild)).owner(), caller);
+
+        assertParentChild({
+            parentIpId: ipIdParent,
+            childIpId: ipIdChild,
+            expectedParentCount: 1,
+            expectedParentIndex: 0
+        });
+    }
+
+    function _registerIpAndMakeDerivativeBaseTest_DEPR() internal {
+        (address licenseTemplateParent, uint256 licenseTermsIdParent) = licenseRegistry.getAttachedLicenseTerms(
+            ipIdParent,
+            0
+        );
+
+        uint256 tokenIdChild = nftContract.mint(
+            address(caller),
+            ipMetadataDefault.nftMetadataURI,
+            ipMetadataDefault.nftMetadataHash,
+            true
+        );
+        address ipIdChild = ipAssetRegistry.ipId(block.chainid, address(nftContract), tokenIdChild);
+
+        uint256 deadline = block.timestamp + 1000;
+
+        (bytes memory sigMetadata, bytes32 expectedState, ) = _getSetPermissionSigForPeriphery({
+            ipId: ipIdChild,
+            to: address(derivativeWorkflows),
+            module: address(coreMetadataModule),
+            selector: ICoreMetadataModule.setAll.selector,
+            deadline: deadline,
+            state: bytes32(0),
+            signerSk: sk.alice
+        });
+        (bytes memory sigRegister, , ) = _getSetPermissionSigForPeriphery({
+            ipId: ipIdChild,
+            to: address(derivativeWorkflows),
+            module: address(licensingModule),
+            selector: ILicensingModule.registerDerivative.selector,
+            deadline: deadline,
+            state: expectedState,
+            signerSk: sk.alice
+        });
+
+        address[] memory parentIpIds = new address[](1);
+        parentIpIds[0] = ipIdParent;
+
+        uint256[] memory licenseTermsIds = new uint256[](1);
+        licenseTermsIds[0] = licenseTermsIdParent;
+
+        address ipIdChildActual = derivativeWorkflows.registerIpAndMakeDerivative({
+            nftContract: address(nftContract),
+            tokenId: tokenIdChild,
+            derivData: WorkflowStructs.MakeDerivativeDEPR({
+                parentIpIds: parentIpIds,
+                licenseTemplate: address(pilTemplate),
+                licenseTermsIds: licenseTermsIds,
+                royaltyContext: ""
             }),
             ipMetadata: ipMetadataDefault,
             sigMetadata: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: sigMetadata }),


### PR DESCRIPTION
## Description
<!-- Add a description of the changes that this PR introduces -->
This PR reintroduces compatibility with protocol periphery v1.2 in `DerivativeWorkflows`. The v1.2 interface has been restored, with updated function implementations to ensure compatibility with protocol core v1.3.  

## Test Plan 
<!-- The test plan section indicates detailed steps on how to verify and test code changes. 
You can list the test cases or test steps that need to be performed.-->
Restored and updated the test cases for the v1.2 interface. All tests passes locally.

## Related Issue
<!-- The related Issue section can indicate which issue or task the Pull Request is related with -->
- Addresses part of #131.

## Notes
<!-- The Important Matters section can alert others to special requirements or matters that need extra attention -->
Downstream integrations should now use the added `MakeDerivativeDEPR` struct (for v1.2 compatibility) in `WorkflowStructs` instead of the `MakeDerivative` struct (specific to v1.3). No additional changes are required.  