### PR TITLE
docs: improve TODO comment for MockIPGraph limitation in RoyaltyWorkf…

### DIFF
--- a/test/workflows/RoyaltyWorkflows.t.sol
+++ b/test/workflows/RoyaltyWorkflows.t.sol
@@ -92,7 +92,8 @@ contract RoyaltyWorkflowsTest is BaseTest {
                 royaltyModule.maxPercent() + // 1000 * 10% = 100 royalty from childIpB
                 (((defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent()) * defaultCommRevShareA) /
                 royaltyModule.maxPercent() // 1000 * 10% * 10% = 10 royalty from grandChildIp
-            // TODO: should be 20 but MockIPGraph currently only supports single-path calculation
+            // TODO(SP-XXX): Value should be 20 but MockIPGraph in @storyprotocol/test currently only supports 
+            // single-path calculation. This needs to be updated once MockIPGraph supports multi-path calculations.
         );
         assertEq(
             claimerBalanceCAfter - claimerBalanceCBefore,


### PR DESCRIPTION
…lows test

Description:
Enhanced the TODO comment in RoyaltyWorkflows test to better document the current limitation of MockIPGraph regarding single-path calculations. This will help track the dependency on MockIPGraph's multi-path calculation support that needs to be implemented in the core Story Protocol repository.

The comment now includes:
- A placeholder for tracking issue number
- Clear explanation of the expected vs actual behavior
- Reference to the external dependency that needs to be updated
