### PR TITLE
feat: replace permanent permission with transient permission

### DIFF
--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -1,4 +1,3 @@
-
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 

--- a/contracts/lib/MetadataHelper.sol
+++ b/contracts/lib/MetadataHelper.sol
@@ -24,7 +24,7 @@ library MetadataHelper {
         WorkflowStructs.SignatureData calldata sigData
     ) internal {
         if (sigData.signer != address(0) && sigData.deadline != 0 && sigData.signature.length != 0) {
-            PermissionHelper.setPermissionForModule({
+            PermissionHelper.setTransientPermissionForModule({
                 ipId: ipId,
                 module: coreMetadataModule,
                 accessController: accessController,

--- a/contracts/lib/PermissionHelper.sol
+++ b/contracts/lib/PermissionHelper.sol
@@ -10,14 +10,14 @@ import { WorkflowStructs } from "./WorkflowStructs.sol";
 /// @title Periphery Permission Helper Library
 /// @notice Library for all permissions related helper functions for Periphery contracts.
 library PermissionHelper {
-    /// @dev Sets permission via signature to allow this contract to interact with the Licensing Module on behalf of the
+    /// @dev Sets transient permission via signature to allow this contract to interact with the Licensing Module on behalf of the
     /// provided IP Account.
     /// @param ipId The ID of the IP.
     /// @param module The address of the module to set the permission for.
     /// @param accessController The address of the Access Controller contract.
     /// @param selector The selector of the function to be permitted for execution.
     /// @param sigData Signature data for setting the permission.
-    function setPermissionForModule(
+    function setTransientPermissionForModule(
         address ipId,
         address module,
         address accessController,
@@ -28,7 +28,7 @@ library PermissionHelper {
             accessController,
             0,
             abi.encodeWithSelector(
-                IAccessController.setPermission.selector,
+                IAccessController.setTransientPermission.selector,
                 address(ipId),
                 address(this),
                 address(module),
@@ -41,14 +41,14 @@ library PermissionHelper {
         );
     }
 
-    /// @dev Sets batch permission via signature to allow this contract to interact with multiple modules
+    /// @dev Sets batch transient permission via signature to allow this contract to interact with multiple modules
     /// on behalf of the provided IP Account.
     /// @param ipId The ID of the IP.
     /// @param accessController The address of the Access Controller contract.
     /// @param modules The addresses of the modules to set the permission for.
     /// @param selectors The selectors of the functions to be permitted for execution.
     /// @param sigData Signature data for setting the batch permission.
-    function setBatchPermissionForModules(
+    function setBatchTransientPermissionForModules(
         address ipId,
         address accessController,
         address[] memory modules,
@@ -70,7 +70,7 @@ library PermissionHelper {
         IIPAccount(payable(ipId)).executeWithSig(
             accessController,
             0,
-            abi.encodeWithSelector(IAccessController.setBatchPermissions.selector, permissionList),
+            abi.encodeWithSelector(IAccessController.setBatchTransientPermissions.selector, permissionList),
             sigData.signer,
             sigData.deadline,
             sigData.signature

--- a/contracts/workflows/DerivativeWorkflows.sol
+++ b/contracts/workflows/DerivativeWorkflows.sol
@@ -154,7 +154,7 @@ contract DerivativeWorkflows is
         modules[1] = address(LICENSING_MODULE);
         selectors[0] = ICoreMetadataModule.setAll.selector;
         selectors[1] = ILicensingModule.registerDerivative.selector;
-        PermissionHelper.setBatchPermissionForModules({
+        PermissionHelper.setBatchTransientPermissionForModules({
             ipId: ipId,
             accessController: address(ACCESS_CONTROLLER),
             modules: modules,
@@ -242,7 +242,7 @@ contract DerivativeWorkflows is
         modules[1] = address(LICENSING_MODULE);
         selectors[0] = ICoreMetadataModule.setAll.selector;
         selectors[1] = ILicensingModule.registerDerivativeWithLicenseTokens.selector;
-        PermissionHelper.setBatchPermissionForModules({
+        PermissionHelper.setBatchTransientPermissionForModules({
             ipId: ipId,
             accessController: address(ACCESS_CONTROLLER),
             modules: modules,
@@ -349,7 +349,7 @@ contract DerivativeWorkflows is
             sigMetadata
         );
 
-        PermissionHelper.setPermissionForModule(
+        PermissionHelper.setTransientPermissionForModule(
             ipId,
             address(LICENSING_MODULE),
             address(ACCESS_CONTROLLER),
@@ -436,7 +436,7 @@ contract DerivativeWorkflows is
             sigMetadata
         );
 
-        PermissionHelper.setPermissionForModule(
+        PermissionHelper.setTransientPermissionForModule(
             ipId,
             address(LICENSING_MODULE),
             address(ACCESS_CONTROLLER),

--- a/contracts/workflows/GroupingWorkflows.sol
+++ b/contracts/workflows/GroupingWorkflows.sol
@@ -139,7 +139,7 @@ contract GroupingWorkflows is
 
         _attachLicensesAndSetConfigs(ipId, licensesData);
 
-        PermissionHelper.setPermissionForModule(
+        PermissionHelper.setTransientPermissionForModule(
             groupId,
             address(GROUPING_MODULE),
             address(ACCESS_CONTROLLER),
@@ -193,7 +193,7 @@ contract GroupingWorkflows is
         selectors[1] = ILicensingModule.attachLicenseTerms.selector;
         selectors[2] = ILicensingModule.setLicensingConfig.selector;
 
-        PermissionHelper.setBatchPermissionForModules({
+        PermissionHelper.setBatchTransientPermissionForModules({
             ipId: ipId,
             accessController: address(ACCESS_CONTROLLER),
             modules: modules,
@@ -205,7 +205,7 @@ contract GroupingWorkflows is
 
         _attachLicensesAndSetConfigs(ipId, licensesData);
 
-        PermissionHelper.setPermissionForModule(
+        PermissionHelper.setTransientPermissionForModule(
             groupId,
             address(GROUPING_MODULE),
             address(ACCESS_CONTROLLER),
@@ -362,7 +362,7 @@ contract GroupingWorkflows is
 
         _prepConfigAndAttachLicenseAndSetConfig(ipId, groupId, licenseTemplate, licenseTermsId);
 
-        PermissionHelper.setPermissionForModule(
+        PermissionHelper.setTransientPermissionForModule(
             groupId,
             address(GROUPING_MODULE),
             address(ACCESS_CONTROLLER),
@@ -408,7 +408,7 @@ contract GroupingWorkflows is
         selectors[1] = ILicensingModule.attachLicenseTerms.selector;
         selectors[2] = ILicensingModule.setLicensingConfig.selector;
 
-        PermissionHelper.setBatchPermissionForModules(
+        PermissionHelper.setBatchTransientPermissionForModules(
             ipId,
             address(ACCESS_CONTROLLER),
             modules,
@@ -420,7 +420,7 @@ contract GroupingWorkflows is
 
         _prepConfigAndAttachLicenseAndSetConfig(ipId, groupId, licenseTemplate, licenseTermsId);
 
-        PermissionHelper.setPermissionForModule(
+        PermissionHelper.setTransientPermissionForModule(
             groupId,
             address(GROUPING_MODULE),
             address(ACCESS_CONTROLLER),

--- a/contracts/workflows/LicenseAttachmentWorkflows.sol
+++ b/contracts/workflows/LicenseAttachmentWorkflows.sol
@@ -93,7 +93,7 @@ contract LicenseAttachmentWorkflows is
         modules[1] = address(LICENSING_MODULE);
         selectors[0] = ILicensingModule.attachLicenseTerms.selector;
         selectors[1] = ILicensingModule.setLicensingConfig.selector;
-        PermissionHelper.setBatchPermissionForModules({
+        PermissionHelper.setBatchTransientPermissionForModules({
             ipId: ipId,
             accessController: address(ACCESS_CONTROLLER),
             modules: modules,
@@ -186,7 +186,7 @@ contract LicenseAttachmentWorkflows is
         selectors[0] = ICoreMetadataModule.setAll.selector;
         selectors[1] = ILicensingModule.attachLicenseTerms.selector;
         selectors[2] = ILicensingModule.setLicensingConfig.selector;
-        PermissionHelper.setBatchPermissionForModules({
+        PermissionHelper.setBatchTransientPermissionForModules({
             ipId: ipId,
             accessController: address(ACCESS_CONTROLLER),
             modules: modules,
@@ -258,7 +258,7 @@ contract LicenseAttachmentWorkflows is
         modules[1] = address(LICENSING_MODULE);
         selectors[0] = ICoreMetadataModule.setAll.selector;
         selectors[1] = ILicensingModule.attachDefaultLicenseTerms.selector;
-        PermissionHelper.setBatchPermissionForModules({
+        PermissionHelper.setBatchTransientPermissionForModules({
             ipId: ipId,
             accessController: address(ACCESS_CONTROLLER),
             modules: modules,
@@ -294,7 +294,7 @@ contract LicenseAttachmentWorkflows is
         if (msg.sender != sigAttach.signer)
             revert Errors.LicenseAttachmentWorkflows__CallerNotSigner(msg.sender, sigAttach.signer);
 
-        PermissionHelper.setPermissionForModule(
+        PermissionHelper.setTransientPermissionForModule(
             ipId,
             address(LICENSING_MODULE),
             address(ACCESS_CONTROLLER),
@@ -360,7 +360,7 @@ contract LicenseAttachmentWorkflows is
             sigMetadata
         );
 
-        PermissionHelper.setPermissionForModule(
+        PermissionHelper.setTransientPermissionForModule(
             ipId,
             address(LICENSING_MODULE),
             address(ACCESS_CONTROLLER),
@@ -381,7 +381,7 @@ contract LicenseAttachmentWorkflows is
         if (msg.sender != sigAttach.signer)
             revert Errors.LicenseAttachmentWorkflows__CallerNotSigner(msg.sender, sigAttach.signer);
 
-        PermissionHelper.setPermissionForModule(
+        PermissionHelper.setTransientPermissionForModule(
             ipId,
             address(LICENSING_MODULE),
             address(ACCESS_CONTROLLER),
@@ -450,7 +450,7 @@ contract LicenseAttachmentWorkflows is
             sigMetadata
         );
 
-        PermissionHelper.setPermissionForModule(
+        PermissionHelper.setTransientPermissionForModule(
             ipId,
             address(LICENSING_MODULE),
             address(ACCESS_CONTROLLER),

--- a/contracts/workflows/RoyaltyTokenDistributionWorkflows.sol
+++ b/contracts/workflows/RoyaltyTokenDistributionWorkflows.sol
@@ -234,7 +234,7 @@ contract RoyaltyTokenDistributionWorkflows is
         selectors[0] = ICoreMetadataModule.setAll.selector;
         selectors[1] = ILicensingModule.attachLicenseTerms.selector;
         selectors[2] = ILicensingModule.setLicensingConfig.selector;
-        PermissionHelper.setBatchPermissionForModules({
+        PermissionHelper.setBatchTransientPermissionForModules({
             ipId: ipId,
             accessController: address(ACCESS_CONTROLLER),
             modules: modules,
@@ -281,7 +281,7 @@ contract RoyaltyTokenDistributionWorkflows is
         modules[1] = address(LICENSING_MODULE);
         selectors[0] = ICoreMetadataModule.setAll.selector;
         selectors[1] = ILicensingModule.registerDerivative.selector;
-        PermissionHelper.setBatchPermissionForModules({
+        PermissionHelper.setBatchTransientPermissionForModules({
             ipId: ipId,
             accessController: address(ACCESS_CONTROLLER),
             modules: modules,
@@ -509,7 +509,7 @@ contract RoyaltyTokenDistributionWorkflows is
             sigMetadata
         );
 
-        PermissionHelper.setPermissionForModule(
+        PermissionHelper.setTransientPermissionForModule(
             ipId,
             address(LICENSING_MODULE),
             address(ACCESS_CONTROLLER),

--- a/test/integration/BaseIntegration.t.sol
+++ b/test/integration/BaseIntegration.t.sol
@@ -247,12 +247,12 @@ contract BaseIntegration is Test, Script, StoryProtocolCoreAddressManager, Story
                     IIPAccount.execute.selector,
                     address(accessControllerAddr),
                     0, // amount of ether to send
-                    abi.encodeWithSelector(IAccessController.setBatchPermissions.selector, permissionList)
+                    abi.encodeWithSelector(IAccessController.setBatchTransientPermissions.selector, permissionList)
                 )
             )
         );
 
-        data = abi.encodeWithSelector(IAccessController.setBatchPermissions.selector, permissionList);
+        data = abi.encodeWithSelector(IAccessController.setBatchTransientPermissions.selector, permissionList);
 
         bytes32 digest = MessageHashUtils.toTypedDataHash(
             MetaTx.calculateDomainSeparator(ipId),
@@ -299,7 +299,7 @@ contract BaseIntegration is Test, Script, StoryProtocolCoreAddressManager, Story
                     address(accessControllerAddr),
                     0, // amount of ether to send
                     abi.encodeWithSelector(
-                        IAccessController.setPermission.selector,
+                        IAccessController.setTransientPermission.selector,
                         ipId,
                         to,
                         address(module),
@@ -311,7 +311,7 @@ contract BaseIntegration is Test, Script, StoryProtocolCoreAddressManager, Story
         );
 
         data = abi.encodeWithSelector(
-            IAccessController.setPermission.selector,
+            IAccessController.setTransientPermission.selector,
             ipId,
             to,
             address(module),

--- a/test/utils/BaseTest.t.sol
+++ b/test/utils/BaseTest.t.sol
@@ -423,12 +423,12 @@ contract BaseTest is Test, DeployHelper {
                     IIPAccount.execute.selector,
                     address(accessControllerAddr),
                     0, // amount of ether to send
-                    abi.encodeWithSelector(IAccessController.setBatchPermissions.selector, permissionList)
+                    abi.encodeWithSelector(IAccessController.setBatchTransientPermissions.selector, permissionList)
                 )
             )
         );
 
-        data = abi.encodeWithSelector(IAccessController.setBatchPermissions.selector, permissionList);
+        data = abi.encodeWithSelector(IAccessController.setBatchTransientPermissions.selector, permissionList);
 
         bytes32 digest = MessageHashUtils.toTypedDataHash(
             MetaTx.calculateDomainSeparator(ipId),
@@ -475,7 +475,7 @@ contract BaseTest is Test, DeployHelper {
                     address(accessControllerAddr),
                     0, // amount of ether to send
                     abi.encodeWithSelector(
-                        IAccessController.setPermission.selector,
+                        IAccessController.setTransientPermission.selector,
                         ipId,
                         to,
                         address(module),
@@ -487,7 +487,7 @@ contract BaseTest is Test, DeployHelper {
         );
 
         data = abi.encodeWithSelector(
-            IAccessController.setPermission.selector,
+            IAccessController.setTransientPermission.selector,
             ipId,
             to,
             address(module),

--- a/yarn.lock
+++ b/yarn.lock
@@ -418,7 +418,7 @@
 
 "@story-protocol/protocol-core@github:storyprotocol/protocol-core-v1#main":
   version "1.1.0"
-  resolved "https://codeload.github.com/storyprotocol/protocol-core-v1/tar.gz/108f44760d86e4e90d20a4c0e474e00df5d2c1ee"
+  resolved "https://codeload.github.com/storyprotocol/protocol-core-v1/tar.gz/a10c179c93cc7d360bcd9a290cd159c1574928f2"
   dependencies:
     "@openzeppelin/contracts" "5.2.0"
     "@openzeppelin/contracts-upgradeable" "5.2.0"
@@ -471,9 +471,9 @@
   integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
 "@types/node@*":
-  version "22.12.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.12.0.tgz#bf8af3b2af0837b5a62a368756ff2b705ae0048c"
-  integrity sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==
+  version "22.13.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.13.1.tgz#a2a3fefbdeb7ba6b89f40371842162fac0934f33"
+  integrity sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==
   dependencies:
     undici-types "~6.20.0"
 
@@ -1517,9 +1517,9 @@ ignore@^5.1.1, ignore@^5.2.0, ignore@^5.2.4:
   integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
 
 import-fresh@^3.2.1, import-fresh@^3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
-  integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.1.tgz#9cecb56503c0ada1f2741dbbd6546e4b13b57ccf"
+  integrity sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
@@ -2237,9 +2237,9 @@ sc-istanbul@^0.4.5:
     wordwrap "^1.0.0"
 
 semver@^7.3.4, semver@^7.3.7, semver@^7.5.2, semver@^7.6.3:
-  version "7.7.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.0.tgz#9c6fe61d0c6f9fa9e26575162ee5a9180361b09c"
-  integrity sha512-DrfFnPzblFmNrIZzg5RzHegbiRWg7KMR7btwi2yjHwx06zsUbO5g613sVwEV7FTwmzJu+Io0lJe2GJ3LxqpvBQ==
+  version "7.7.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.1.tgz#abd5098d82b18c6c81f6074ff2647fd3e7220c9f"
+  integrity sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==
 
 serialize-javascript@^6.0.2:
   version "6.0.2"


### PR DESCRIPTION
## Description
<!-- Add a description of the changes that this PR introduces -->
This PR updates the permission system to use transient permissions (introduced in core protocol [PR #393](https://github.com/storyprotocol/protocol-core-v1/pull/393)) instead of permanent permissions across the workflow contracts. This change affects multiple contracts and their interactions with the `AccessController`. 

### Key Changes
- Renamed permission-related functions to include "transient" in their names:
  - `setPermission` → `setTransientPermission`
  - `setBatchPermissions` → `setBatchTransientPermissions`
  - `setPermissionForModule` → `setTransientPermissionForModule`
  - `setBatchPermissionForModules` → `setBatchTransientPermissionForModules`

### Dependencies
- Updated protocol-core dependency to latest version

## Impact
This change improves security by making permissions temporary rather than permanent, reducing the risk of lingering permissions. The functionality remains the same, but permissions will now automatically expire after use.

## Testing
All existing tests have been updated to use the new transient permission functions and should pass without modification to their logic.

## Additional Notes
- No breaking changes to external interfaces
- All permission-related function calls have been updated consistently across the codebase
- Documentation comments have been updated to reflect the transient nature of permissions