### PR TITLE
chore(workflows): clean up unused storage variables and functions

### DIFF
--- a/.github/workflows/foundry_ci.yml
+++ b/.github/workflows/foundry_ci.yml
@@ -60,4 +60,4 @@ jobs:
     # uses: ./../gha-workflows/.github/workflows/reusable-forge-code-coverage.yml
     with:
       exclude_paths: 'test/*, script/*'
-      branch_coverage: true
+      branch_coverage: true --ignore-errors unused

--- a/contracts/workflows/DerivativeWorkflows.sol
+++ b/contracts/workflows/DerivativeWorkflows.sol
@@ -36,18 +36,6 @@ contract DerivativeWorkflows is
 {
     using ERC165Checker for address;
 
-    /// @dev Storage structure for the DerivativeWorkflows
-    /// @param nftContractBeacon The address of the NFT contract beacon.
-    /// @custom:storage-location erc7201:story-protocol-periphery.DerivativeWorkflows
-    struct DerivativeWorkflowsStorage {
-        address nftContractBeacon;
-    }
-
-    // solhint-disable-next-line max-line-length
-    // keccak256(abi.encode(uint256(keccak256("story-protocol-periphery.DerivativeWorkflows")) - 1)) & ~bytes32(uint256(0xff));
-    bytes32 private constant DerivativeWorkflowsStorageLocation =
-        0xd52de5238bdb22c2473ee7a9de2482cc2f392e6aae2d3cca6798fa8abd456f00;
-
     /// @notice The address of the Royalty Module.
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     IRoyaltyModule public immutable ROYALTY_MODULE;
@@ -99,14 +87,6 @@ contract DerivativeWorkflows is
         if (accessManager == address(0)) revert Errors.DerivativeWorkflows__ZeroAddressParam();
         __AccessManaged_init(accessManager);
         __UUPSUpgradeable_init();
-    }
-
-    /// @dev Sets the NFT contract beacon address.
-    /// @param newNftContractBeacon The address of the new NFT contract beacon.
-    function setNftContractBeacon(address newNftContractBeacon) external restricted {
-        if (newNftContractBeacon == address(0)) revert Errors.DerivativeWorkflows__ZeroAddressParam();
-        DerivativeWorkflowsStorage storage $ = _getDerivativeWorkflowsStorage();
-        $.nftContractBeacon = newNftContractBeacon;
     }
 
     /// @notice Mint an NFT from a SPGNFT collection and register it as a derivative IP without license tokens.
@@ -287,13 +267,6 @@ contract DerivativeWorkflows is
     //
     // Upgrade
     //
-
-    /// @dev Returns the storage struct of DerivativeWorkflows.
-    function _getDerivativeWorkflowsStorage() private pure returns (DerivativeWorkflowsStorage storage $) {
-        assembly {
-            $.slot := DerivativeWorkflowsStorageLocation
-        }
-    }
 
     /// @dev Hook to authorize the upgrade according to UUPSUpgradeable
     /// @param newImplementation The address of the new implementation

--- a/contracts/workflows/GroupingWorkflows.sol
+++ b/contracts/workflows/GroupingWorkflows.sol
@@ -39,18 +39,6 @@ contract GroupingWorkflows is
 {
     using ERC165Checker for address;
 
-    /// @dev Storage structure for the GroupingWorkflows
-    /// @param nftContractBeacon The address of the NFT contract beacon.
-    /// @custom:storage-location erc7201:story-protocol-periphery.GroupingWorkflows
-    struct GroupingWorkflowsStorage {
-        address nftContractBeacon;
-    }
-
-    // solhint-disable-next-line max-line-length
-    // keccak256(abi.encode(uint256(keccak256("story-protocol-periphery.GroupingWorkflows")) - 1)) & ~bytes32(uint256(0xff));
-    bytes32 private constant GroupingWorkflowsStorageLocation =
-        0xa8ddbb5f662015e2b3d6b4c61921979ad3d3d1d19e338b1c4ba6a196b10c6400;
-
     /// @notice The address of the Grouping Module.
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     IGroupingModule public immutable GROUPING_MODULE;
@@ -108,14 +96,6 @@ contract GroupingWorkflows is
         if (accessManager == address(0)) revert Errors.GroupingWorkflows__ZeroAddressParam();
         __AccessManaged_init(accessManager);
         __UUPSUpgradeable_init();
-    }
-
-    /// @dev Sets the NFT contract beacon address.
-    /// @param newNftContractBeacon The address of the new NFT contract beacon.
-    function setNftContractBeacon(address newNftContractBeacon) external restricted {
-        if (newNftContractBeacon == address(0)) revert Errors.GroupingWorkflows__ZeroAddressParam();
-        GroupingWorkflowsStorage storage $ = _getGroupingWorkflowsStorage();
-        $.nftContractBeacon = newNftContractBeacon;
     }
 
     /// @notice Mint an NFT from a SPGNFT collection, register it with metadata as an IP, attach
