### PR TITLE
fix(backwards-compatibility): rename functions to avoid overloading conflicts

### DIFF
--- a/contracts/interfaces/workflows/IDerivativeWorkflows.sol
+++ b/contracts/interfaces/workflows/IDerivativeWorkflows.sol
@@ -88,7 +88,7 @@ interface IDerivativeWorkflows {
 
     /// @notice Mint an NFT from a SPGNFT collection and register it as a derivative IP without license tokens.
     /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function mintAndRegisterIpAndMakeDerivative(
+    function mintAndRegisterIpAndMakeDerivative_deprecated(
         address spgNftContract,
         WorkflowStructs.MakeDerivativeDEPR calldata derivData,
         WorkflowStructs.IPMetadata calldata ipMetadata,
@@ -97,7 +97,7 @@ interface IDerivativeWorkflows {
 
     /// @notice Register the given NFT as a derivative IP with metadata without license tokens.
     /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function registerIpAndMakeDerivative(
+    function registerIpAndMakeDerivative_deprecated(
         address nftContract,
         uint256 tokenId,
         WorkflowStructs.MakeDerivativeDEPR calldata derivData,
@@ -108,7 +108,7 @@ interface IDerivativeWorkflows {
 
     /// @notice Mint an NFT from a SPGNFT collection and register it as a derivative IP using license tokens.
     /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function mintAndRegisterIpAndMakeDerivativeWithLicenseTokens(
+    function mintAndRegisterIpAndMakeDerivativeWithLicenseTokens_deprecated(
         address spgNftContract,
         uint256[] calldata licenseTokenIds,
         bytes calldata royaltyContext,
@@ -118,7 +118,7 @@ interface IDerivativeWorkflows {
 
     /// @notice Register the given NFT as a derivative IP using license tokens.
     /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function registerIpAndMakeDerivativeWithLicenseTokens(
+    function registerIpAndMakeDerivativeWithLicenseTokens_deprecated(
         address nftContract,
         uint256 tokenId,
         uint256[] calldata licenseTokenIds,

--- a/contracts/interfaces/workflows/IGroupingWorkflows.sol
+++ b/contracts/interfaces/workflows/IGroupingWorkflows.sol
@@ -89,7 +89,7 @@ interface IGroupingWorkflows {
     /// @notice Mint an NFT from a SPGNFT collection, register it with metadata as an IP,
     /// attach license terms to the registered IP, and add it to a group IP.
     /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function mintAndRegisterIpAndAttachLicenseAndAddToGroup(
+    function mintAndRegisterIpAndAttachLicenseAndAddToGroup_deprecated(
         address spgNftContract,
         address groupId,
         address recipient,
@@ -104,7 +104,7 @@ interface IGroupingWorkflows {
     /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
     /// @dev UPDATE REQUIRED: The sigMetadataAndAttachAndConfig permission signature data must be updated and include permissions for
     /// metadata setting, license attachment, and licensing configuration permissions
-    function registerIpAndAttachLicenseAndAddToGroup(
+    function registerIpAndAttachLicenseAndAddToGroup_deprecated(
         address nftContract,
         uint256 tokenId,
         address groupId,
@@ -117,7 +117,7 @@ interface IGroupingWorkflows {
 
     /// @notice Register a group IP with a group reward pool and attach license terms to the group IP
     /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function registerGroupAndAttachLicense(
+    function registerGroupAndAttachLicense_deprecated(
         address groupPool,
         address licenseTemplate,
         uint256 licenseTermsId
@@ -126,7 +126,7 @@ interface IGroupingWorkflows {
     /// @notice Register a group IP with a group reward pool, attach license terms to the group IP,
     /// and add individual IPs to the group IP.
     /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function registerGroupAndAttachLicenseAndAddIps(
+    function registerGroupAndAttachLicenseAndAddIps_deprecated(
         address groupPool,
         address[] calldata ipIds,
         address licenseTemplate,
@@ -135,7 +135,7 @@ interface IGroupingWorkflows {
 
     /// @notice Collect royalties for the entire group and distribute the rewards to each member IP's royalty vault
     /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function collectRoyaltiesAndClaimReward(
+    function collectRoyaltiesAndClaimReward_deprecated(
         address groupIpId,
         address[] calldata currencyTokens,
         uint256[] calldata groupSnapshotIds,

--- a/contracts/interfaces/workflows/ILicenseAttachmentWorkflows.sol
+++ b/contracts/interfaces/workflows/ILicenseAttachmentWorkflows.sol
@@ -63,7 +63,7 @@ interface ILicenseAttachmentWorkflows {
 
     /// @notice Register Programmable IP License Terms (if unregistered) and attach it to IP.
     /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function registerPILTermsAndAttach(
+    function registerPILTermsAndAttach_deprecated(
         address ipId,
         PILTerms[] calldata terms,
         WorkflowStructs.SignatureData calldata sigAttach
@@ -72,7 +72,7 @@ interface ILicenseAttachmentWorkflows {
     /// @notice Mint an NFT from a SPGNFT collection, register it with metadata as an IP,
     /// register Programmable IPLicense
     /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function mintAndRegisterIpAndAttachPILTerms(
+    function mintAndRegisterIpAndAttachPILTerms_deprecated(
         address spgNftContract,
         address recipient,
         WorkflowStructs.IPMetadata calldata ipMetadata,
@@ -81,7 +81,7 @@ interface ILicenseAttachmentWorkflows {
 
     /// @notice Register a given NFT as an IP and attach Programmable IP License Terms.
     /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function registerIpAndAttachPILTerms(
+    function registerIpAndAttachPILTerms_deprecated(
         address nftContract,
         uint256 tokenId,
         WorkflowStructs.IPMetadata calldata ipMetadata,
@@ -92,7 +92,7 @@ interface ILicenseAttachmentWorkflows {
 
     /// @notice Register Programmable IP License Terms (if unregistered) and attach it to IP.
     /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function registerPILTermsAndAttach(
+    function registerPILTermsAndAttach_deprecated(
         address ipId,
         PILTerms calldata terms,
         WorkflowStructs.SignatureData calldata sigAttach
@@ -101,7 +101,7 @@ interface ILicenseAttachmentWorkflows {
     /// Mint an NFT from a SPGNFT collection, register it with metadata as an IP,
     /// register Programmable IPLicense
     /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function mintAndRegisterIpAndAttachPILTerms(
+    function mintAndRegisterIpAndAttachPILTerms_deprecated(
         address spgNftContract,
         address recipient,
         WorkflowStructs.IPMetadata calldata ipMetadata,
@@ -110,7 +110,7 @@ interface ILicenseAttachmentWorkflows {
 
     /// @notice Register a given NFT as an IP and attach Programmable IP License Terms.
     /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function registerIpAndAttachPILTerms(
+    function registerIpAndAttachPILTerms_deprecated(
         address nftContract,
         uint256 tokenId,
         WorkflowStructs.IPMetadata calldata ipMetadata,

--- a/contracts/interfaces/workflows/IRegistrationWorkflows.sol
+++ b/contracts/interfaces/workflows/IRegistrationWorkflows.sol
@@ -51,7 +51,7 @@ interface IRegistrationWorkflows {
 
     /// @notice Mint an NFT from a SPGNFT collection and register it with metadata as an IP.
     /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function mintAndRegisterIp(
+    function mintAndRegisterIp_deprecated(
         address spgNftContract,
         address recipient,
         WorkflowStructs.IPMetadata calldata ipMetadata

--- a/contracts/interfaces/workflows/IRoyaltyTokenDistributionWorkflows.sol
+++ b/contracts/interfaces/workflows/IRoyaltyTokenDistributionWorkflows.sol
@@ -96,7 +96,7 @@ interface IRoyaltyTokenDistributionWorkflows {
 
     /// @notice Mint an NFT and register the IP, attach PIL terms, and distribute royalty tokens.
     /// @dev THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function mintAndRegisterIpAndAttachPILTermsAndDistributeRoyaltyTokens(
+    function mintAndRegisterIpAndAttachPILTermsAndDistributeRoyaltyTokens_deprecated(
         address spgNftContract,
         address recipient,
         WorkflowStructs.IPMetadata calldata ipMetadata,
@@ -106,7 +106,7 @@ interface IRoyaltyTokenDistributionWorkflows {
 
     /// @notice Register an IP, attach PIL terms, and deploy a royalty vault.
     /// @dev THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function registerIpAndAttachPILTermsAndDeployRoyaltyVault(
+    function registerIpAndAttachPILTermsAndDeployRoyaltyVault_deprecated(
         address nftContract,
         uint256 tokenId,
         WorkflowStructs.IPMetadata calldata ipMetadata,

--- a/contracts/workflows/DerivativeWorkflows.sol
+++ b/contracts/workflows/DerivativeWorkflows.sol
@@ -278,7 +278,7 @@ contract DerivativeWorkflows is
 
     /// @notice Mint an NFT from a SPGNFT collection and register it as a derivative IP without license tokens.
     /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function mintAndRegisterIpAndMakeDerivative(
+    function mintAndRegisterIpAndMakeDerivative_deprecated(
         address spgNftContract,
         WorkflowStructs.MakeDerivativeDEPR calldata derivData,
         WorkflowStructs.IPMetadata calldata ipMetadata,
@@ -320,7 +320,7 @@ contract DerivativeWorkflows is
 
     /// @notice Register the given NFT as a derivative IP with metadata without license tokens.
     /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function registerIpAndMakeDerivative(
+    function registerIpAndMakeDerivative_deprecated(
         address nftContract,
         uint256 tokenId,
         WorkflowStructs.MakeDerivativeDEPR calldata derivData,
@@ -368,7 +368,7 @@ contract DerivativeWorkflows is
 
     /// @notice Mint an NFT from a collection and register it as a derivative IP using license tokens
     /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function mintAndRegisterIpAndMakeDerivativeWithLicenseTokens(
+    function mintAndRegisterIpAndMakeDerivativeWithLicenseTokens_deprecated(
         address spgNftContract,
         uint256[] calldata licenseTokenIds,
         bytes calldata royaltyContext,
@@ -399,7 +399,7 @@ contract DerivativeWorkflows is
 
     /// @notice Register the given NFT as a derivative IP using license tokens.
     /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function registerIpAndMakeDerivativeWithLicenseTokens(
+    function registerIpAndMakeDerivativeWithLicenseTokens_deprecated(
         address nftContract,
         uint256 tokenId,
         uint256[] calldata licenseTokenIds,

--- a/contracts/workflows/GroupingWorkflows.sol
+++ b/contracts/workflows/GroupingWorkflows.sol
@@ -325,7 +325,7 @@ contract GroupingWorkflows is
     /// @notice Mint an NFT from a SPGNFT collection, register it with metadata as an IP, attach
     /// license terms to the registered IP, and add it to a group IP.
     /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function mintAndRegisterIpAndAttachLicenseAndAddToGroup(
+    function mintAndRegisterIpAndAttachLicenseAndAddToGroup_deprecated(
         address spgNftContract,
         address groupId,
         address recipient,
@@ -366,7 +366,7 @@ contract GroupingWorkflows is
     /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
     /// @dev UPDATE REQUIRED: The sigMetadataAndAttachAndConfig permission signature data must be updated and include permissions for
     /// metadata setting, license attachment, and licensing configuration permissions
-    function registerIpAndAttachLicenseAndAddToGroup(
+    function registerIpAndAttachLicenseAndAddToGroup_deprecated(
         address nftContract,
         uint256 tokenId,
         address groupId,
@@ -414,7 +414,7 @@ contract GroupingWorkflows is
 
     /// @notice Register a group IP with a group reward pool and attach license terms to the group IP
     /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function registerGroupAndAttachLicense(
+    function registerGroupAndAttachLicense_deprecated(
         address groupPool,
         address licenseTemplate,
         uint256 licenseTermsId
@@ -429,7 +429,7 @@ contract GroupingWorkflows is
     /// @notice Register a group IP with a group reward pool, attach license terms to the group IP,
     /// and add individual IPs to the group IP.
     /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function registerGroupAndAttachLicenseAndAddIps(
+    function registerGroupAndAttachLicenseAndAddIps_deprecated(
         address groupPool,
         address[] calldata ipIds,
         address licenseTemplate,
@@ -446,7 +446,7 @@ contract GroupingWorkflows is
 
     /// @notice Collect royalties for the entire group and distribute the rewards to each member IP's royalty vault
     /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function collectRoyaltiesAndClaimReward(
+    function collectRoyaltiesAndClaimReward_deprecated(
         address groupIpId,
         address[] calldata currencyTokens,
         uint256[] calldata groupSnapshotIds,
@@ -482,6 +482,7 @@ contract GroupingWorkflows is
         }
     }
 
+    /// @notice THIS FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
     function _prepConfigAndAttachLicenseAndSetConfig(
         address ipId,
         address groupId,
@@ -507,6 +508,7 @@ contract GroupingWorkflows is
         _attachLicensesAndSetConfigs(ipId, licensesData);
     }
 
+    /// @notice THIS FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
     function _prepConfigAndAttachLicenseAndSetConfigForGroup(
         address groupId,
         address groupRewardPool,

--- a/contracts/workflows/LicenseAttachmentWorkflows.sol
+++ b/contracts/workflows/LicenseAttachmentWorkflows.sol
@@ -211,7 +211,7 @@ contract LicenseAttachmentWorkflows is
 
     /// @notice Register Programmable IP License Terms (if unregistered) and attach it to IP.
     /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function registerPILTermsAndAttach(
+    function registerPILTermsAndAttach_deprecated(
         address ipId,
         PILTerms[] calldata terms,
         WorkflowStructs.SignatureData calldata sigAttach
@@ -232,7 +232,7 @@ contract LicenseAttachmentWorkflows is
     /// @notice Mint an NFT from a SPGNFT collection, register it with metadata as an IP,
     /// register Programmable IP License Terms (if unregistered), and attach it to the registered IP.
     /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function mintAndRegisterIpAndAttachPILTerms(
+    function mintAndRegisterIpAndAttachPILTerms_deprecated(
         address spgNftContract,
         address recipient,
         WorkflowStructs.IPMetadata calldata ipMetadata,
@@ -261,7 +261,7 @@ contract LicenseAttachmentWorkflows is
 
     /// @notice Register a given NFT as an IP and attach Programmable IP License Terms.
     /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function registerIpAndAttachPILTerms(
+    function registerIpAndAttachPILTerms_deprecated(
         address nftContract,
         uint256 tokenId,
         WorkflowStructs.IPMetadata calldata ipMetadata,
@@ -293,7 +293,7 @@ contract LicenseAttachmentWorkflows is
 
     /// @notice Register Programmable IP License Terms (if unregistered) and attach it to IP.
     /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function registerPILTermsAndAttach(
+    function registerPILTermsAndAttach_deprecated(
         address ipId,
         PILTerms calldata terms,
         WorkflowStructs.SignatureData calldata sigAttach
@@ -317,7 +317,7 @@ contract LicenseAttachmentWorkflows is
     /// @notice Mint an NFT from a SPGNFT collection, register it with metadata as an IP,
     /// register Programmable IP License Terms (if unregistered), and attach it to the registered IP.
     /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function mintAndRegisterIpAndAttachPILTerms(
+    function mintAndRegisterIpAndAttachPILTerms_deprecated(
         address spgNftContract,
         address recipient,
         WorkflowStructs.IPMetadata calldata ipMetadata,
@@ -345,7 +345,7 @@ contract LicenseAttachmentWorkflows is
 
     /// @notice Register a given NFT as an IP and attach Programmable IP License Terms.
     /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function registerIpAndAttachPILTerms(
+    function registerIpAndAttachPILTerms_deprecated(
         address nftContract,
         uint256 tokenId,
         WorkflowStructs.IPMetadata calldata ipMetadata,
@@ -378,7 +378,7 @@ contract LicenseAttachmentWorkflows is
         );
     }
 
-    /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
+    /// @notice THIS FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
     function _registerMultiplePILTermsAndAttach(
         address ipId,
         PILTerms[] calldata terms

--- a/contracts/workflows/RegistrationWorkflows.sol
+++ b/contracts/workflows/RegistrationWorkflows.sol
@@ -171,7 +171,7 @@ contract RegistrationWorkflows is
     ////////////////////////////////////////////////////////////////////////////
     /// @notice Mint an NFT from a SPGNFT collection and register it with metadata as an IP.
     /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function mintAndRegisterIp(
+    function mintAndRegisterIp_deprecated(
         address spgNftContract,
         address recipient,
         WorkflowStructs.IPMetadata calldata ipMetadata

--- a/contracts/workflows/RoyaltyTokenDistributionWorkflows.sol
+++ b/contracts/workflows/RoyaltyTokenDistributionWorkflows.sol
@@ -433,7 +433,7 @@ contract RoyaltyTokenDistributionWorkflows is
 
     /// @notice Mint an NFT and register the IP, attach PIL terms, and distribute royalty tokens.
     /// @dev THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function mintAndRegisterIpAndAttachPILTermsAndDistributeRoyaltyTokens(
+    function mintAndRegisterIpAndAttachPILTermsAndDistributeRoyaltyTokens_deprecated(
         address spgNftContract,
         address recipient,
         WorkflowStructs.IPMetadata calldata ipMetadata,
@@ -468,7 +468,7 @@ contract RoyaltyTokenDistributionWorkflows is
 
     /// @notice Register an IP, attach PIL terms, and deploy a royalty vault.
     /// @dev THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
-    function registerIpAndAttachPILTermsAndDeployRoyaltyVault(
+    function registerIpAndAttachPILTermsAndDeployRoyaltyVault_deprecated(
         address nftContract,
         uint256 tokenId,
         WorkflowStructs.IPMetadata calldata ipMetadata,
@@ -499,7 +499,7 @@ contract RoyaltyTokenDistributionWorkflows is
     }
 
     /// @dev Deploys a royalty vault for the IP.
-    /// @dev THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
+    /// @dev THIS FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
     function _deployRoyaltyVaultDEPR(
         address ipId,
         address licenseTemplate,
@@ -537,7 +537,7 @@ contract RoyaltyTokenDistributionWorkflows is
         if (ipRoyaltyVault == address(0)) revert Errors.RoyaltyTokenDistributionWorkflows__RoyaltyVaultNotDeployed();
     }
 
-    /// @notice THIS VERSION OF THE FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
+    /// @notice THIS FUNCTION IS DEPRECATED, WILL BE REMOVED IN V1.4
     function _registerMultiplePILTermsAndAttach(
         address ipId,
         PILTerms[] calldata terms

--- a/test/workflows/DerivativeWorkflows.t.sol
+++ b/test/workflows/DerivativeWorkflows.t.sol
@@ -602,7 +602,7 @@ contract DerivativeWorkflowsTest is BaseTest {
         licenseTokenIds[0] = startLicenseTokenId;
 
         (address ipIdChild, uint256 tokenIdChild) = derivativeWorkflows
-            .mintAndRegisterIpAndMakeDerivativeWithLicenseTokens({
+            .mintAndRegisterIpAndMakeDerivativeWithLicenseTokens_deprecated({
                 spgNftContract: address(nftContract),
                 licenseTokenIds: licenseTokenIds,
                 royaltyContext: "",
@@ -685,7 +685,7 @@ contract DerivativeWorkflowsTest is BaseTest {
             signerSk: sk.alice
         });
 
-        address ipIdChildActual = derivativeWorkflows.registerIpAndMakeDerivativeWithLicenseTokens({
+        address ipIdChildActual = derivativeWorkflows.registerIpAndMakeDerivativeWithLicenseTokens_deprecated({
             nftContract: address(nftContract),
             tokenId: tokenIdChild,
             licenseTokenIds: licenseTokenIds,
@@ -734,7 +734,7 @@ contract DerivativeWorkflowsTest is BaseTest {
             data[i] = abi.encodeWithSelector(
                 bytes4(
                     keccak256(
-                        "mintAndRegisterIpAndMakeDerivative(address,(address[],address,uint256[],bytes),(string,bytes32,string,bytes32),address)"
+                        "mintAndRegisterIpAndMakeDerivative_deprecated(address,(address[],address,uint256[],bytes),(string,bytes32,string,bytes32),address)"
                     )
                 ),
                 address(nftContract),
@@ -785,7 +785,7 @@ contract DerivativeWorkflowsTest is BaseTest {
         uint256[] memory licenseTermsIds = new uint256[](1);
         licenseTermsIds[0] = licenseTermsIdParent;
 
-        (address ipIdChild, uint256 tokenIdChild) = derivativeWorkflows.mintAndRegisterIpAndMakeDerivative({
+        (address ipIdChild, uint256 tokenIdChild) = derivativeWorkflows.mintAndRegisterIpAndMakeDerivative_deprecated({
             spgNftContract: address(nftContract),
             derivData: WorkflowStructs.MakeDerivativeDEPR({
                 parentIpIds: parentIpIds,
@@ -857,7 +857,7 @@ contract DerivativeWorkflowsTest is BaseTest {
         uint256[] memory licenseTermsIds = new uint256[](1);
         licenseTermsIds[0] = licenseTermsIdParent;
 
-        address ipIdChildActual = derivativeWorkflows.registerIpAndMakeDerivative({
+        address ipIdChildActual = derivativeWorkflows.registerIpAndMakeDerivative_deprecated({
             nftContract: address(nftContract),
             tokenId: tokenIdChild,
             derivData: WorkflowStructs.MakeDerivativeDEPR({

--- a/test/workflows/GroupingWorkflows.t.sol
+++ b/test/workflows/GroupingWorkflows.t.sol
@@ -664,7 +664,7 @@ contract GroupingWorkflowsTest is BaseTest, ERC721Holder {
         });
 
         vm.startPrank(minter);
-        (address ipId, uint256 tokenId) = groupingWorkflows.mintAndRegisterIpAndAttachLicenseAndAddToGroup({
+        (address ipId, uint256 tokenId) = groupingWorkflows.mintAndRegisterIpAndAttachLicenseAndAddToGroup_deprecated({
             spgNftContract: address(spgNftPublic),
             groupId: groupId,
             recipient: minter,
@@ -735,7 +735,7 @@ contract GroupingWorkflowsTest is BaseTest, ERC721Holder {
             signerSk: groupOwnerSk
         });
 
-        address ipId = groupingWorkflows.registerIpAndAttachLicenseAndAddToGroup({
+        address ipId = groupingWorkflows.registerIpAndAttachLicenseAndAddToGroup_deprecated({
             nftContract: address(mockNft),
             tokenId: tokenId,
             groupId: groupId,
@@ -778,7 +778,7 @@ contract GroupingWorkflowsTest is BaseTest, ERC721Holder {
     // Register group IP → Attach license terms to group IPA
     function test_GroupingWorkflows_registerGroupAndAttachLicense_DEPR() public {
         vm.startPrank(groupOwner);
-        address newGroupId = groupingWorkflows.registerGroupAndAttachLicense({
+        address newGroupId = groupingWorkflows.registerGroupAndAttachLicense_deprecated({
             groupPool: address(evenSplitGroupPool),
             licenseTemplate: address(pilTemplate),
             licenseTermsId: testLicensesData[0].licenseTermsId
@@ -800,7 +800,7 @@ contract GroupingWorkflowsTest is BaseTest, ERC721Holder {
     // Register group IP → Attach license terms to group IPA → Add existing IPs to the new group IPA
     function test_GroupingWorkflows_registerGroupAndAttachLicenseAndAddIps_DEPR() public {
         vm.startPrank(groupOwner);
-        address newGroupId = groupingWorkflows.registerGroupAndAttachLicenseAndAddIps({
+        address newGroupId = groupingWorkflows.registerGroupAndAttachLicenseAndAddIps_deprecated({
             groupPool: address(evenSplitGroupPool),
             ipIds: ipIds,
             licenseTemplate: address(pilTemplate),
@@ -832,7 +832,7 @@ contract GroupingWorkflowsTest is BaseTest, ERC721Holder {
         address ipOwner2 = u.carl;
 
         vm.startPrank(groupOwner);
-        address newGroupId = groupingWorkflows.registerGroupAndAttachLicenseAndAddIps({
+        address newGroupId = groupingWorkflows.registerGroupAndAttachLicenseAndAddIps_deprecated({
             groupPool: address(evenSplitGroupPool),
             ipIds: ipIds,
             licenseTemplate: address(pilTemplate),
@@ -853,7 +853,7 @@ contract GroupingWorkflowsTest is BaseTest, ERC721Holder {
         mockToken.mint(ipOwner1, 1 * 10 ** mockToken.decimals());
         mockToken.approve(address(spgNftPublic), 1 * 10 ** mockToken.decimals());
 
-        (address ipId1, ) = derivativeWorkflows.mintAndRegisterIpAndMakeDerivative({
+        (address ipId1, ) = derivativeWorkflows.mintAndRegisterIpAndMakeDerivative_deprecated({
             spgNftContract: address(spgNftPublic),
             derivData: WorkflowStructs.MakeDerivativeDEPR({
                 parentIpIds: parentIpIds,
@@ -871,7 +871,7 @@ contract GroupingWorkflowsTest is BaseTest, ERC721Holder {
         mockToken.mint(ipOwner2, 1 * 10 ** mockToken.decimals());
         mockToken.approve(address(spgNftPublic), 1 * 10 ** mockToken.decimals());
 
-        (address ipId2, ) = derivativeWorkflows.mintAndRegisterIpAndMakeDerivative({
+        (address ipId2, ) = derivativeWorkflows.mintAndRegisterIpAndMakeDerivative_deprecated({
             spgNftContract: address(spgNftPublic),
             derivData: WorkflowStructs.MakeDerivativeDEPR({
                 parentIpIds: parentIpIds,
@@ -904,7 +904,7 @@ contract GroupingWorkflowsTest is BaseTest, ERC721Holder {
         address[] memory royaltyTokens = new address[](1);
         royaltyTokens[0] = address(mockToken);
 
-        uint256[] memory collectedRoyalties = groupingWorkflows.collectRoyaltiesAndClaimReward(
+        uint256[] memory collectedRoyalties = groupingWorkflows.collectRoyaltiesAndClaimReward_deprecated(
             newGroupId,
             royaltyTokens,
             snapshotIds,
@@ -935,7 +935,7 @@ contract GroupingWorkflowsTest is BaseTest, ERC721Holder {
         snapshotIds[0] = 0;
 
         vm.expectRevert(Errors.GroupingWorkflows__ZeroAddressParam.selector);
-        groupingWorkflows.collectRoyaltiesAndClaimReward(groupId, currencyTokens, snapshotIds, ipIds);
+        groupingWorkflows.collectRoyaltiesAndClaimReward_deprecated(groupId, currencyTokens, snapshotIds, ipIds);
     }
 
     // Multicall (mint → Register IP → Attach PIL terms → Add new IP to group IPA)
@@ -964,7 +964,7 @@ contract GroupingWorkflowsTest is BaseTest, ERC721Holder {
             data[i] = abi.encodeWithSelector(
                 bytes4(
                     keccak256(
-                        "mintAndRegisterIpAndAttachLicenseAndAddToGroup(address,address,address,address,uint256,(string,bytes32,string,bytes32),(address,uint256,bytes))"
+                        "mintAndRegisterIpAndAttachLicenseAndAddToGroup_deprecated(address,address,address,address,uint256,(string,bytes32,string,bytes32),(address,uint256,bytes))"
                     )
                 ),
                 address(spgNftPublic),
@@ -1054,7 +1054,7 @@ contract GroupingWorkflowsTest is BaseTest, ERC721Holder {
             data[i] = abi.encodeWithSelector(
                 bytes4(
                     keccak256(
-                        "registerIpAndAttachLicenseAndAddToGroup(address,uint256,address,address,uint256,(string,bytes32,string,bytes32),(address,uint256,bytes),(address,uint256,bytes))"
+                        "registerIpAndAttachLicenseAndAddToGroup_deprecated(address,uint256,address,address,uint256,(string,bytes32,string,bytes32),(address,uint256,bytes),(address,uint256,bytes))"
                     )
                 ),
                 mockNft,

--- a/test/workflows/LicenseAttachmentWorkflows.t.sol
+++ b/test/workflows/LicenseAttachmentWorkflows.t.sol
@@ -467,7 +467,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
 
         uint256 ltAmt = pilTemplate.totalRegisteredLicenseTerms();
 
-        uint256[] memory licenseTermsIds = licenseAttachmentWorkflows.registerPILTermsAndAttach({
+        uint256[] memory licenseTermsIds = licenseAttachmentWorkflows.registerPILTermsAndAttach_deprecated({
             ipId: ipId,
             terms: terms,
             sigAttach: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: signature })
@@ -487,7 +487,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
         withEnoughTokens(address(licenseAttachmentWorkflows))
     {
         (address ipId1, uint256 tokenId1, uint256[] memory licenseTermsIds1) = licenseAttachmentWorkflows
-            .mintAndRegisterIpAndAttachPILTerms({
+            .mintAndRegisterIpAndAttachPILTerms_deprecated({
                 spgNftContract: address(nftContract),
                 recipient: caller,
                 ipMetadata: ipMetadataEmpty,
@@ -519,7 +519,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
         assertEq(licenseTermsId, licenseTermsIds1[4]);
 
         (address ipId2, uint256 tokenId2, uint256[] memory licenseTermsIds2) = licenseAttachmentWorkflows
-            .mintAndRegisterIpAndAttachPILTerms({
+            .mintAndRegisterIpAndAttachPILTerms_deprecated({
                 spgNftContract: address(nftContract),
                 recipient: caller,
                 ipMetadata: ipMetadataDefault,
@@ -567,7 +567,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
             signerSk: sk.alice
         });
 
-        licenseAttachmentWorkflows.registerIpAndAttachPILTerms({
+        licenseAttachmentWorkflows.registerIpAndAttachPILTerms_deprecated({
             nftContract: address(nftContract),
             tokenId: tokenId,
             ipMetadata: ipMetadataDefault,
@@ -613,7 +613,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
             signerSk: sk.alice
         });
 
-        uint256[] memory licenseTermsIds1 = licenseAttachmentWorkflows.registerPILTermsAndAttach({
+        uint256[] memory licenseTermsIds1 = licenseAttachmentWorkflows.registerPILTermsAndAttach_deprecated({
             ipId: ipId,
             terms: terms,
             sigAttach: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: signature1 })
@@ -630,7 +630,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
         });
 
         /// attach the same license terms to the IP again, but it shouldn't revert
-        uint256[] memory licenseTermsIds2 = licenseAttachmentWorkflows.registerPILTermsAndAttach({
+        uint256[] memory licenseTermsIds2 = licenseAttachmentWorkflows.registerPILTermsAndAttach_deprecated({
             ipId: ipId,
             terms: terms,
             sigAttach: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: signature2 })
@@ -650,7 +650,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
         withEnoughTokens(address(licenseAttachmentWorkflows))
     {
         (address ipIdParent, , uint256[] memory licenseTermsIdsParent) = licenseAttachmentWorkflows
-            .mintAndRegisterIpAndAttachPILTerms({
+            .mintAndRegisterIpAndAttachPILTerms_deprecated({
                 spgNftContract: address(nftContract),
                 recipient: caller,
                 ipMetadata: ipMetadataDefault,
@@ -663,7 +663,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
         uint256[] memory licenseTermsIds = new uint256[](1);
         licenseTermsIds[0] = licenseTermsIdsParent[0];
 
-        (address ipIdChild, ) = derivativeWorkflows.mintAndRegisterIpAndMakeDerivative({
+        (address ipIdChild, ) = derivativeWorkflows.mintAndRegisterIpAndMakeDerivative_deprecated({
             spgNftContract: address(nftContract),
             derivData: WorkflowStructs.MakeDerivativeDEPR({
                 parentIpIds: parentIpIds,
@@ -689,7 +689,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
 
         /// attach license terms to the child ip, should revert with the correct error
         vm.expectRevert(CoreErrors.LicensingModule__DerivativesCannotAddLicenseTerms.selector);
-        licenseAttachmentWorkflows.registerPILTermsAndAttach({
+        licenseAttachmentWorkflows.registerPILTermsAndAttach_deprecated({
             ipId: ipIdChild,
             terms: terms,
             sigAttach: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: signature })
@@ -716,7 +716,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
 
         uint256 ltAmt = pilTemplate.totalRegisteredLicenseTerms();
 
-        uint256 licenseTermsId = licenseAttachmentWorkflows.registerPILTermsAndAttach({
+        uint256 licenseTermsId = licenseAttachmentWorkflows.registerPILTermsAndAttach_deprecated({
             ipId: ipId,
             terms: PILFlavors.commercialUse({
                 mintingFee: 100,
@@ -736,7 +736,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
         withEnoughTokens(address(licenseAttachmentWorkflows))
     {
         (address ipId1, uint256 tokenId1, uint256 licenseTermsId1) = licenseAttachmentWorkflows
-            .mintAndRegisterIpAndAttachPILTerms({
+            .mintAndRegisterIpAndAttachPILTerms_deprecated({
                 spgNftContract: address(nftContract),
                 recipient: caller,
                 ipMetadata: ipMetadataEmpty,
@@ -752,7 +752,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
         assertEq(licenseTermsId, licenseTermsId1);
 
         (address ipId2, uint256 tokenId2, uint256 licenseTermsId2) = licenseAttachmentWorkflows
-            .mintAndRegisterIpAndAttachPILTerms({
+            .mintAndRegisterIpAndAttachPILTerms_deprecated({
                 spgNftContract: address(nftContract),
                 recipient: caller,
                 ipMetadata: ipMetadataDefault,
@@ -796,7 +796,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
             signerSk: sk.alice
         });
 
-        licenseAttachmentWorkflows.registerIpAndAttachPILTerms({
+        licenseAttachmentWorkflows.registerIpAndAttachPILTerms_deprecated({
             nftContract: address(nftContract),
             tokenId: tokenId,
             ipMetadata: ipMetadataDefault,
@@ -824,7 +824,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
             signerSk: sk.alice
         });
 
-        uint256 licenseTermsId1 = licenseAttachmentWorkflows.registerPILTermsAndAttach({
+        uint256 licenseTermsId1 = licenseAttachmentWorkflows.registerPILTermsAndAttach_deprecated({
             ipId: ipId,
             terms: PILFlavors.commercialUse({
                 mintingFee: 100,
@@ -845,7 +845,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
         });
 
         // attach the same license terms to the IP again, but it shouldn't revert
-        uint256 licenseTermsId2 = licenseAttachmentWorkflows.registerPILTermsAndAttach({
+        uint256 licenseTermsId2 = licenseAttachmentWorkflows.registerPILTermsAndAttach_deprecated({
             ipId: ipId,
             terms: PILFlavors.commercialUse({
                 mintingFee: 100,
@@ -865,7 +865,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
         withEnoughTokens(address(licenseAttachmentWorkflows))
     {
         (address ipIdParent, , uint256 licenseTermsIdParent) = licenseAttachmentWorkflows
-            .mintAndRegisterIpAndAttachPILTerms({
+            .mintAndRegisterIpAndAttachPILTerms_deprecated({
                 spgNftContract: address(nftContract),
                 recipient: caller,
                 ipMetadata: ipMetadataDefault,
@@ -878,7 +878,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
         uint256[] memory licenseTermsIds = new uint256[](1);
         licenseTermsIds[0] = licenseTermsIdParent;
 
-        (address ipIdChild, ) = derivativeWorkflows.mintAndRegisterIpAndMakeDerivative({
+        (address ipIdChild, ) = derivativeWorkflows.mintAndRegisterIpAndMakeDerivative_deprecated({
             spgNftContract: address(nftContract),
             derivData: WorkflowStructs.MakeDerivativeDEPR({
                 parentIpIds: parentIpIds,
@@ -904,7 +904,7 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
 
         // attach a different license terms to the child ip, should revert with the correct error
         vm.expectRevert(CoreErrors.LicensingModule__DerivativesCannotAddLicenseTerms.selector);
-        licenseAttachmentWorkflows.registerPILTermsAndAttach({
+        licenseAttachmentWorkflows.registerPILTermsAndAttach_deprecated({
             ipId: ipIdChild,
             terms: PILFlavors.commercialUse({
                 mintingFee: 100,

--- a/test/workflows/RegistrationWorkflows.t.sol
+++ b/test/workflows/RegistrationWorkflows.t.sol
@@ -289,7 +289,7 @@ contract RegistrationWorkflowsTest is BaseTest {
 
         vm.expectRevert(Errors.Workflow__CallerNotAuthorizedToMint.selector);
         vm.prank(u.bob); // caller does not have minter role
-        registrationWorkflows.mintAndRegisterIp({
+        registrationWorkflows.mintAndRegisterIp_deprecated({
             spgNftContract: address(nftContract),
             recipient: u.bob,
             ipMetadata: ipMetadataEmpty
@@ -321,7 +321,7 @@ contract RegistrationWorkflowsTest is BaseTest {
         mockToken.approve(address(nftContract), 1000 * 10 ** mockToken.decimals());
 
         // caller has minter role and public minting is enabled
-        (address ipId, uint256 tokenId) = registrationWorkflows.mintAndRegisterIp({
+        (address ipId, uint256 tokenId) = registrationWorkflows.mintAndRegisterIp_deprecated({
             spgNftContract: address(nftContract),
             recipient: u.bob,
             ipMetadata: ipMetadataEmpty
@@ -338,7 +338,7 @@ contract RegistrationWorkflowsTest is BaseTest {
         mockToken.mint(address(caller), 1000 * 10 ** mockToken.decimals());
         mockToken.approve(address(nftContract), 1000 * 10 ** mockToken.decimals());
 
-        (address ipId1, uint256 tokenId1) = registrationWorkflows.mintAndRegisterIp({
+        (address ipId1, uint256 tokenId1) = registrationWorkflows.mintAndRegisterIp_deprecated({
             spgNftContract: address(nftContract),
             recipient: u.bob,
             ipMetadata: ipMetadataEmpty
@@ -348,7 +348,7 @@ contract RegistrationWorkflowsTest is BaseTest {
         assertEq(nftContract.tokenURI(tokenId1), string.concat(testBaseURI, tokenId1.toString()));
         assertMetadata(ipId1, ipMetadataEmpty);
 
-        (address ipId2, uint256 tokenId2) = registrationWorkflows.mintAndRegisterIp({
+        (address ipId2, uint256 tokenId2) = registrationWorkflows.mintAndRegisterIp_deprecated({
             spgNftContract: address(nftContract),
             recipient: u.bob,
             ipMetadata: ipMetadataDefault
@@ -370,7 +370,7 @@ contract RegistrationWorkflowsTest is BaseTest {
         bytes[] memory data = new bytes[](10);
         for (uint256 i = 0; i < 10; i++) {
             data[i] = abi.encodeWithSelector(
-                bytes4(keccak256("mintAndRegisterIp(address,address,(string,bytes32,string,bytes32))")),
+                bytes4(keccak256("mintAndRegisterIp_deprecated(address,address,(string,bytes32,string,bytes32))")),
                 address(nftContract),
                 u.bob,
                 ipMetadataDefault

--- a/test/workflows/RoyaltyTokenDistributionWorkflows.t.sol
+++ b/test/workflows/RoyaltyTokenDistributionWorkflows.t.sol
@@ -500,7 +500,7 @@ contract RoyaltyTokenDistributionWorkflowsTest is BaseTest {
         mockToken.approve(address(royaltyTokenDistributionWorkflows), licenseMintingFee);
 
         (address ipId, uint256 tokenId, uint256[] memory licenseTermsIds) = royaltyTokenDistributionWorkflows
-            .mintAndRegisterIpAndAttachPILTermsAndDistributeRoyaltyTokens({
+            .mintAndRegisterIpAndAttachPILTermsAndDistributeRoyaltyTokens_deprecated({
                 spgNftContract: address(spgNftPublic),
                 recipient: u.alice,
                 ipMetadata: ipMetadataDefault,
@@ -534,7 +534,7 @@ contract RoyaltyTokenDistributionWorkflowsTest is BaseTest {
         PILTerms[] memory terms = new PILTerms[](1);
         terms[0] = PILFlavors.nonCommercialSocialRemixing();
         vm.expectRevert(Errors.RoyaltyTokenDistributionWorkflows__RoyaltyVaultNotDeployed.selector);
-        royaltyTokenDistributionWorkflows.mintAndRegisterIpAndAttachPILTermsAndDistributeRoyaltyTokens({
+        royaltyTokenDistributionWorkflows.mintAndRegisterIpAndAttachPILTermsAndDistributeRoyaltyTokens_deprecated({
             spgNftContract: address(spgNftPublic),
             recipient: u.alice,
             ipMetadata: ipMetadataDefault,
@@ -578,12 +578,13 @@ contract RoyaltyTokenDistributionWorkflowsTest is BaseTest {
         vm.startPrank(u.alice);
         mockToken.mint(u.alice, licenseMintingFee);
         mockToken.approve(address(spgNftPublic), licenseMintingFee);
-        (ipIdParent[0], , licenseTermsIdsParent) = licenseAttachmentWorkflows.mintAndRegisterIpAndAttachPILTerms({
-            spgNftContract: address(spgNftPublic),
-            recipient: u.alice,
-            ipMetadata: ipMetadataDefault,
-            terms: commRemixTermsParent
-        });
+        (ipIdParent[0], , licenseTermsIdsParent) = licenseAttachmentWorkflows
+            .mintAndRegisterIpAndAttachPILTerms_deprecated({
+                spgNftContract: address(spgNftPublic),
+                recipient: u.alice,
+                ipMetadata: ipMetadataDefault,
+                terms: commRemixTermsParent
+            });
         vm.stopPrank();
 
         derivativeDataDEPR = WorkflowStructs.MakeDerivativeDEPR({


### PR DESCRIPTION
## Description
<!-- Add a description of the changes that this PR introduces -->
This PR resolves issues encountered during downstream integration with Ethereum libraries that do not fully support Solidity's function overloading. These issues caused errors when dispatching function calls on-chain. To address this, the deprecated overloaded functions have been renamed to make sure all functions have unique names.