### PR TITLE
feat(SPGNFT): add `setTokenURI` function to `SPGNFT` Contract

### DIFF
--- a/contracts/SPGNFT.sol
+++ b/contracts/SPGNFT.sol
@@ -222,13 +222,13 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
     /// @notice Sets the token URI for a specific token.
     /// @dev Only callable by the owner of the token. This updates the metadata URI
     ///      for the specified token and emits a MetadataUpdate event.
-    /// @param tokenId The ID of the token to update.
+    /// @param tokenId_ The ID of the token to update.
     /// @param tokenURI_ The new metadata URI to associate with the token.
-    function setTokenURI(uint256 tokenId, string memory tokenURI_) external {
+    function setTokenURI(uint256 tokenId_, string memory tokenURI_) external {
         // revert if caller is not the owner of the `tokenId` token
-        address owner = ownerOf(tokenId);
-        if (owner != msg.sender) revert Errors.SPGNFT__CallerNotOwner(tokenId, msg.sender, owner);
-        _setTokenURI(tokenId, tokenURI_);
+        address owner = ownerOf(tokenId_);
+        if (owner != msg.sender) revert Errors.SPGNFT__CallerNotOwner(tokenId_, msg.sender, owner);
+        _setTokenURI(tokenId_, tokenURI_);
     }
 
     /// @notice Sets the contract URI for the collection.

--- a/contracts/SPGNFT.sol
+++ b/contracts/SPGNFT.sol
@@ -219,6 +219,18 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
         _getSPGNFTStorage()._baseURI = baseURI;
     }
 
+    /// @notice Sets the token URI for a specific token.
+    /// @dev Only callable by the owner of the token. This updates the metadata URI
+    ///      for the specified token and emits a MetadataUpdate event.
+    /// @param tokenId The ID of the token to update.
+    /// @param tokenURI_ The new metadata URI to associate with the token.
+    function setTokenURI(uint256 tokenId, string memory tokenURI_) external {
+        // revert if caller is not the owner of the `tokenId` token
+        address owner = ownerOf(tokenId);
+        if (owner != msg.sender) revert Errors.SPGNFT__CallerNotOwner(tokenId, msg.sender, owner);
+        _setTokenURI(tokenId, tokenURI_);
+    }
+
     /// @notice Sets the contract URI for the collection.
     /// @dev Only callable by the admin role.
     /// @param contractURI The new contract URI for the collection. Follows ERC-7572 standard.

--- a/contracts/SPGNFT.sol
+++ b/contracts/SPGNFT.sol
@@ -222,13 +222,13 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
     /// @notice Sets the token URI for a specific token.
     /// @dev Only callable by the owner of the token. This updates the metadata URI
     ///      for the specified token and emits a MetadataUpdate event.
