### PR TITLE
fix: correct inaccurate comments marking non-optional parameters as optional

### DIFF
--- a/contracts/SPGNFT.sol
+++ b/contracts/SPGNFT.sol
@@ -228,8 +228,7 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
     /// @notice Mints an NFT from the collection. Only callable by the minter role.
     /// @param to The address of the recipient of the minted NFT.
     /// @param nftMetadataURI OPTIONAL. The URI of the desired metadata for the newly minted NFT.
-    /// @param nftMetadataHash OPTIONAL. A bytes32 hash of the NFT's metadata.
-    /// This metadata is accessible via the NFT's tokenURI.
+    /// @param nftMetadataHash OPTIONAL. A bytes32 hash of the NFT's metadata. This metadata is accessible via the NFT's tokenURI.
     /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
     /// @return tokenId The token ID of the minted NFT with the given metadata hash.
     function mint(
@@ -254,8 +253,7 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
     /// @param to The address of the recipient of the minted NFT.
     /// @param payer The address of the payer for the mint fee.
     /// @param nftMetadataURI OPTIONAL. The URI of the desired metadata for the newly minted NFT.
-    /// @param nftMetadataHash OPTIONAL. A bytes32 hash of the NFT's metadata.
-    /// This metadata is accessible via the NFT's tokenURI.
+    /// @param nftMetadataHash OPTIONAL. A bytes32 hash of the NFT's metadata. This metadata is accessible via the NFT's tokenURI.
     /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
     /// @return tokenId The token ID of the minted NFT with the given metadata hash.
     function mintByPeriphery(
@@ -292,8 +290,7 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
     /// @param to The address of the recipient of the minted NFT.
     /// @param payer The address of the payer for the mint fee.
     /// @param nftMetadataURI OPTIONAL. The URI of the desired metadata for the newly minted NFT.
-    /// @param nftMetadataHash OPTIONAL. A bytes32 hash of the NFT's metadata.
-    /// This metadata is accessible via the NFT's tokenURI.
+    /// @param nftMetadataHash OPTIONAL. A bytes32 hash of the NFT's metadata. This metadata is accessible via the NFT's tokenURI.
     /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
     /// @return tokenId The token ID of the minted NFT with the given metadata hash.
     function _mintToken(

--- a/contracts/interfaces/ISPGNFT.sol
+++ b/contracts/interfaces/ISPGNFT.sol
@@ -112,8 +112,7 @@ interface ISPGNFT is IAccessControl, IERC721Metadata, IERC7572 {
     /// @notice Mints an NFT from the collection. Only callable by the minter role.
     /// @param to The address of the recipient of the minted NFT.
     /// @param nftMetadataURI OPTIONAL. The desired metadata for the newly minted NFT.
-    /// @param nftMetadataHash OPTIONAL. A bytes32 hash of the NFT's metadata.
-    /// This metadata is accessible via the NFT's tokenURI.
+    /// @param nftMetadataHash OPTIONAL. A bytes32 hash of the NFT's metadata. This metadata is accessible via the NFT's tokenURI.
     /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
     /// @return tokenId The token ID of the minted NFT with the given metadata hash.
     function mint(
@@ -127,8 +126,7 @@ interface ISPGNFT is IAccessControl, IERC721Metadata, IERC7572 {
     /// @param to The address of the recipient of the minted NFT.
     /// @param payer The address of the payer for the mint fee.
     /// @param nftMetadataURI OPTIONAL. The desired metadata for the newly minted NFT.
-    /// @param nftMetadataHash OPTIONAL. A bytes32 hash of the NFT's metadata.
-    /// This metadata is accessible via the NFT's tokenURI.
+    /// @param nftMetadataHash OPTIONAL. A bytes32 hash of the NFT's metadata. This metadata is accessible via the NFT's tokenURI.
     /// @param allowDuplicates Set to true to allow minting an NFT with a duplicate metadata hash.
     /// @return tokenId The token ID of the minted NFT with the given metadata hash.
     function mintByPeriphery(

--- a/contracts/interfaces/workflows/IDerivativeWorkflows.sol
+++ b/contracts/interfaces/workflows/IDerivativeWorkflows.sol
@@ -28,7 +28,7 @@ interface IDerivativeWorkflows {
     /// @param tokenId The ID of the NFT.
     /// @param derivData The derivative data to be used for registerDerivative.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
-    /// @param sigMetadataAndRegister OPTIONAL. Signature data for setAll (metadata) for the IP via the Core Metadata Module
+    /// @param sigMetadataAndRegister Signature data for setAll (metadata) for the IP via the Core Metadata Module
     /// and registerDerivative for the IP via the Licensing Module.
     /// @return ipId The ID of the newly registered IP.
     function registerIpAndMakeDerivative(

--- a/contracts/workflows/DerivativeWorkflows.sol
+++ b/contracts/workflows/DerivativeWorkflows.sol
@@ -132,7 +132,7 @@ contract DerivativeWorkflows is
     /// @param tokenId The ID of the NFT.
     /// @param derivData The derivative data to be used for registerDerivative.
     /// @param ipMetadata OPTIONAL. The desired metadata for the newly registered IP.
-    /// @param sigMetadataAndRegister OPTIONAL. Signature data for setAll (metadata) for the IP via the Core Metadata
+    /// @param sigMetadataAndRegister Signature data for setAll (metadata) for the IP via the Core Metadata
     /// Module and registerDerivative for the IP via the Licensing Module.
     /// @return ipId The ID of the newly registered IP.
     function registerIpAndMakeDerivative(


### PR DESCRIPTION
## Description
<!-- Add a description of the changes that this PR introduces -->
This PR addresses misleading comments in function parameter documentation. Previously, some non-optional parameters were incorrectly labeled as optional in the comments.