### PR TITLE
feat(deriv): use batch permissions for derivative registration

### DIFF
--- a/contracts/interfaces/workflows/IDerivativeWorkflows.sol
+++ b/contracts/interfaces/workflows/IDerivativeWorkflows.sol
@@ -28,16 +28,15 @@ interface IDerivativeWorkflows {
     /// @param tokenId The ID of the NFT.
     /// @param derivData The derivative data to be used for registerDerivative.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
-    /// @param sigMetadata OPTIONAL. Signature data for setAll (metadata) for the IP via the Core Metadata Module.
-    /// @param sigRegister Signature data for registerDerivative for the IP via the Licensing Module.
+    /// @param sigMetadataAndRegister OPTIONAL. Signature data for setAll (metadata) for the IP via the Core Metadata Module
+    /// and registerDerivative for the IP via the Licensing Module.
     /// @return ipId The ID of the newly registered IP.
     function registerIpAndMakeDerivative(
         address nftContract,
         uint256 tokenId,
         WorkflowStructs.MakeDerivative calldata derivData,
         WorkflowStructs.IPMetadata calldata ipMetadata,
-        WorkflowStructs.SignatureData calldata sigMetadata,
-        WorkflowStructs.SignatureData calldata sigRegister
+        WorkflowStructs.SignatureData calldata sigMetadataAndRegister
     ) external returns (address ipId);
 
     /// @notice Mint an NFT from a SPGNFT collection and register it as a derivative IP using license tokens.
@@ -70,8 +69,8 @@ interface IDerivativeWorkflows {
     /// @param royaltyContext The context for royalty module, should be empty for Royalty Policy LAP.
     /// @param maxRts The maximum number of royalty tokens that can be distributed to the external royalty policies.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
-    /// @param sigMetadata OPTIONAL. Signature data for setAll (metadata) for the IP via the Core Metadata Module.
-    /// @param sigRegister Signature data for registerDerivativeWithLicenseTokens for the IP via the Licensing Module.
+    /// @param sigMetadataAndRegister Signature data for setAll (metadata) for the IP via the Core Metadata Module
+    /// and registerDerivativeWithLicenseTokens for the IP via the Licensing Module.
     /// @return ipId The ID of the newly registered IP.
     function registerIpAndMakeDerivativeWithLicenseTokens(
         address nftContract,
@@ -80,8 +79,7 @@ interface IDerivativeWorkflows {
         bytes calldata royaltyContext,
         uint32 maxRts,
         WorkflowStructs.IPMetadata calldata ipMetadata,
-        WorkflowStructs.SignatureData calldata sigMetadata,
-        WorkflowStructs.SignatureData calldata sigRegister
+        WorkflowStructs.SignatureData calldata sigMetadataAndRegister
     ) external returns (address ipId);
 
     ////////////////////////////////////////////////////////////////////////////

--- a/contracts/interfaces/workflows/IRoyaltyTokenDistributionWorkflows.sol
+++ b/contracts/interfaces/workflows/IRoyaltyTokenDistributionWorkflows.sol
@@ -114,5 +114,4 @@ interface IRoyaltyTokenDistributionWorkflows {
         WorkflowStructs.SignatureData calldata sigMetadata,
         WorkflowStructs.SignatureData calldata sigAttach
     ) external returns (address ipId, uint256[] memory licenseTermsIds, address ipRoyaltyVault);
-
 }

--- a/test/integration/BaseIntegration.t.sol
+++ b/test/integration/BaseIntegration.t.sol
@@ -134,6 +134,37 @@ contract BaseIntegration is Test, Script, StoryProtocolCoreAddressManager, Story
     /*//////////////////////////////////////////////////////////////////////////
                                       HELPERS
     //////////////////////////////////////////////////////////////////////////*/
+    /// @dev Get the permission list for setting metadata and registering a derivative for the IP.
+    /// @param ipId The ID of the IP that the permissions are for.
+    /// @param to The address of the periphery contract to receive the permission.
+    /// @return permissionList The list of permissions for setting metadata and registering a derivative.
+    function _getMetadataAndDerivativeRegistrationPermissionList(
+        address ipId,
+        address to,
+        bool withLicenseToken
+    ) internal view returns (AccessPermission.Permission[] memory permissionList) {
+        address[] memory modules = new address[](2);
+        bytes4[] memory selectors = new bytes4[](2);
+        permissionList = new AccessPermission.Permission[](2);
+        modules[0] = coreMetadataModuleAddr;
+        modules[1] = licensingModuleAddr;
+        selectors[0] = ICoreMetadataModule.setAll.selector;
+        if (withLicenseToken) {
+            selectors[1] = ILicensingModule.registerDerivativeWithLicenseTokens.selector;
+        } else {
+            selectors[1] = ILicensingModule.registerDerivative.selector;
+        }
+        for (uint256 i = 0; i < 2; i++) {
+            permissionList[i] = AccessPermission.Permission({
+                ipAccount: ipId,
+                signer: to,
+                to: modules[i],
+                func: selectors[i],
+                permission: AccessPermission.ALLOW
+            });
+        }
+    }
+
     /// @dev Get the permission list for attaching license terms and setting licensing config for the IP.
     /// @param ipId The ID of the IP that the permissions are for.
     /// @param to The address of the periphery contract to receive the permission.

--- a/test/integration/workflows/RoyaltyIntegration.t.sol
+++ b/test/integration/workflows/RoyaltyIntegration.t.sol
@@ -218,11 +218,14 @@ contract RoyaltyIntegration is BaseIntegration {
 
         // register childIpA as derivative of ancestorIp under Terms A
         {
-            (bytes memory sigRegister, , ) = _getSetPermissionSigForPeriphery({
-                ipId: ipAssetRegistry.ipId(block.chainid, address(spgNftContract), childTokenIdA),
-                to: derivativeWorkflowsAddr,
-                module: licensingModuleAddr,
-                selector: licensingModule.registerDerivative.selector,
+            address childIpId = ipAssetRegistry.ipId(block.chainid, address(spgNftContract), childTokenIdA);
+            (bytes memory signatureMetadataAndRegister, , ) = _getSetBatchPermissionSigForPeriphery({
+                ipId: childIpId,
+                permissionList: _getMetadataAndDerivativeRegistrationPermissionList(
+                    childIpId,
+                    address(derivativeWorkflows),
+                    false
+                ),
                 deadline: deadline,
                 state: bytes32(0),
                 signerSk: testSenderSk
@@ -248,11 +251,10 @@ contract RoyaltyIntegration is BaseIntegration {
                     maxRevenueShare: 0
                 }),
                 ipMetadata: emptyIpMetadata,
-                sigMetadata: emptySigData,
-                sigRegister: WorkflowStructs.SignatureData({
+                sigMetadataAndRegister: WorkflowStructs.SignatureData({
                     signer: testSender,
                     deadline: deadline,
-                    signature: sigRegister
+                    signature: signatureMetadataAndRegister
                 })
             });
             vm.label(childIpIdA, "ChildIpA");
@@ -260,11 +262,14 @@ contract RoyaltyIntegration is BaseIntegration {
 
         // register childIpB as derivative of ancestorIp under Terms A
         {
-            (bytes memory sigRegister, , ) = _getSetPermissionSigForPeriphery({
-                ipId: ipAssetRegistry.ipId(block.chainid, address(spgNftContract), childTokenIdB),
-                to: derivativeWorkflowsAddr,
-                module: licensingModuleAddr,
-                selector: licensingModule.registerDerivative.selector,
+            address childIpId = ipAssetRegistry.ipId(block.chainid, address(spgNftContract), childTokenIdB);
+            (bytes memory signatureMetadataAndRegister, , ) = _getSetBatchPermissionSigForPeriphery({
+                ipId: childIpId,
+                permissionList: _getMetadataAndDerivativeRegistrationPermissionList(
+                    childIpId,
+                    address(derivativeWorkflows),
+                    false
+                ),
                 deadline: deadline,
                 state: bytes32(0),
                 signerSk: testSenderSk
@@ -290,11 +295,10 @@ contract RoyaltyIntegration is BaseIntegration {
                     maxRevenueShare: 0
                 }),
                 ipMetadata: emptyIpMetadata,
-                sigMetadata: emptySigData,
-                sigRegister: WorkflowStructs.SignatureData({
+                sigMetadataAndRegister: WorkflowStructs.SignatureData({
                     signer: testSender,
                     deadline: deadline,
-                    signature: sigRegister
+                    signature: signatureMetadataAndRegister
                 })
             });
             vm.label(childIpIdB, "ChildIpB");
@@ -302,11 +306,14 @@ contract RoyaltyIntegration is BaseIntegration {
 
         /// register childIpC as derivative of ancestorIp under Terms C
         {
-            (bytes memory sigRegister, , ) = _getSetPermissionSigForPeriphery({
-                ipId: ipAssetRegistry.ipId(block.chainid, address(spgNftContract), childTokenIdC),
-                to: derivativeWorkflowsAddr,
-                module: licensingModuleAddr,
-                selector: licensingModule.registerDerivative.selector,
+            address childIpId = ipAssetRegistry.ipId(block.chainid, address(spgNftContract), childTokenIdC);
+            (bytes memory signatureMetadataAndRegister, , ) = _getSetBatchPermissionSigForPeriphery({
+                ipId: childIpId,
+                permissionList: _getMetadataAndDerivativeRegistrationPermissionList(
+                    childIpId,
+                    address(derivativeWorkflows),
+                    false
+                ),
                 deadline: deadline,
                 state: bytes32(0),
                 signerSk: testSenderSk
@@ -332,11 +339,10 @@ contract RoyaltyIntegration is BaseIntegration {
                     maxRevenueShare: 0
                 }),
                 ipMetadata: emptyIpMetadata,
-                sigMetadata: emptySigData,
-                sigRegister: WorkflowStructs.SignatureData({
+                sigMetadataAndRegister: WorkflowStructs.SignatureData({
                     signer: testSender,
                     deadline: deadline,
-                    signature: sigRegister
+                    signature: signatureMetadataAndRegister
                 })
             });
             vm.label(childIpIdC, "ChildIpC");
@@ -344,11 +350,14 @@ contract RoyaltyIntegration is BaseIntegration {
 
         // register grandChildIp as derivative for childIp A and B under Terms A
         {
-            (bytes memory sigRegister, , ) = _getSetPermissionSigForPeriphery({
-                ipId: ipAssetRegistry.ipId(block.chainid, address(spgNftContract), grandChildTokenId),
-                to: derivativeWorkflowsAddr,
-                module: address(licensingModule),
-                selector: licensingModule.registerDerivative.selector,
+            address childIpId = ipAssetRegistry.ipId(block.chainid, address(spgNftContract), grandChildTokenId);
+            (bytes memory signatureMetadataAndRegister, , ) = _getSetBatchPermissionSigForPeriphery({
+                ipId: childIpId,
+                permissionList: _getMetadataAndDerivativeRegistrationPermissionList(
+                    childIpId,
+                    address(derivativeWorkflows),
+                    false
+                ),
                 deadline: deadline,
                 state: bytes32(0),
                 signerSk: testSenderSk
@@ -377,11 +386,10 @@ contract RoyaltyIntegration is BaseIntegration {
                     maxRevenueShare: 0
                 }),
                 ipMetadata: emptyIpMetadata,
-                sigMetadata: emptySigData,
-                sigRegister: WorkflowStructs.SignatureData({
+                sigMetadataAndRegister: WorkflowStructs.SignatureData({
                     signer: testSender,
                     deadline: deadline,
-                    signature: sigRegister
+                    signature: signatureMetadataAndRegister
                 })
             });
             vm.label(grandChildIpId, "GrandChildIp");

--- a/test/utils/BaseTest.t.sol
+++ b/test/utils/BaseTest.t.sol
@@ -297,7 +297,8 @@ contract BaseTest is Test, DeployHelper {
     /// @return permissionList The list of permissions for setting metadata and registering a derivative.
     function _getMetadataAndDerivativeRegistrationPermissionList(
         address ipId,
-        address to
+        address to,
+        bool withLicenseToken
     ) internal view returns (AccessPermission.Permission[] memory permissionList) {
         address[] memory modules = new address[](2);
         bytes4[] memory selectors = new bytes4[](2);
@@ -305,7 +306,11 @@ contract BaseTest is Test, DeployHelper {
         modules[0] = coreMetadataModuleAddr;
         modules[1] = licensingModuleAddr;
         selectors[0] = ICoreMetadataModule.setAll.selector;
-        selectors[1] = ILicensingModule.registerDerivative.selector;
+        if (withLicenseToken) {
+            selectors[1] = ILicensingModule.registerDerivativeWithLicenseTokens.selector;
+        } else {
+            selectors[1] = ILicensingModule.registerDerivative.selector;
+        }
         for (uint256 i = 0; i < 2; i++) {
             permissionList[i] = AccessPermission.Permission({
                 ipAccount: ipId,

--- a/test/workflows/RoyaltyTokenDistributionWorkflows.t.sol
+++ b/test/workflows/RoyaltyTokenDistributionWorkflows.t.sol
@@ -181,7 +181,8 @@ contract RoyaltyTokenDistributionWorkflowsTest is BaseTest {
             ipId: expectedIpId,
             permissionList: _getMetadataAndDerivativeRegistrationPermissionList(
                 expectedIpId,
-                address(royaltyTokenDistributionWorkflows)
+                address(royaltyTokenDistributionWorkflows),
+                false
             ),
             deadline: deadline,
             state: bytes32(0),

--- a/test/workflows/RoyaltyWorkflows.t.sol
+++ b/test/workflows/RoyaltyWorkflows.t.sol
@@ -236,11 +236,14 @@ contract RoyaltyWorkflowsTest is BaseTest {
 
         // register childIpA as derivative of ancestorIp under Terms A
         {
-            (bytes memory sigRegisterAlice, , ) = _getSetPermissionSigForPeriphery({
-                ipId: ipAssetRegistry.ipId(block.chainid, address(mockNft), childTokenIdA),
-                to: address(derivativeWorkflows),
-                module: address(licensingModule),
-                selector: licensingModule.registerDerivative.selector,
+            address childIpId = ipAssetRegistry.ipId(block.chainid, address(mockNft), childTokenIdA);
+            (bytes memory signatureMetadataAndRegister, , ) = _getSetBatchPermissionSigForPeriphery({
+                ipId: childIpId,
+                permissionList: _getMetadataAndDerivativeRegistrationPermissionList(
+                    childIpId,
+                    address(derivativeWorkflows),
+                    false
+                ),
                 deadline: deadline,
                 state: bytes32(0),
                 signerSk: sk.alice
@@ -266,11 +269,10 @@ contract RoyaltyWorkflowsTest is BaseTest {
                     maxRevenueShare: 0
                 }),
                 ipMetadata: emptyIpMetadata,
-                sigMetadata: emptySigData,
-                sigRegister: WorkflowStructs.SignatureData({
+                sigMetadataAndRegister: WorkflowStructs.SignatureData({
                     signer: u.alice,
                     deadline: deadline,
-                    signature: sigRegisterAlice
+                    signature: signatureMetadataAndRegister
                 })
             });
             vm.stopPrank();
@@ -279,11 +281,14 @@ contract RoyaltyWorkflowsTest is BaseTest {
 
         // register childIpB as derivative of ancestorIp under Terms A
         {
-            (bytes memory sigRegisterBob, , ) = _getSetPermissionSigForPeriphery({
-                ipId: ipAssetRegistry.ipId(block.chainid, address(mockNft), childTokenIdB),
-                to: address(derivativeWorkflows),
-                module: address(licensingModule),
-                selector: licensingModule.registerDerivative.selector,
+            address childIpId = ipAssetRegistry.ipId(block.chainid, address(mockNft), childTokenIdB);
+            (bytes memory signatureMetadataAndRegister, , ) = _getSetBatchPermissionSigForPeriphery({
+                ipId: childIpId,
+                permissionList: _getMetadataAndDerivativeRegistrationPermissionList(
+                    childIpId,
+                    address(derivativeWorkflows),
+                    false
+                ),
                 deadline: deadline,
                 state: bytes32(0),
                 signerSk: sk.bob
@@ -309,11 +314,10 @@ contract RoyaltyWorkflowsTest is BaseTest {
                     maxRevenueShare: 0
                 }),
                 ipMetadata: emptyIpMetadata,
-                sigMetadata: emptySigData,
-                sigRegister: WorkflowStructs.SignatureData({
+                sigMetadataAndRegister: WorkflowStructs.SignatureData({
                     signer: u.bob,
                     deadline: deadline,
-                    signature: sigRegisterBob
+                    signature: signatureMetadataAndRegister
                 })
             });
             vm.stopPrank();
@@ -322,11 +326,14 @@ contract RoyaltyWorkflowsTest is BaseTest {
 
         /// register childIpC as derivative of ancestorIp under Terms C
         {
-            (bytes memory sigRegisterCarl, , ) = _getSetPermissionSigForPeriphery({
-                ipId: ipAssetRegistry.ipId(block.chainid, address(mockNft), childTokenIdC),
-                to: address(derivativeWorkflows),
-                module: address(licensingModule),
-                selector: licensingModule.registerDerivative.selector,
+            address childIpId = ipAssetRegistry.ipId(block.chainid, address(mockNft), childTokenIdC);
+            (bytes memory signatureMetadataAndRegister, , ) = _getSetBatchPermissionSigForPeriphery({
+                ipId: childIpId,
+                permissionList: _getMetadataAndDerivativeRegistrationPermissionList(
+                    childIpId,
+                    address(derivativeWorkflows),
+                    false
+                ),
                 deadline: deadline,
                 state: bytes32(0),
                 signerSk: sk.carl
@@ -352,11 +359,10 @@ contract RoyaltyWorkflowsTest is BaseTest {
                     maxRevenueShare: 0
                 }),
                 ipMetadata: emptyIpMetadata,
-                sigMetadata: emptySigData,
-                sigRegister: WorkflowStructs.SignatureData({
+                sigMetadataAndRegister: WorkflowStructs.SignatureData({
                     signer: u.carl,
                     deadline: deadline,
-                    signature: sigRegisterCarl
+                    signature: signatureMetadataAndRegister
                 })
             });
             vm.stopPrank();
@@ -365,11 +371,14 @@ contract RoyaltyWorkflowsTest is BaseTest {
 
         // register grandChildIp as derivative for childIp A and B under Terms A
         {
-            (bytes memory sigRegisterDan, , ) = _getSetPermissionSigForPeriphery({
-                ipId: ipAssetRegistry.ipId(block.chainid, address(mockNft), grandChildTokenId),
-                to: address(derivativeWorkflows),
-                module: address(licensingModule),
-                selector: licensingModule.registerDerivative.selector,
+            address childIpId = ipAssetRegistry.ipId(block.chainid, address(mockNft), grandChildTokenId);
+            (bytes memory signatureMetadataAndRegister, , ) = _getSetBatchPermissionSigForPeriphery({
+                ipId: childIpId,
+                permissionList: _getMetadataAndDerivativeRegistrationPermissionList(
+                    childIpId,
+                    address(derivativeWorkflows),
+                    false
+                ),
                 deadline: deadline,
                 state: bytes32(0),
                 signerSk: sk.dan
@@ -398,11 +407,10 @@ contract RoyaltyWorkflowsTest is BaseTest {
                     maxRevenueShare: 0
                 }),
                 ipMetadata: emptyIpMetadata,
-                sigMetadata: emptySigData,
-                sigRegister: WorkflowStructs.SignatureData({
+                sigMetadataAndRegister: WorkflowStructs.SignatureData({
                     signer: u.dan,
                     deadline: deadline,
-                    signature: sigRegisterDan
+                    signature: signatureMetadataAndRegister
                 })
             });
             vm.stopPrank();


### PR DESCRIPTION
### Description  
This PR refactors the `registerIpAndMakeDerivative` and `registerIpAndMakeDerivativeWithLicenseTokens` functions in `DerivativeWorkflows` to leverage `setBatchPermissions` instead of setting permissions one at a time. With this change, both functions now require only a single signature to grant `DerivativeWorkflows` the necessary permissions to interact with the core protocol on behalf of the IP owner. This enhancement reduces overhead and simplifies the authorization process.

### Test Plan  
- Updated tests to reflect the use of `setBatchPermissions`.  
- all tests pass locally

### Related Issue  
- Closes #31.