-    /// @param tokenId_ The ID of the token to update.
-    /// @param tokenURI_ The new metadata URI to associate with the token.
-    function setTokenURI(uint256 tokenId_, string memory tokenURI_) external {
+    /// @param tokenId The ID of the token to update.
+    /// @param tokenUri The new metadata URI to associate with the token.
+    function setTokenURI(uint256 tokenId, string memory tokenUri) external {
         // revert if caller is not the owner of the `tokenId` token
-        address owner = ownerOf(tokenId_);
-        if (owner != msg.sender) revert Errors.SPGNFT__CallerNotOwner(tokenId_, msg.sender, owner);
-        _setTokenURI(tokenId_, tokenURI_);
+        address owner = ownerOf(tokenId);
+        if (owner != msg.sender) revert Errors.SPGNFT__CallerNotOwner(tokenId, msg.sender, owner);
+        _setTokenURI(tokenId, tokenUri);
     }
 
     /// @notice Sets the contract URI for the collection.

--- a/contracts/interfaces/ISPGNFT.sol
+++ b/contracts/interfaces/ISPGNFT.sol
@@ -112,9 +112,9 @@ interface ISPGNFT is IAccessControl, IERC721Metadata, IERC7572 {
     /// @notice Sets the token URI for a specific token.
     /// @dev Only callable by the owner of the token. This updates the metadata URI
     ///      for the specified token and emits a MetadataUpdate event.
-    /// @param tokenId The ID of the token to update.
+    /// @param tokenId_ The ID of the token to update.
     /// @param tokenURI_ The new metadata URI to associate with the token.
-    function setTokenURI(uint256 tokenId, string memory tokenURI_) external;
+    function setTokenURI(uint256 tokenId_, string memory tokenURI_) external;
 
     /// @notice Mints an NFT from the collection. Only callable by the minter role.
     /// @param to The address of the recipient of the minted NFT.

--- a/contracts/interfaces/ISPGNFT.sol
+++ b/contracts/interfaces/ISPGNFT.sol
@@ -112,9 +112,9 @@ interface ISPGNFT is IAccessControl, IERC721Metadata, IERC7572 {
     /// @notice Sets the token URI for a specific token.
     /// @dev Only callable by the owner of the token. This updates the metadata URI
     ///      for the specified token and emits a MetadataUpdate event.
-    /// @param tokenId_ The ID of the token to update.
-    /// @param tokenURI_ The new metadata URI to associate with the token.
-    function setTokenURI(uint256 tokenId_, string memory tokenURI_) external;
+    /// @param tokenId The ID of the token to update.
+    /// @param tokenUri The new metadata URI to associate with the token.
+    function setTokenURI(uint256 tokenId, string memory tokenUri) external;
 
     /// @notice Mints an NFT from the collection. Only callable by the minter role.
     /// @param to The address of the recipient of the minted NFT.

--- a/contracts/interfaces/ISPGNFT.sol
+++ b/contracts/interfaces/ISPGNFT.sol
@@ -109,6 +109,13 @@ interface ISPGNFT is IAccessControl, IERC721Metadata, IERC7572 {
     ///        See https://eips.ethereum.org/EIPS/eip-7572
     function setContractURI(string memory contractURI) external;
 
+    /// @notice Sets the token URI for a specific token.
+    /// @dev Only callable by the owner of the token. This updates the metadata URI
+    ///      for the specified token and emits a MetadataUpdate event.
+    /// @param tokenId The ID of the token to update.
+    /// @param tokenURI_ The new metadata URI to associate with the token.
+    function setTokenURI(uint256 tokenId, string memory tokenURI_) external;
+
     /// @notice Mints an NFT from the collection. Only callable by the minter role.
     /// @param to The address of the recipient of the minted NFT.
     /// @param nftMetadataURI OPTIONAL. The desired metadata for the newly minted NFT.

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -117,6 +117,12 @@ library Errors {
     /// @param nftMetadataHash The hash of the NFT metadata that caused the duplication error.
     error SPGNFT__DuplicatedNFTMetadataHash(address spgNftContract, uint256 tokenId, bytes32 nftMetadataHash);
 
+    /// @notice Caller is not the owner of the `tokenId` token.
+    /// @param tokenId The ID of the token.
+    /// @param caller The address of the caller.
+    /// @param owner The owner of the token.
+    error SPGNFT__CallerNotOwner(uint256 tokenId, address caller, address owner);
+
     ////////////////////////////////////////////////////////////////////////////
     //                               OwnableERC20                             //
     ////////////////////////////////////////////////////////////////////////////

--- a/test/SPGNFT.t.sol
+++ b/test/SPGNFT.t.sol
@@ -399,4 +399,50 @@ contract SPGNFTTest is BaseTest {
         nftContract.setMintFeeRecipient(u.bob);
         vm.stopPrank();
     }
+
+    function test_SPGNFT_setTokenURI() public {
+        // mint a token to alice
+        vm.startPrank(u.alice);
+        mockToken.mint(address(u.alice), 1000 * 10 ** mockToken.decimals());
+        mockToken.approve(address(nftContract), 1000 * 10 ** mockToken.decimals());
+
+        uint256 tokenId = nftContract.mint(
+            address(u.alice),
+            ipMetadataDefault.nftMetadataURI,
+            ipMetadataDefault.nftMetadataHash,
+            false
+        );
+
+        // alice can set the token URI as the owner
+        string memory newTokenURI = string.concat(testBaseURI, "newTokenURI");
+        nftContract.setTokenURI(tokenId, "newTokenURI");
+
+        // Verify the token URI was updated
+        assertEq(nftContract.tokenURI(tokenId), newTokenURI);
+
+        vm.stopPrank();
+    }
+
+    function test_SPGNFT_setTokenURI_revert_callerNotOwner() public {
+        // mint a token to alice
+        vm.startPrank(u.alice);
+        mockToken.mint(address(u.alice), 1000 * 10 ** mockToken.decimals());
+        mockToken.approve(address(nftContract), 1000 * 10 ** mockToken.decimals());
+
+        uint256 tokenId = nftContract.mint(
+            address(u.alice),
+            ipMetadataDefault.nftMetadataURI,
+            ipMetadataDefault.nftMetadataHash,
+            false
+        );
+        vm.stopPrank();
+
+        // bob cannot set the token URI as he's not the owner
+        vm.startPrank(u.bob);
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.SPGNFT__CallerNotOwner.selector, tokenId, u.bob, u.alice));
+        nftContract.setTokenURI(tokenId, "newTokenURI");
+
+        vm.stopPrank();
+    }
 }


### PR DESCRIPTION
## Description
This PR adds functionality to allow NFT token owners to update their token URIs. The new `setTokenURI` function enables token owners to modify the metadata URI of their tokens while maintaining proper access control.

## Changes
- Added `setTokenURI` function to `SPGNFT` contract that allows token owners to update their token URIs
- Added corresponding interface function to `ISPGNFT`
- Added new `SPGNFT__CallerNotOwner` error for unauthorized access attempts
- Added test cases to verify:
  - Successful token URI updates by token owners
  - Rejection of unauthorized attempts to update token URIs

## Testing
- Added `test_SPGNFT_setTokenURI()` to verify successful token URI updates
- Added `test_SPGNFT_setTokenURI_revert_callerNotOwner()` to verify access control
- All tests pass successfully

## Related Issues
- Closes #188 