### PR TITLE
fix: license attachment integration tests

### DIFF
--- a/test/integration/BaseIntegration.t.sol
+++ b/test/integration/BaseIntegration.t.sol
@@ -224,6 +224,32 @@ contract BaseIntegration is Test, Script, StoryProtocolCoreAddressManager, Story
         }
     }
 
+    /// @dev Get the permission list for setting metadata and attaching default license terms for the IP.
+    /// @param ipId The ID of the IP that the permissions are for.
+    /// @param to The address of the periphery contract to receive the permission.
+    /// @return permissionList The list of permissions for setting metadata and attaching default license terms.
+    function _getMetadataAndDefaultTermsPermissionList(
+        address ipId,
+        address to
+    ) internal view returns (AccessPermission.Permission[] memory permissionList) {
+        address[] memory modules = new address[](2);
+        bytes4[] memory selectors = new bytes4[](2);
+        permissionList = new AccessPermission.Permission[](2);
+        modules[0] = coreMetadataModuleAddr;
+        modules[1] = licensingModuleAddr;
+        selectors[0] = ICoreMetadataModule.setAll.selector;
+        selectors[1] = ILicensingModule.attachDefaultLicenseTerms.selector;
+        for (uint256 i = 0; i < 2; i++) {
+            permissionList[i] = AccessPermission.Permission({
+                ipAccount: ipId,
+                signer: to,
+                to: modules[i],
+                func: selectors[i],
+                permission: AccessPermission.ALLOW
+            });
+        }
+    }
+
     /// @dev Get the signature for setting batch permission for the IP by the SPG.
     /// @param ipId The ID of the IP to set the permissions for.
     /// @param permissionList A list of permissions to set.

--- a/test/integration/workflows/LicenseAttachmentIntegration.t.sol
+++ b/test/integration/workflows/LicenseAttachmentIntegration.t.sol
@@ -223,12 +223,9 @@ contract LicenseAttachmentIntegration is BaseIntegration {
 
         uint256 deadline = block.timestamp + 1000;
 
-        (bytes memory sigMetadataAndAttachAndConfig, bytes32 expectedState, ) = _getSetBatchPermissionSigForPeriphery({
+        (bytes memory sigMetadataAndDefaultTerms, bytes32 expectedState, ) = _getSetBatchPermissionSigForPeriphery({
             ipId: expectedIpId,
-            permissionList: _getMetadataAndAttachTermsAndConfigPermissionList(
-                expectedIpId,
-                licenseAttachmentWorkflowsAddr
-            ),
+            permissionList: _getMetadataAndDefaultTermsPermissionList(expectedIpId, licenseAttachmentWorkflowsAddr),
             deadline: deadline,
             state: bytes32(0),
             signerSk: testSenderSk
@@ -241,7 +238,7 @@ contract LicenseAttachmentIntegration is BaseIntegration {
             sigMetadataAndDefaultTerms: WorkflowStructs.SignatureData({
                 signer: testSender,
                 deadline: deadline,
-                signature: sigMetadataAndAttachAndConfig
+                signature: sigMetadataAndDefaultTerms
             })
         });
 


### PR DESCRIPTION
## Description 

Fixed an issue in the license attachment integration test where an incorrect permission helper function was being used, leading to invalid signatures in the test case.

## Changes
- Added new helper function `_getMetadataAndDefaultTermsPermissionList` in `BaseIntegration.t.sol` to correctly generate permissions for metadata and default license terms
- Updated `LicenseAttachmentIntegration.t.sol` to use the correct helper function instead of the invalid `_getMetadataAndAttachTermsAndConfigPermissionList`
- Renamed variables to better reflect their purpose (e.g., `sigMetadataAndAttachAndConfig` → `sigMetadataAndDefaultTerms`)