@@ -333,13 +313,6 @@ contract GroupingWorkflows is
     //
     // Upgrade
     //
-
-    /// @dev Returns the storage struct of GroupingWorkflows.
-    function _getGroupingWorkflowsStorage() private pure returns (GroupingWorkflowsStorage storage $) {
-        assembly {
-            $.slot := GroupingWorkflowsStorageLocation
-        }
-    }
 
     /// @dev Hook to authorize the upgrade according to UUPSUpgradeable
     /// @param newImplementation The address of the new implementation

--- a/contracts/workflows/LicenseAttachmentWorkflows.sol
+++ b/contracts/workflows/LicenseAttachmentWorkflows.sol
@@ -32,18 +32,6 @@ contract LicenseAttachmentWorkflows is
 {
     using ERC165Checker for address;
 
-    /// @dev Storage structure for the LicenseAttachmentWorkflows
-    /// @param nftContractBeacon The address of the NFT contract beacon.
-    /// @custom:storage-location erc7201:story-protocol-periphery.LicenseAttachmentWorkflows
-    struct LicenseAttachmentWorkflowsStorage {
-        address nftContractBeacon;
-    }
-
-    // solhint-disable-next-line max-line-length
-    // keccak256(abi.encode(uint256(keccak256("story-protocol-periphery.LicenseAttachmentWorkflows")) - 1)) & ~bytes32(uint256(0xff));
-    bytes32 private constant LicenseAttachmentWorkflowsStorageLocation =
-        0x5dffa4259249ac7a3ead22d30b4086dd3916391710734d6dd1182f2c1fe1b200;
-
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(
         address accessController,
@@ -80,14 +68,6 @@ contract LicenseAttachmentWorkflows is
         if (accessManager == address(0)) revert Errors.LicenseAttachmentWorkflows__ZeroAddressParam();
         __AccessManaged_init(accessManager);
         __UUPSUpgradeable_init();
-    }
-
-    /// @dev Sets the NFT contract beacon address.
-    /// @param newNftContractBeacon The address of the new NFT contract beacon.
-    function setNftContractBeacon(address newNftContractBeacon) external restricted {
-        if (newNftContractBeacon == address(0)) revert Errors.LicenseAttachmentWorkflows__ZeroAddressParam();
-        LicenseAttachmentWorkflowsStorage storage $ = _getLicenseAttachmentWorkflowsStorage();
-        $.nftContractBeacon = newNftContractBeacon;
     }
 
     /// @notice Register Programmable IP License Terms (if unregistered) and attach it to IP.
@@ -220,17 +200,6 @@ contract LicenseAttachmentWorkflows is
     //
     // Upgrade
     //
-
-    /// @dev Returns the storage struct of LicenseAttachmentWorkflows.
-    function _getLicenseAttachmentWorkflowsStorage()
-        private
-        pure
-        returns (LicenseAttachmentWorkflowsStorage storage $)
-    {
-        assembly {
-            $.slot := LicenseAttachmentWorkflowsStorageLocation
-        }
-    }
 
     /// @dev Hook to authorize the upgrade according to UUPSUpgradeable
     /// @param newImplementation The address of the new implementation

--- a/contracts/workflows/RoyaltyTokenDistributionWorkflows.sol
+++ b/contracts/workflows/RoyaltyTokenDistributionWorkflows.sol
@@ -37,18 +37,6 @@ contract RoyaltyTokenDistributionWorkflows is
 {
     using ERC165Checker for address;
 
-    /// @dev Storage structure for the RoyaltyTokenDistributionWorkflows
-    /// @param nftContractBeacon The address of the NFT contract beacon.
-    /// @custom:storage-location erc7201:story-protocol-periphery.RoyaltyTokenDistributionWorkflows
-    struct RoyaltyTokenDistributionWorkflowsStorage {
-        address nftContractBeacon;
-    }
-
-    // solhint-disable-next-line max-line-length
-    // keccak256(abi.encode(uint256(keccak256("story-protocol-periphery.RoyaltyTokenDistributionWorkflows")) - 1)) & ~bytes32(uint256(0xff));
-    bytes32 private constant RoyaltyTokenDistributionWorkflowsStorageLocation =
-        0x49f5a60a01a4171ac277a9cd523bb469bbf7cf89b7349fb34e8335e241d25600;
-
     /// @notice The address of the Royalty Module.
     /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
     IRoyaltyModule public immutable ROYALTY_MODULE;
@@ -107,14 +95,6 @@ contract RoyaltyTokenDistributionWorkflows is
         if (accessManager == address(0)) revert Errors.RoyaltyTokenDistributionWorkflows__ZeroAddressParam();
         __AccessManaged_init(accessManager);
         __UUPSUpgradeable_init();
-    }
-
-    /// @dev Sets the NFT contract beacon address.
-    /// @param newNftContractBeacon The address of the new NFT contract beacon.
-    function setNftContractBeacon(address newNftContractBeacon) external restricted {
-        if (newNftContractBeacon == address(0)) revert Errors.RoyaltyTokenDistributionWorkflows__ZeroAddressParam();
-        RoyaltyTokenDistributionWorkflowsStorage storage $ = _getRoyaltyTokenDistributionWorkflowsStorage();
-        $.nftContractBeacon = newNftContractBeacon;
     }
 
     /// @notice Mint an NFT and register the IP, attach PIL terms, and distribute royalty tokens.
@@ -442,17 +422,6 @@ contract RoyaltyTokenDistributionWorkflows is
     //
     // Upgrade
     //
-
-    /// @dev Returns the storage struct of RoyaltyTokenDistributionWorkflows.
-    function _getRoyaltyTokenDistributionWorkflowsStorage()
-        private
-        pure
-        returns (RoyaltyTokenDistributionWorkflowsStorage storage $)
-    {
-        assembly {
-            $.slot := RoyaltyTokenDistributionWorkflowsStorageLocation
-        }
-    }
 
     /// @dev Hook to authorize the upgrade according to UUPSUpgradeable
     /// @param newImplementation The address of the new implementation

--- a/script/utils/DeployHelper.sol
+++ b/script/utils/DeployHelper.sol
@@ -177,11 +177,7 @@ contract DeployHelper is
 
             // Set SPGNFTBeacon for periphery workflow contracts, access controlled
             // can't be done in deployment script:
-            // derivativeWorkflows.setNftContractBeacon(address(spgNftBeacon));
-            // groupingWorkflows.setNftContractBeacon(address(spgNftBeacon));
-            // licenseAttachmentWorkflows.setNftContractBeacon(address(spgNftBeacon));
             // registrationWorkflows.setNftContractBeacon(address(spgNftBeacon));
-            // royaltyTokenDistributionWorkflows.setNftContractBeacon(address(spgNftBeacon));
         }
     }
 

