### PR TITLE
fix: add array length matching check in internal library functions

### DIFF
--- a/contracts/lib/LicensingHelper.sol
+++ b/contracts/lib/LicensingHelper.sol
@@ -17,6 +17,9 @@ import { WorkflowStructs } from "./WorkflowStructs.sol";
 library LicensingHelper {
     using SafeERC20 for IERC20;
 
+    /// @notice Error for when the length of parent IP IDs and license terms IDs mismatch.
+    error LicensingHelper__ParentIpIdsAndLicenseTermsIdsMismatch();
+
     /// @notice Registers multiple PIL terms and attaches them to the given IP and sets their licensing configurations.
     /// @param ipId The ID of the IP.
     /// @param licenseTermsData The PIL terms and licensing configuration data to be attached to the IP.
@@ -208,6 +211,9 @@ library LicensingHelper {
         address[] memory parentIpIds,
         uint256[] memory licenseTermsIds
     ) private view returns (uint256 totalMintFee) {
+        if (parentIpIds.length != licenseTermsIds.length)
+            revert LicensingHelper__ParentIpIdsAndLicenseTermsIdsMismatch();
+
         uint256 mintFee;
 
         for (uint256 i = 0; i < parentIpIds.length; i++) {

--- a/contracts/lib/PermissionHelper.sol
+++ b/contracts/lib/PermissionHelper.sol
@@ -10,6 +10,9 @@ import { WorkflowStructs } from "./WorkflowStructs.sol";
 /// @title Periphery Permission Helper Library
 /// @notice Library for all permissions related helper functions for Periphery contracts.
 library PermissionHelper {
+    /// @notice Error for when the length of modules and selectors mismatch.
+    error PermissionHelper__ModulesAndSelectorsMismatch();
+
     /// @dev Sets transient permission via signature to allow this contract to interact with the Licensing Module on behalf of the
     /// provided IP Account.
     /// @param ipId The ID of the IP.
@@ -55,7 +58,8 @@ library PermissionHelper {
         bytes4[] memory selectors,
         WorkflowStructs.SignatureData calldata sigData
     ) internal {
-        // assumes modules and selectors must have a 1:1 mapping
+        if (modules.length != selectors.length) revert PermissionHelper__ModulesAndSelectorsMismatch();
+
         AccessPermission.Permission[] memory permissionList = new AccessPermission.Permission[](modules.length);
         for (uint256 i = 0; i < modules.length; i++) {
             permissionList[i] = AccessPermission.Permission({


### PR DESCRIPTION
## Description
<!-- Add a description of the changes that this PR introduces -->
This PR adds array length validation checks in the following functions:  

- `setBatchPermissionForModules` in `PermissionHelper`  
- `aggregateMintFees`  
- `LicensingHelper`  