### PR TITLE
Improve Grammar and Clarity in Code Comments

### DIFF
--- a/contracts/hooks/LockLicenseHook.sol
+++ b/contracts/hooks/LockLicenseHook.sol
@@ -16,13 +16,13 @@ contract LockLicenseHook is BaseModule, ILicensingHook {
 
     /// @notice This function is called when the LicensingModule mints license tokens.
     /// @dev This function will always revert to prevent any license token minting.
-    /// @param caller The address of the caller who calling the mintLicenseTokens() function.
+    /// @param caller The address of the caller who is calling the mintLicenseTokens() function.
     /// @param licensorIpId The ID of licensor IP from which issue the license tokens.
     /// @param licenseTemplate The address of the license template.
     /// @param licenseTermsId The ID of the license terms within the license template,
     /// which is used to mint license tokens.
     /// @param amount The amount of license tokens to mint.
-    /// @param receiver The address of the receiver who receive the license tokens.
+    /// @param receiver The address of the receiver who receives the license tokens.
     /// @param hookData The data to be used by the licensing hook.
     /// @return totalMintingFee The total minting fee to be paid when minting amount of license tokens.
     function beforeMintLicenseTokens(

--- a/contracts/interfaces/modules/tokenizer/IOwnableERC20.sol
+++ b/contracts/interfaces/modules/tokenizer/IOwnableERC20.sol
@@ -31,6 +31,6 @@ interface IOwnableERC20 is IERC20, IERC165 {
     /// @notice Returns the upgradable beacon
     function upgradableBeacon() external view returns (address);
 
-    /// @notice Returns the ip id to whom this fractionalized token belongs to
+    /// @notice Returns the ip id to which this fractionalized token belongs to
     function ipId() external view returns (address);
 }

--- a/contracts/interfaces/workflows/IGroupingWorkflows.sol
+++ b/contracts/interfaces/workflows/IGroupingWorkflows.sol
@@ -60,7 +60,7 @@ interface IGroupingWorkflows {
 
     /// @notice Register a group IP with a group reward pool, attach license terms to the group IP,
     /// and add individual IPs to the group IP.
-    /// @dev ipIds must be have the same license terms as the group IP.
+    /// @dev ipIds must have to the same license terms as the group IP.
     /// @param groupPool The address of the group reward pool.
     /// @param ipIds The IDs of the IPs to add to the newly registered group IP.
     /// @param licenseData The data of the license and its configuration to be attached to the new group IP.


### PR DESCRIPTION
  File: contracts/hooks/LockLicensesHook.sol
Old: who calling → New: who is calling
Reason: Added "is" for grammatical correctness.
Old: who receive → New: who receives
Reason: Changed to ensure subject-verb agreement.

  File: contracts/interfaces/modules/tokenizer/IOwnableERC20.sol
Old: to whom → New: to which
Reason: Corrected usage for referring to a token.
  
  File: contracts/interfaces/workflows/IGroupingWorkflows.sol
Old: must be have → New: must have to
Reason: Fixed grammatical accuracy.