### PR TITLE
fix: lock pragma version in `CachableNFT`

### DIFF
--- a/contracts/story-nft/CachableNFT.sol
+++ b/contracts/story-nft/CachableNFT.sol
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.8.26;
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.26;
 
 // cache contract has three modes
 // 1. cache mode


### PR DESCRIPTION
## Description
<!-- Add a description of the changes that this PR introduces -->
This PR locks `CachableNFT`'s pragma version to 0.8.26 and updates the license to MIT

