### PR TITLE
Fix Typos in Organization NFT Contracts

### DIFF
--- a/contracts/interfaces/story-nft/IERC5192.sol
+++ b/contracts/interfaces/story-nft/IERC5192.sol
@@ -14,7 +14,7 @@ interface IERC5192 {
     /// @param tokenId The identifier for a token.
     event Unlocked(uint256 tokenId);
 
-    /// @notice Returns the locking status of an Soulbound Token
+    /// @notice Returns the locking status of a Soulbound Token
     /// @dev SBTs assigned to zero address are considered invalid, and queries
     /// about them do throw.
     /// @param tokenId The identifier for an SBT.

--- a/contracts/interfaces/story-nft/IOrgNFT.sol
+++ b/contracts/interfaces/story-nft/IOrgNFT.sol
@@ -7,7 +7,7 @@ import { WorkflowStructs } from "../../lib/WorkflowStructs.sol";
 /// @title Organization NFT Interface
 /// @notice Each organization token represents a Story ecosystem project.
 ///         The root organization token represents Story.
-///         Each organization token register as a IP on Story and is a derivative of the root organization IP.
+///         Each organization token register as an IP on Story and is a derivative of the root organization IP.
 interface IOrgNFT is IERC721Metadata {
     ////////////////////////////////////////////////////////////////////////////
     //                              Errors                                     //

--- a/contracts/interfaces/story-nft/IOrgNFT.sol
+++ b/contracts/interfaces/story-nft/IOrgNFT.sol
@@ -35,7 +35,7 @@ interface IOrgNFT is IERC721Metadata {
     ////////////////////////////////////////////////////////////////////////////
     //                              Events                                    //
     ////////////////////////////////////////////////////////////////////////////
-    /// @notice Emitted when a organization token minted.
+    /// @notice Emitted when an organization token minted.
     /// @param recipient The address of the recipient of the organization token.
     /// @param orgNft The address of the organization NFT.
     /// @param tokenId The ID of the minted organization token.
@@ -55,7 +55,7 @@ interface IOrgNFT is IERC721Metadata {
         WorkflowStructs.IPMetadata calldata orgIpMetadata
     ) external returns (uint256 rootOrgTokenId, address rootOrgIpId);
 
-    /// @notice Mints a organization token, register it as an IP,
+    /// @notice Mints an organization token, register it as an IP,
     /// and makes the IP as a derivative of the root organization IP.
     /// @param recipient The address of the recipient of the minted organization token.
     /// @param orgIpMetadata OPTIONAL. The desired metadata for the newly minted OrgNFT and registered IP.

--- a/contracts/story-nft/OrgNFT.sol
+++ b/contracts/story-nft/OrgNFT.sol
@@ -123,7 +123,7 @@ contract OrgNFT is IOrgNFT, ERC721URIStorageUpgradeable, AccessManagedUpgradeabl
         _safeTransfer(address(this), recipient, rootOrgTokenId);
     }
 
-    /// @notice Mints a organization token, register it as an IP,
+    /// @notice Mints an organization token, register it as an IP,
     /// and makes the IP as a derivative of the root organization IP.
     /// @dev This function is only callable by the OrgStoryNFTFactory contract.
     /// @param recipient The address of the recipient of the minted organization token.
@@ -168,7 +168,7 @@ contract OrgNFT is IOrgNFT, ERC721URIStorageUpgradeable, AccessManagedUpgradeabl
         _setTokenURI(tokenId, tokenURI_);
     }
 
-    /// @notice Mints a organization token and register it as an IP.
+    /// @notice Mints an organization token and register it as an IP.
     /// @param recipient The address of the recipient of the minted organization token.
     /// @param orgIpMetadata OPTIONAL. The desired metadata for the newly minted OrgNFT and registered IP.
     /// @return orgTokenId The ID of the minted organization token.

--- a/contracts/story-nft/OrgNFT.sol
+++ b/contracts/story-nft/OrgNFT.sol
@@ -19,7 +19,7 @@ import { WorkflowStructs } from "../lib/WorkflowStructs.sol";
 /// @title Organization NFT
 /// @notice Each organization token represents a Story ecosystem project.
 ///         The root organization token represents Story.
-///         Each organization token register as a IP on Story and is a derivative of the root organization IP.
+///         Each organization token register as an IP on Story and is a derivative of the root organization IP.
 contract OrgNFT is IOrgNFT, ERC721URIStorageUpgradeable, AccessManagedUpgradeable, UUPSUpgradeable, ERC721Holder {
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
 


### PR DESCRIPTION
This PR corrects typos in the Organization NFT contract files to improve documentation clarity and adherence to grammatical standards. Changes include replacing "a" with "an" before words beginning with vowel sounds, such as "organization" and "IP."

### Files Updated
- `IERC5192.sol`
  - Corrected grammatical error in the description of the `Unlocked` event.

- `IOrgNFT.sol`
  - Updated comments and event descriptions to replace "a" with "an" where applicable.

- `OrgNFT.sol`
  - Fixed typos in comments and function descriptions to ensure clarity and correctness.