--- a/test/utils/BaseTest.t.sol
+++ b/test/utils/BaseTest.t.sol
@@ -116,11 +116,7 @@ contract BaseTest is Test, DeployHelper {
         );
 
         // set the NFT contract beacon for workflow contracts
-        derivativeWorkflows.setNftContractBeacon(address(spgNftBeacon));
-        groupingWorkflows.setNftContractBeacon(address(spgNftBeacon));
-        licenseAttachmentWorkflows.setNftContractBeacon(address(spgNftBeacon));
         registrationWorkflows.setNftContractBeacon(address(spgNftBeacon));
-        royaltyTokenDistributionWorkflows.setNftContractBeacon(address(spgNftBeacon));
 
         vm.stopPrank();
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -485,9 +485,9 @@
   integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
 "@types/node@*":
-  version "22.10.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.10.4.tgz#da36bebcc4b124f3d62bfde1cd1dafd7763949c1"
-  integrity sha512-99l6wv4HEzBQhvaU/UGoeBoCK61SCROQaCCGyQSgX2tEQ3rKkNZ2S7CEWnS/4s1LV+8ODdK21UeyR1fHP2mXug==
+  version "22.10.5"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.10.5.tgz#95af89a3fb74a2bb41ef9927f206e6472026e48b"
+  integrity sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==
   dependencies:
     undici-types "~6.20.0"
 


### PR DESCRIPTION
## Description  
This PR removes the unused `nftContractBeacon` storage variable and its associated functions from the following workflow contracts:  
- `DerivativeWorkflows`  
- `GroupingWorkflows`  
- `LicenseAttachmentWorkflows`  
- `RoyaltyTokenDistributionWorkflows`  