### PR TITLE
fix(story-nft): enforce max balanceOf() of 1 for each address

### DIFF
--- a/contracts/interfaces/story-nft/IStoryBadgeNFT.sol
+++ b/contracts/interfaces/story-nft/IStoryBadgeNFT.sol
@@ -24,6 +24,10 @@ interface IStoryBadgeNFT is IStoryNFT, IERC721Metadata, IERC5192 {
     /// @notice Zero address provided as a param to StoryBadgeNFT functions.
     error StoryBadgeNFT__ZeroAddressParam();
 
+    /// @notice The recipient already has a badge.
+    /// @param recipient The address of the recipient.
+    error StoryBadgeNFT__RecipientAlreadyHasBadge(address recipient);
+
     ////////////////////////////////////////////////////////////////////////////
     //                              Structs                                   //
     ////////////////////////////////////////////////////////////////////////////

--- a/contracts/story-nft/OrgStoryNFTFactory.sol
+++ b/contracts/story-nft/OrgStoryNFTFactory.sol
@@ -273,6 +273,9 @@ contract OrgStoryNFTFactory is IOrgStoryNFTFactory, AccessManagedUpgradeable, UU
         if ($.deployedOrgStoryNftsByOrgName[orgName] != address(0))
             revert OrgStoryNFTFactory__OrgAlreadyDeployed(orgName, $.deployedOrgStoryNftsByOrgName[orgName]);
 
+        if (ORG_NFT.balanceOf(orgNftRecipient) > 0)
+            revert OrgStoryNFTFactory__OrgAlreadyDeployed(orgName, $.deployedOrgStoryNftsByOrgName[orgName]);
+
         // Mint the organization NFT and register it as an IP
         if (isRootOrg) {
             (orgTokenId, orgIpId) = ORG_NFT.mintRootOrgNft(orgNftRecipient, orgIpMetadata);

--- a/contracts/story-nft/StoryBadgeNFT.sol
+++ b/contracts/story-nft/StoryBadgeNFT.sol
@@ -91,6 +91,9 @@ contract StoryBadgeNFT is IStoryBadgeNFT, BaseOrgStoryNFT, CachableNFT, ERC721Ho
         // The given signature must not have been used
         if ($.usedSignatures[signature]) revert StoryBadgeNFT__SignatureAlreadyUsed();
 
+        // The recipient must not already have a badge
+        if (balanceOf(recipient) > 0) revert StoryBadgeNFT__RecipientAlreadyHasBadge(recipient);
+
         // Mark the signature as used
         $.usedSignatures[signature] = true;
 

--- a/test/story-nft/OrgStoryNFTFactory.t.sol
+++ b/test/story-nft/OrgStoryNFTFactory.t.sol
@@ -369,4 +369,42 @@ contract OrgStoryNFTFactoryTest is BaseTest {
             storyNftInitParams: storyNftInitParams
         });
     }
+
+    function test_StoryNFTFactory_revert_deployStoryNftByAdmin_OrgAlreadyDeployed() public {
+        bytes memory signature = _signAddress(orgStoryNftFactorySignerSk, u.carl);
+
+        vm.startPrank(u.carl);
+        (, uint256 orgTokenId, address orgIpId, address storyNft) = orgStoryNftFactory.deployOrgStoryNft({
+            orgStoryNftTemplate: address(defaultOrgStoryNftTemplate),
+            orgNftRecipient: u.carl,
+            orgName: orgName,
+            orgIpMetadata: ipMetadataDefault,
+            signature: signature,
+            storyNftInitParams: storyNftInitParams
+        });
+        vm.stopPrank();
+
+        // Change signer
+        vm.prank(u.admin);
+        orgStoryNftFactory.setSigner(u.dan);
+
+        // Try to deploy with same org name but different signer
+        signature = _signAddress(sk.dan, u.carl);
+        vm.prank(u.carl);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IOrgStoryNFTFactory.OrgStoryNFTFactory__OrgAlreadyDeployed.selector,
+                orgName,
+                address(storyNft)
+            )
+        );
+        orgStoryNftFactory.deployOrgStoryNft({
+            orgStoryNftTemplate: address(defaultOrgStoryNftTemplate),
+            orgNftRecipient: u.carl,
+            orgName: orgName,
+            orgIpMetadata: ipMetadataDefault,
+            signature: signature,
+            storyNftInitParams: storyNftInitParams
+        });
+    }
 }

--- a/test/story-nft/StoryBadgeNFT.t.sol
+++ b/test/story-nft/StoryBadgeNFT.t.sol
@@ -321,4 +321,25 @@ contract StoryBadgeNFTTest is BaseTest {
         rootOrgStoryNft.safeTransferFrom(u.carl, u.bob, tokenId);
         vm.stopPrank();
     }
+
+    function test_StoryBadgeNFT_revert_mint_RecipientAlreadyHasBadge() public {
+        bytes memory signature = _signAddress(rootOrgStoryNftSignerSk, u.carl);
+
+        vm.startPrank(u.carl);
+        rootOrgStoryNft.mint(u.carl, signature);
+        vm.stopPrank();
+
+        // Change signer
+        vm.prank(u.admin);
+        rootOrgStoryNft.setSigner(u.dan);
+
+        // Try to mint again with new signer
+        signature = _signAddress(sk.dan, u.carl);
+
+        vm.prank(u.carl);
+        vm.expectRevert(
+            abi.encodeWithSelector(IStoryBadgeNFT.StoryBadgeNFT__RecipientAlreadyHasBadge.selector, u.carl)
+        );
+        rootOrgStoryNft.mint(u.carl, signature);
+    }
 }


### PR DESCRIPTION
## Description
<!-- Add a description of the changes that this PR introduces -->
This PR enhances security in the `StoryBadgeNFT` and `OrgStoryNFTFactory` contracts by adding additional validation checks to prevent duplicate minting scenarios. 

For `StoryBadgeNFT`, we now verify that a recipient can only hold one badge NFT by checking their balance before minting, regardless of signature changes. Similarly for `OrgStoryNFTFactory`, we validate that an organization NFT recipient doesn't already have an NFT before deployment. 

These changes are accompanied by new error types (`StoryBadgeNFT__RecipientAlreadyHasBadge`) and test cases to verify the updated behavior. 