### PR TITLE
test(integration): replace mock ERC20 with Wrapped IP token (WIP) 

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
         "@openzeppelin/contracts-upgradeable": "5.2.0",
         "@story-protocol/protocol-core": "github:storyprotocol/protocol-core-v1#v1.3.1",
         "erc6551": "^0.3.1",
-        "solady": "^0.0.281"
+        "solady": "^0.0.281",
+        "wip": "github:piplabs/wip#main"
     }
 }

--- a/remappings.txt
+++ b/remappings.txt
@@ -4,5 +4,7 @@
 @storyprotocol/script/=node_modules/@story-protocol/protocol-core/script/foundry/
 @storyprotocol/test/=node_modules/@story-protocol/protocol-core/test/foundry/
 @solady/=node_modules/solady/
+solady/tokens/=node_modules/solady/src/tokens/
+@wip/=node_modules/wip/src/
 ds-test/=lib/forge-std/lib/ds-test/src/
 forge-std/=lib/forge-std/src/

--- a/script/deployment/StoryNFT.s.sol
+++ b/script/deployment/StoryNFT.s.sol
@@ -6,7 +6,7 @@ import { ILicenseRegistry } from "@storyprotocol/core/interfaces/registries/ILic
 import { DeployHelper } from "../utils/DeployHelper.sol";
 
 contract StoryNFT is DeployHelper {
-    address internal CREATE3_DEPLOYER = 0x384a891dFDE8180b054f04D66379f16B7a678Ad6;
+    address internal CREATE3_DEPLOYER = 0x9fBB3DF7C40Da2e5A0dE984fFE2CCB7C47cd0ABf;
     uint256 private constant CREATE3_DEFAULT_SEED = 1234567890;
     constructor() DeployHelper(CREATE3_DEPLOYER) {}
 

--- a/script/utils/StoryProtocolPeripheryAddressManager.sol
+++ b/script/utils/StoryProtocolPeripheryAddressManager.sol
@@ -15,10 +15,6 @@ contract StoryProtocolPeripheryAddressManager is Script {
     address internal royaltyTokenDistributionWorkflowsAddr;
     address internal spgNftBeaconAddr;
     address internal spgNftImplAddr;
-    address internal defaultOrgStoryNftTemplateAddr;
-    address internal defaultOrgStoryNftBeaconAddr;
-    address internal orgNftAddr;
-    address internal orgStoryNftFactoryAddr;
 
     function _readStoryProtocolPeripheryAddresses() internal {
         string memory root = vm.projectRoot();
@@ -35,9 +31,5 @@ contract StoryProtocolPeripheryAddressManager is Script {
         royaltyTokenDistributionWorkflowsAddr = json.readAddress(".main.RoyaltyTokenDistributionWorkflows");
         spgNftBeaconAddr = json.readAddress(".main.SPGNFTBeacon");
         spgNftImplAddr = json.readAddress(".main.SPGNFTImpl");
-        defaultOrgStoryNftTemplateAddr = json.readAddress(".main.DefaultOrgStoryNFTTemplate");
-        defaultOrgStoryNftBeaconAddr = json.readAddress(".main.DefaultOrgStoryNFTBeacon");
-        orgNftAddr = json.readAddress(".main.OrgNFT");
-        orgStoryNftFactoryAddr = json.readAddress(".main.OrgStoryNFTFactory");
     }
 }

--- a/script/utils/upgrades/UpgradeHelper.s.sol
+++ b/script/utils/upgrades/UpgradeHelper.s.sol
@@ -44,6 +44,12 @@ contract UpgradeHelper is
     SPGNFT internal spgNftImpl;
     UpgradeableBeacon internal spgNftBeacon;
 
+    // TODO: change these four addresses when upgrading Story NFTs
+    address public orgNftAddr = address(0x1);
+    address public orgStoryNftFactoryAddr = address(0x2);
+    address public defaultOrgStoryNftBeaconAddr = address(0x3);
+    address public defaultOrgStoryNftTemplateAddr = address(0x4);
+
     constructor() JsonDeploymentHandler("main") {}
 
     function run() public virtual {
@@ -73,7 +79,7 @@ contract UpgradeHelper is
     }
 
     function _writeAllAddresses() internal {
-        string[] memory contractKeys = new string[](12);
+        string[] memory contractKeys = new string[](8);
         contractKeys[0] = "DerivativeWorkflows";
         contractKeys[1] = "GroupingWorkflows";
         contractKeys[2] = "LicenseAttachmentWorkflows";
@@ -82,12 +88,8 @@ contract UpgradeHelper is
         contractKeys[5] = "RoyaltyTokenDistributionWorkflows";
         contractKeys[6] = "SPGNFTBeacon";
         contractKeys[7] = "SPGNFTImpl";
-        contractKeys[8] = "DefaultOrgStoryNFTTemplate";
-        contractKeys[9] = "DefaultOrgStoryNFTBeacon";
-        contractKeys[10] = "OrgNFT";
-        contractKeys[11] = "OrgStoryNFTFactory";
 
-        address[] memory addresses = new address[](12);
+        address[] memory addresses = new address[](8);
         addresses[0] = derivativeWorkflowsAddr;
         addresses[1] = groupingWorkflowsAddr;
         addresses[2] = licenseAttachmentWorkflowsAddr;
@@ -96,10 +98,6 @@ contract UpgradeHelper is
         addresses[5] = royaltyTokenDistributionWorkflowsAddr;
         addresses[6] = spgNftBeaconAddr;
         addresses[7] = spgNftImplAddr;
-        addresses[8] = defaultOrgStoryNftTemplateAddr;
-        addresses[9] = defaultOrgStoryNftBeaconAddr;
-        addresses[10] = orgNftAddr;
-        addresses[11] = orgStoryNftFactoryAddr;
 
         for (uint256 i = 0; i < contractKeys.length; i++) {
             _writeAddress(contractKeys[i], addresses[i]);

--- a/test/integration/BaseIntegration.t.sol
+++ b/test/integration/BaseIntegration.t.sol
@@ -6,7 +6,7 @@ pragma solidity 0.8.26;
 import { console2 } from "forge-std/console2.sol";
 import { Script } from "forge-std/Script.sol";
 import { Test } from "forge-std/Test.sol";
-import { SUSD } from "@storyprotocol/test/mocks/token/SUSD.sol";
+import { WIP } from "@wip/WIP.sol";
 import { MessageHashUtils } from "@openzeppelin/contracts/utils/cryptography/MessageHashUtils.sol";
 import { AccessPermission } from "@storyprotocol/core/lib/AccessPermission.sol";
 import { IAccessController } from "@storyprotocol/core/interfaces/access/IAccessController.sol";
@@ -59,8 +59,8 @@ contract BaseIntegration is Test, Script, StoryProtocolCoreAddressManager, Story
     RoyaltyWorkflows internal royaltyWorkflows;
     RoyaltyTokenDistributionWorkflows internal royaltyTokenDistributionWorkflows;
 
-    /// @dev Story USD
-    SUSD internal StoryUSD = SUSD(0xF2104833d386a2734a4eB3B8ad6FC6812F29E38E);
+    /// @dev Wrapped IP token
+    WIP internal wrappedIP = WIP(payable(0x1514000000000000000000000000000000000000));
 
     /// @dev Test data
     string internal testCollectionName;
@@ -116,8 +116,8 @@ contract BaseIntegration is Test, Script, StoryProtocolCoreAddressManager, Story
         testBaseURI = "https://test.com/";
         testContractURI = "https://test-contract-uri.com/";
         testMaxSupply = 100_000;
-        testMintFee = 10 * 10 ** StoryUSD.decimals(); // 10 SUSD
-        testMintFeeToken = address(StoryUSD);
+        testMintFee = 1 * 10 ** wrappedIP.decimals(); // 1 WIP
+        testMintFeeToken = address(wrappedIP);
         testIpMetadata = WorkflowStructs.IPMetadata({
             ipMetadataURI: "test-ip-uri",
             ipMetadataHash: "test-ip-hash",

--- a/test/integration/workflows/DerivativeIntegration.t.sol
+++ b/test/integration/workflows/DerivativeIntegration.t.sol
@@ -45,9 +45,9 @@ contract DerivativeIntegration is BaseIntegration {
         private
         logTest("test_DerivativeIntegration_mintAndRegisterIpAndMakeDerivative")
     {
-        StoryUSD.mint(testSender, testMintFee * 2);
-        StoryUSD.approve(address(spgNftContract), testMintFee); // for nft minting fee
-        StoryUSD.approve(derivativeWorkflowsAddr, testMintFee); // for derivative minting fee
+        wrappedIP.deposit{ value: testMintFee * 2 }(); // wrapping native IP
+        wrappedIP.approve(address(spgNftContract), testMintFee); // for nft minting fee
+        wrappedIP.approve(derivativeWorkflowsAddr, testMintFee); // for derivative minting fee
         (address childIpId, uint256 childTokenId) = derivativeWorkflows.mintAndRegisterIpAndMakeDerivative({
             spgNftContract: address(spgNftContract),
             derivData: WorkflowStructs.MakeDerivative({
@@ -87,8 +87,8 @@ contract DerivativeIntegration is BaseIntegration {
         private
         logTest("test_DerivativeIntegration_registerIpAndMakeDerivative")
     {
-        StoryUSD.mint(testSender, testMintFee);
-        StoryUSD.approve(address(spgNftContract), testMintFee); // for nft minting fee
+        wrappedIP.deposit{ value: testMintFee }();
+        wrappedIP.approve(address(spgNftContract), testMintFee); // for nft minting fee
 
         uint256 childTokenId = spgNftContract.mint({
             to: testSender,
@@ -112,8 +112,8 @@ contract DerivativeIntegration is BaseIntegration {
             signerSk: testSenderSk
         });
 
-        StoryUSD.mint(testSender, testMintFee);
-        StoryUSD.approve(derivativeWorkflowsAddr, testMintFee); // for derivative minting fee
+        wrappedIP.deposit{ value: testMintFee }();
+        wrappedIP.approve(derivativeWorkflowsAddr, testMintFee); // for derivative minting fee
         derivativeWorkflows.registerIpAndMakeDerivative({
             nftContract: address(spgNftContract),
             tokenId: childTokenId,
@@ -157,8 +157,8 @@ contract DerivativeIntegration is BaseIntegration {
         private
         logTest("test_DerivativeIntegration_mintAndRegisterIpAndMakeDerivativeWithLicenseTokens")
     {
-        StoryUSD.mint(testSender, testMintFee);
-        StoryUSD.approve(royaltyModuleAddr, testMintFee); // for license token minting fee
+        wrappedIP.deposit{ value: testMintFee }();
+        wrappedIP.approve(royaltyModuleAddr, testMintFee); // for license token minting fee
         uint256 startLicenseTokenId = licensingModule.mintLicenseTokens({
             licensorIpId: parentIpIds[0],
             licenseTemplate: parentLicenseTemplate,
@@ -176,8 +176,8 @@ contract DerivativeIntegration is BaseIntegration {
         uint256[] memory licenseTokenIds = new uint256[](1);
         licenseTokenIds[0] = startLicenseTokenId;
 
-        StoryUSD.mint(testSender, testMintFee);
-        StoryUSD.approve(address(spgNftContract), testMintFee); // for nft minting fee
+        wrappedIP.deposit{ value: testMintFee }();
+        wrappedIP.approve(address(spgNftContract), testMintFee); // for nft minting fee
         (address childIpId, uint256 childTokenId) = derivativeWorkflows
             .mintAndRegisterIpAndMakeDerivativeWithLicenseTokens({
                 spgNftContract: address(spgNftContract),
@@ -213,8 +213,8 @@ contract DerivativeIntegration is BaseIntegration {
         private
         logTest("test_DerivativeIntegration_registerIpAndMakeDerivativeWithLicenseTokens")
     {
-        StoryUSD.mint(testSender, testMintFee);
-        StoryUSD.approve(address(spgNftContract), testMintFee); // for nft minting fee
+        wrappedIP.deposit{ value: testMintFee }();
+        wrappedIP.approve(address(spgNftContract), testMintFee); // for nft minting fee
         uint256 childTokenId = spgNftContract.mint({
             to: testSender,
             nftMetadataURI: testIpMetadata.nftMetadataURI,
@@ -225,8 +225,8 @@ contract DerivativeIntegration is BaseIntegration {
 
         uint256 deadline = block.timestamp + 1000;
 
-        StoryUSD.mint(testSender, testMintFee);
-        StoryUSD.approve(royaltyModuleAddr, testMintFee); // for license token minting fee
+        wrappedIP.deposit{ value: testMintFee }();
+        wrappedIP.approve(royaltyModuleAddr, testMintFee); // for license token minting fee
         uint256 startLicenseTokenId = licensingModule.mintLicenseTokens({
             licensorIpId: parentIpIds[0],
             licenseTemplate: parentLicenseTemplate,
@@ -315,9 +315,9 @@ contract DerivativeIntegration is BaseIntegration {
             );
         }
 
-        StoryUSD.mint(testSender, testMintFee * numCalls * 2);
-        StoryUSD.approve(address(spgNftContract), testMintFee * numCalls);
-        StoryUSD.approve(derivativeWorkflowsAddr, testMintFee * numCalls);
+        wrappedIP.deposit{ value: testMintFee * numCalls * 2 }();
+        wrappedIP.approve(address(spgNftContract), testMintFee * numCalls);
+        wrappedIP.approve(derivativeWorkflowsAddr, testMintFee * numCalls);
 
         bytes[] memory results = derivativeWorkflows.multicall(data);
 
@@ -385,8 +385,8 @@ contract DerivativeIntegration is BaseIntegration {
             })
         );
 
-        StoryUSD.mint(testSender, testMintFee);
-        StoryUSD.approve(address(spgNftContract), testMintFee);
+        wrappedIP.deposit{ value: testMintFee }();
+        wrappedIP.approve(address(spgNftContract), testMintFee);
         address parentIpId;
         (parentIpId, , parentLicenseTermIds) = licenseAttachmentWorkflows.mintAndRegisterIpAndAttachPILTerms({
             spgNftContract: address(spgNftContract),

--- a/test/integration/workflows/GroupingIntegration.t.sol
+++ b/test/integration/workflows/GroupingIntegration.t.sol
@@ -66,8 +66,8 @@ contract GroupingIntegration is BaseIntegration {
             signerSk: testSenderSk
         });
 
-        StoryUSD.mint(testSender, testMintFee);
-        StoryUSD.approve(address(spgNftContract), testMintFee);
+        wrappedIP.deposit{ value: testMintFee }();
+        wrappedIP.approve(address(spgNftContract), testMintFee);
         (address ipId, uint256 tokenId) = groupingWorkflows.mintAndRegisterIpAndAttachLicenseAndAddToGroup({
             spgNftContract: address(spgNftContract),
             groupId: groupId,
@@ -99,8 +99,8 @@ contract GroupingIntegration is BaseIntegration {
         private
         logTest("test_GroupingIntegration_registerIpAndAttachLicenseAndAddToGroup")
     {
-        StoryUSD.mint(testSender, testMintFee);
-        StoryUSD.approve(address(spgNftContract), testMintFee);
+        wrappedIP.deposit{ value: testMintFee }();
+        wrappedIP.approve(address(spgNftContract), testMintFee);
         uint256 tokenId = spgNftContract.mint({
             to: testSender,
             nftMetadataURI: testIpMetadata.nftMetadataURI,
@@ -228,8 +228,8 @@ contract GroupingIntegration is BaseIntegration {
         uint256[] memory licenseTermsIds = new uint256[](1);
         licenseTermsIds[0] = testLicensesData[0].licenseTermsId;
 
-        StoryUSD.mint(testSender, testMintFee);
-        StoryUSD.approve(address(spgNftContract), testMintFee);
+        wrappedIP.deposit{ value: testMintFee }();
+        wrappedIP.approve(address(spgNftContract), testMintFee);
         (address ipId1, ) = derivativeWorkflows.mintAndRegisterIpAndMakeDerivative({
             spgNftContract: address(spgNftContract),
             derivData: WorkflowStructs.MakeDerivative({
@@ -246,8 +246,8 @@ contract GroupingIntegration is BaseIntegration {
             allowDuplicates: true
         });
 
-        StoryUSD.mint(testSender, testMintFee);
-        StoryUSD.approve(address(spgNftContract), testMintFee);
+        wrappedIP.deposit{ value: testMintFee }();
+        wrappedIP.approve(address(spgNftContract), testMintFee);
         (address ipId2, ) = derivativeWorkflows.mintAndRegisterIpAndMakeDerivative({
             spgNftContract: address(spgNftContract),
             derivData: WorkflowStructs.MakeDerivative({
@@ -264,20 +264,20 @@ contract GroupingIntegration is BaseIntegration {
             allowDuplicates: true
         });
 
-        uint256 amount1 = 1_000 * 10 ** StoryUSD.decimals(); // 1,000 tokens
-        StoryUSD.mint(testSender, amount1);
-        StoryUSD.approve(address(royaltyModule), amount1);
-        royaltyModule.payRoyaltyOnBehalf(ipId1, testSender, address(StoryUSD), amount1);
-        IGraphAwareRoyaltyPolicy(royaltyPolicyLRPAddr).transferToVault(ipId1, newGroupId, address(StoryUSD));
+        uint256 amount1 = 1 * 10 ** wrappedIP.decimals(); // 1 token
+        wrappedIP.deposit{ value: amount1 }();
+        wrappedIP.approve(address(royaltyModule), amount1);
+        royaltyModule.payRoyaltyOnBehalf(ipId1, testSender, address(wrappedIP), amount1);
+        IGraphAwareRoyaltyPolicy(royaltyPolicyLRPAddr).transferToVault(ipId1, newGroupId, address(wrappedIP));
 
-        uint256 amount2 = 10_000 * 10 ** StoryUSD.decimals(); // 10,000 tokens
-        StoryUSD.mint(testSender, amount2);
-        StoryUSD.approve(address(royaltyModule), amount2);
-        royaltyModule.payRoyaltyOnBehalf(ipId2, testSender, address(StoryUSD), amount2);
-        IGraphAwareRoyaltyPolicy(royaltyPolicyLRPAddr).transferToVault(ipId2, newGroupId, address(StoryUSD));
+        uint256 amount2 = 2 * 10 ** wrappedIP.decimals(); // 2 tokens
+        wrappedIP.deposit{ value: amount2 }();
+        wrappedIP.approve(address(royaltyModule), amount2);
+        royaltyModule.payRoyaltyOnBehalf(ipId2, testSender, address(wrappedIP), amount2);
+        IGraphAwareRoyaltyPolicy(royaltyPolicyLRPAddr).transferToVault(ipId2, newGroupId, address(wrappedIP));
 
         address[] memory royaltyTokens = new address[](1);
-        royaltyTokens[0] = address(StoryUSD);
+        royaltyTokens[0] = address(wrappedIP);
 
         uint256[] memory collectedRoyalties = groupingWorkflows.collectRoyaltiesAndClaimReward(
             newGroupId,
@@ -293,7 +293,10 @@ contract GroupingIntegration is BaseIntegration {
 
         // check each member IP received the reward in their IP royalty vault
         for (uint256 i = 0; i < ipIds.length; i++) {
-            assertEq(StoryUSD.balanceOf(royaltyModule.ipRoyaltyVaults(ipIds[i])), collectedRoyalties[0] / ipIds.length);
+            assertEq(
+                wrappedIP.balanceOf(royaltyModule.ipRoyaltyVaults(ipIds[i])),
+                collectedRoyalties[0] / ipIds.length
+            );
         }
     }
 
@@ -338,8 +341,8 @@ contract GroupingIntegration is BaseIntegration {
             );
         }
 
-        StoryUSD.mint(testSender, testMintFee * numCalls);
-        StoryUSD.approve(address(spgNftContract), testMintFee * numCalls);
+        wrappedIP.deposit{ value: testMintFee * numCalls }();
+        wrappedIP.approve(address(spgNftContract), testMintFee * numCalls);
 
         // batch call `mintAndRegisterIpAndAttachLicenseAndAddToGroup`
         bytes[] memory results = groupingWorkflows.multicall(data);
@@ -367,8 +370,8 @@ contract GroupingIntegration is BaseIntegration {
     {
         uint256 numCalls = 10;
 
-        StoryUSD.mint(testSender, testMintFee * numCalls);
-        StoryUSD.approve(address(spgNftContract), testMintFee * numCalls);
+        wrappedIP.deposit{ value: testMintFee * numCalls }();
+        wrappedIP.approve(address(spgNftContract), testMintFee * numCalls);
         // mint a NFT from the spgNftContract
         uint256[] memory tokenIds = new uint256[](numCalls);
         for (uint256 i = 0; i < numCalls; i++) {
@@ -474,7 +477,7 @@ contract GroupingIntegration is BaseIntegration {
                         mintingFee: 0,
                         commercialRevShare: revShare,
                         royaltyPolicy: royaltyPolicyLRPAddr,
-                        currencyToken: address(StoryUSD)
+                        currencyToken: address(wrappedIP)
                     })
                 ),
                 licensingConfig: Licensing.LicensingConfig({
@@ -549,8 +552,8 @@ contract GroupingIntegration is BaseIntegration {
                 );
             }
 
-            StoryUSD.mint(testSender, testMintFee * numIps);
-            StoryUSD.approve(address(spgNftContract), testMintFee * numIps);
+            wrappedIP.deposit{ value: testMintFee * numIps }();
+            wrappedIP.approve(address(spgNftContract), testMintFee * numIps);
 
             // batch call `mintAndRegisterIp`
             bytes[] memory results = registrationWorkflows.multicall(data);

--- a/test/integration/workflows/LicenseAttachmentIntegration.t.sol
+++ b/test/integration/workflows/LicenseAttachmentIntegration.t.sol
@@ -39,8 +39,8 @@ contract LicenseAttachmentIntegration is BaseIntegration {
         private
         logTest("test_LicenseAttachmentIntegration_registerPILTermsAndAttach")
     {
-        StoryUSD.mint(testSender, testMintFee);
-        StoryUSD.approve(address(spgNftContract), testMintFee);
+        wrappedIP.deposit{ value: testMintFee }();
+        wrappedIP.approve(address(spgNftContract), testMintFee);
 
         (address ipId, ) = registrationWorkflows.mintAndRegisterIp({
             spgNftContract: address(spgNftContract),
@@ -79,8 +79,8 @@ contract LicenseAttachmentIntegration is BaseIntegration {
     {
         // IP 1
         {
-            StoryUSD.mint(testSender, testMintFee);
-            StoryUSD.approve(address(spgNftContract), testMintFee);
+            wrappedIP.deposit{ value: testMintFee }();
+            wrappedIP.approve(address(spgNftContract), testMintFee);
 
             (address ipId1, uint256 tokenId1, uint256[] memory licenseTermsIds1) = licenseAttachmentWorkflows
                 .mintAndRegisterIpAndAttachPILTerms({
@@ -104,8 +104,8 @@ contract LicenseAttachmentIntegration is BaseIntegration {
 
         // IP 2
         {
-            StoryUSD.mint(testSender, testMintFee);
-            StoryUSD.approve(address(spgNftContract), testMintFee);
+            wrappedIP.deposit{ value: testMintFee }();
+            wrappedIP.approve(address(spgNftContract), testMintFee);
 
             (address ipId2, uint256 tokenId2, uint256[] memory licenseTermsIds2) = licenseAttachmentWorkflows
                 .mintAndRegisterIpAndAttachPILTerms({
@@ -132,8 +132,8 @@ contract LicenseAttachmentIntegration is BaseIntegration {
         private
         logTest("test_LicenseAttachmentIntegration_registerIpAndAttachPILTerms")
     {
-        StoryUSD.mint(testSender, testMintFee);
-        StoryUSD.approve(address(spgNftContract), testMintFee);
+        wrappedIP.deposit{ value: testMintFee }();
+        wrappedIP.approve(address(spgNftContract), testMintFee);
 
         uint256 tokenId = spgNftContract.mint({
             to: testSender,
@@ -186,8 +186,8 @@ contract LicenseAttachmentIntegration is BaseIntegration {
         private
         logTest("test_LicenseAttachmentWorkflows_mintAndRegisterIpAndAttachDefaultTerms")
     {
-        StoryUSD.mint(testSender, testMintFee);
-        StoryUSD.approve(address(spgNftContract), testMintFee);
+        wrappedIP.deposit{ value: testMintFee }();
+        wrappedIP.approve(address(spgNftContract), testMintFee);
 
         (address ipId1, uint256 tokenId1) = licenseAttachmentWorkflows.mintAndRegisterIpAndAttachDefaultTerms({
             spgNftContract: address(spgNftContract),
@@ -210,8 +210,8 @@ contract LicenseAttachmentIntegration is BaseIntegration {
         private
         logTest("test_LicenseAttachmentWorkflows_registerIpAndAttachDefaultTerms")
     {
-        StoryUSD.mint(testSender, testMintFee);
-        StoryUSD.approve(address(spgNftContract), testMintFee);
+        wrappedIP.deposit{ value: testMintFee }();
+        wrappedIP.approve(address(spgNftContract), testMintFee);
 
         uint256 tokenId = spgNftContract.mint({
             to: testSender,

--- a/test/integration/workflows/RegistrationIntegration.t.sol
+++ b/test/integration/workflows/RegistrationIntegration.t.sol
@@ -74,8 +74,8 @@ contract RegistrationIntegration is BaseIntegration {
         private
         logTest("test_RegistrationIntegration_mintAndRegisterIp")
     {
-        StoryUSD.mint(testSender, testMintFee);
-        StoryUSD.approve(address(spgNftContract), testMintFee);
+        wrappedIP.deposit{ value: testMintFee }();
+        wrappedIP.approve(address(spgNftContract), testMintFee);
         (address ipId, uint256 tokenId) = registrationWorkflows.mintAndRegisterIp({
             spgNftContract: address(spgNftContract),
             recipient: testSender,
@@ -90,8 +90,8 @@ contract RegistrationIntegration is BaseIntegration {
     }
 
     function _test_RegistrationIntegration_registerIp() private logTest("test_RegistrationIntegration_registerIp") {
-        StoryUSD.mint(testSender, testMintFee);
-        StoryUSD.approve(address(spgNftContract), testMintFee);
+        wrappedIP.deposit{ value: testMintFee }();
+        wrappedIP.approve(address(spgNftContract), testMintFee);
         uint256 tokenId = spgNftContract.mint(testSender, "", bytes32(0), true);
 
         // get signature for setting IP metadata
@@ -176,8 +176,8 @@ contract RegistrationIntegration is BaseIntegration {
         logTest("test_RegistrationIntegration_multicall_mintAndRegisterIp")
     {
         uint256 totalIps = 10;
-        StoryUSD.mint(testSender, testMintFee * totalIps);
-        StoryUSD.approve(address(spgNftContract), testMintFee * totalIps);
+        wrappedIP.deposit{ value: testMintFee * totalIps }();
+        wrappedIP.approve(address(spgNftContract), testMintFee * totalIps);
 
         bytes[] memory data = new bytes[](totalIps);
         for (uint256 i = 0; i < totalIps; i++) {

--- a/test/integration/workflows/RoyaltyIntegration.t.sol
+++ b/test/integration/workflows/RoyaltyIntegration.t.sol
@@ -26,11 +26,11 @@ contract RoyaltyIntegration is BaseIntegration {
     address internal grandChildIpId;
 
     uint256 internal commRemixTermsIdA;
-    uint256 internal defaultMintingFeeA = 1000 * 10 ** StoryUSD.decimals(); // 1000 SUSD
+    uint256 internal defaultMintingFeeA = 1 * 10 ** wrappedIP.decimals(); // 1 WIP
     uint32 internal defaultCommRevShareA = 10 * 10 ** 6; // 10%
 
     uint256 internal commRemixTermsIdC;
-    uint256 internal defaultMintingFeeC = 500 * 10 ** StoryUSD.decimals(); // 500 SUSD
+    uint256 internal defaultMintingFeeC = 2 * 10 ** wrappedIP.decimals(); // 2 WIP
     uint32 internal defaultCommRevShareC = 20 * 10 ** 6; // 20%
 
     WorkflowStructs.LicenseTermsData[] internal commTermsData;
@@ -58,21 +58,21 @@ contract RoyaltyIntegration is BaseIntegration {
 
         childIpIds[0] = childIpIdA;
         royaltyPolicies[0] = royaltyPolicyLRPAddr;
-        currencyTokens[0] = address(StoryUSD);
+        currencyTokens[0] = address(wrappedIP);
 
         childIpIds[1] = childIpIdB;
         royaltyPolicies[1] = royaltyPolicyLRPAddr;
-        currencyTokens[1] = address(StoryUSD);
+        currencyTokens[1] = address(wrappedIP);
 
         childIpIds[2] = grandChildIpId;
         royaltyPolicies[2] = royaltyPolicyLRPAddr;
-        currencyTokens[2] = address(StoryUSD);
+        currencyTokens[2] = address(wrappedIP);
 
         childIpIds[3] = childIpIdC;
         royaltyPolicies[3] = royaltyPolicyLAPAddr;
-        currencyTokens[3] = address(StoryUSD);
+        currencyTokens[3] = address(wrappedIP);
 
-        uint256 claimerBalanceBefore = StoryUSD.balanceOf(ancestorIpId);
+        uint256 claimerBalanceBefore = wrappedIP.balanceOf(ancestorIpId);
 
         uint256[] memory amountsClaimed = royaltyWorkflows.claimAllRevenue({
             ancestorIpId: ancestorIpId,
@@ -82,23 +82,23 @@ contract RoyaltyIntegration is BaseIntegration {
             currencyTokens: currencyTokens
         });
 
-        uint256 claimerBalanceAfter = StoryUSD.balanceOf(ancestorIpId);
+        uint256 claimerBalanceAfter = wrappedIP.balanceOf(ancestorIpId);
 
         assertEq(amountsClaimed.length, 1); // there is 1 currency token
         assertEq(claimerBalanceAfter - claimerBalanceBefore, amountsClaimed[0]);
         assertEq(
             claimerBalanceAfter - claimerBalanceBefore,
             defaultMintingFeeA +
-                defaultMintingFeeA + // 1000 + 1000 from minting fee of childIpA and childIpB
+                defaultMintingFeeA + // 1 + 1 from minting fee of childIpA and childIpB
                 (defaultMintingFeeA * defaultCommRevShareA) /
-                royaltyModule.maxPercent() + // 1000 * 10% = 100 royalty from childIpA
+                royaltyModule.maxPercent() + // 1 * 10% = 0.1 royalty from childIpA
                 (defaultMintingFeeA * defaultCommRevShareA) /
-                royaltyModule.maxPercent() + // 1000 * 10% = 100 royalty from childIpB
+                royaltyModule.maxPercent() + // 1 * 10% = 0.1 royalty from childIpB
                 (((defaultMintingFeeA * defaultCommRevShareA) / royaltyModule.maxPercent()) * defaultCommRevShareA) /
-                royaltyModule.maxPercent() + // 1000 * 10% * 10% * 2 = 20 royalty from grandChildIp
+                royaltyModule.maxPercent() + // 1 * 10% * 10% * 2 = 0.02 royalty from grandChildIp
                 defaultMintingFeeC +
                 (defaultMintingFeeC * defaultCommRevShareC) /
-                royaltyModule.maxPercent() // 500 from from minting fee of childIpC,500 * 20% = 100 royalty from childIpC
+                royaltyModule.maxPercent() // 2 from from minting fee of childIpC,2 * 20% = 0.4 royalty from childIpC
         );
     }
 
@@ -158,7 +158,7 @@ contract RoyaltyIntegration is BaseIntegration {
                         mintingFee: defaultMintingFeeA,
                         commercialRevShare: defaultCommRevShareA,
                         royaltyPolicy: royaltyPolicyLRPAddr,
-                        currencyToken: address(StoryUSD)
+                        currencyToken: address(wrappedIP)
                     }),
                     licensingConfig: Licensing.LicensingConfig({
                         isSet: true,
@@ -178,7 +178,7 @@ contract RoyaltyIntegration is BaseIntegration {
                         mintingFee: defaultMintingFeeC,
                         commercialRevShare: defaultCommRevShareC,
                         royaltyPolicy: royaltyPolicyLAPAddr,
-                        currencyToken: address(StoryUSD)
+                        currencyToken: address(wrappedIP)
                     }),
                     licensingConfig: Licensing.LicensingConfig({
                         isSet: true,
@@ -236,8 +236,8 @@ contract RoyaltyIntegration is BaseIntegration {
             parentIpIds[0] = ancestorIpId;
             licenseTermsIds[0] = commRemixTermsIdA;
 
-            StoryUSD.mint(testSender, defaultMintingFeeA);
-            StoryUSD.approve(derivativeWorkflowsAddr, defaultMintingFeeA);
+            wrappedIP.deposit{ value: defaultMintingFeeA }();
+            wrappedIP.approve(derivativeWorkflowsAddr, defaultMintingFeeA);
             childIpIdA = derivativeWorkflows.registerIpAndMakeDerivative({
                 nftContract: address(spgNftContract),
                 tokenId: childTokenIdA,
@@ -280,8 +280,8 @@ contract RoyaltyIntegration is BaseIntegration {
             parentIpIds[0] = ancestorIpId;
             licenseTermsIds[0] = commRemixTermsIdA;
 
-            StoryUSD.mint(testSender, defaultMintingFeeA);
-            StoryUSD.approve(derivativeWorkflowsAddr, defaultMintingFeeA);
+            wrappedIP.deposit{ value: defaultMintingFeeA }();
+            wrappedIP.approve(derivativeWorkflowsAddr, defaultMintingFeeA);
             childIpIdB = derivativeWorkflows.registerIpAndMakeDerivative({
                 nftContract: address(spgNftContract),
                 tokenId: childTokenIdB,
@@ -324,8 +324,8 @@ contract RoyaltyIntegration is BaseIntegration {
             parentIpIds[0] = ancestorIpId;
             licenseTermsIds[0] = commRemixTermsIdC;
 
-            StoryUSD.mint(testSender, defaultMintingFeeC);
-            StoryUSD.approve(derivativeWorkflowsAddr, defaultMintingFeeC);
+            wrappedIP.deposit{ value: defaultMintingFeeC }();
+            wrappedIP.approve(derivativeWorkflowsAddr, defaultMintingFeeC);
             childIpIdC = derivativeWorkflows.registerIpAndMakeDerivative({
                 nftContract: address(spgNftContract),
                 tokenId: childTokenIdC,
@@ -371,8 +371,8 @@ contract RoyaltyIntegration is BaseIntegration {
                 licenseTermsIds[i] = commRemixTermsIdA;
             }
 
-            StoryUSD.mint(testSender, defaultMintingFeeA * parentIpIds.length);
-            StoryUSD.approve(derivativeWorkflowsAddr, defaultMintingFeeA * parentIpIds.length);
+            wrappedIP.deposit{ value: defaultMintingFeeA * parentIpIds.length }();
+            wrappedIP.approve(derivativeWorkflowsAddr, defaultMintingFeeA * parentIpIds.length);
             grandChildIpId = derivativeWorkflows.registerIpAndMakeDerivative({
                 nftContract: address(spgNftContract),
                 tokenId: grandChildTokenId,
@@ -397,8 +397,8 @@ contract RoyaltyIntegration is BaseIntegration {
 
         // mints `amountLicenseTokensToMint` grandChildIp and childIpC license tokens
         {
-            StoryUSD.mint(testSender, (defaultMintingFeeA + defaultMintingFeeC) * amountLicenseTokensToMint);
-            StoryUSD.approve(royaltyModuleAddr, (defaultMintingFeeA + defaultMintingFeeC) * amountLicenseTokensToMint);
+            wrappedIP.deposit{ value: (defaultMintingFeeA + defaultMintingFeeC) * amountLicenseTokensToMint }();
+            wrappedIP.approve(royaltyModuleAddr, (defaultMintingFeeA + defaultMintingFeeC) * amountLicenseTokensToMint);
 
             // mint `amountLicenseTokensToMint` grandChildIp's license tokens
             licensingModule.mintLicenseTokens({

--- a/test/integration/workflows/RoyaltyTokenDistributionIntegration.t.sol
+++ b/test/integration/workflows/RoyaltyTokenDistributionIntegration.t.sol
@@ -76,8 +76,8 @@ contract RoyaltyTokenDistributionIntegration is BaseIntegration {
         private
         logTest("test_RoyaltyTokenDistributionIntegration_mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens")
     {
-        StoryUSD.mint(testSender, licenseMintingFee);
-        StoryUSD.approve(royaltyTokenDistributionWorkflowsAddr, licenseMintingFee);
+        wrappedIP.deposit{ value: licenseMintingFee }();
+        wrappedIP.approve(royaltyTokenDistributionWorkflowsAddr, licenseMintingFee);
 
         (address ipId, uint256 tokenId) = royaltyTokenDistributionWorkflows
             .mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens({
@@ -193,8 +193,8 @@ contract RoyaltyTokenDistributionIntegration is BaseIntegration {
         });
 
         // register IP, make derivative, and deploy royalty vault
-        StoryUSD.mint(testSender, licenseMintingFee);
-        StoryUSD.approve(address(royaltyTokenDistributionWorkflows), licenseMintingFee);
+        wrappedIP.deposit{ value: licenseMintingFee }();
+        wrappedIP.approve(address(royaltyTokenDistributionWorkflows), licenseMintingFee);
         (address ipId, address ipRoyaltyVault) = royaltyTokenDistributionWorkflows
             .registerIpAndMakeDerivativeAndDeployRoyaltyVault({
                 nftContract: address(spgNftContract),
@@ -276,7 +276,7 @@ contract RoyaltyTokenDistributionIntegration is BaseIntegration {
             )
         );
 
-        licenseMintingFee = 10 * 10 ** StoryUSD.decimals(); // 10 SUSD
+        licenseMintingFee = 1 * 10 ** wrappedIP.decimals(); // 1 WIP
 
         uint32 testCommRevShare = 5 * 10 ** 6; // 5%
 
@@ -286,7 +286,7 @@ contract RoyaltyTokenDistributionIntegration is BaseIntegration {
                     mintingFee: licenseMintingFee,
                     commercialRevShare: testCommRevShare,
                     royaltyPolicy: royaltyPolicyLRPAddr,
-                    currencyToken: address(StoryUSD)
+                    currencyToken: address(wrappedIP)
                 }),
                 licensingConfig: Licensing.LicensingConfig({
                     isSet: true,
@@ -307,7 +307,7 @@ contract RoyaltyTokenDistributionIntegration is BaseIntegration {
                     mintingFee: licenseMintingFee,
                     commercialRevShare: 5_000_000, // 5%
                     royaltyPolicy: royaltyPolicyLRPAddr,
-                    currencyToken: address(StoryUSD)
+                    currencyToken: address(wrappedIP)
                 }),
                 licensingConfig: Licensing.LicensingConfig({
                     isSet: true,
@@ -328,7 +328,7 @@ contract RoyaltyTokenDistributionIntegration is BaseIntegration {
                     mintingFee: licenseMintingFee,
                     commercialRevShare: 8_000_000, // 8%
                     royaltyPolicy: royaltyPolicyLAPAddr,
-                    currencyToken: address(StoryUSD)
+                    currencyToken: address(wrappedIP)
                 }),
                 licensingConfig: Licensing.LicensingConfig({
                     isSet: true,
@@ -345,8 +345,8 @@ contract RoyaltyTokenDistributionIntegration is BaseIntegration {
 
         address[] memory ipIdParent = new address[](1);
         uint256[] memory licenseTermsIds;
-        StoryUSD.mint(testSender, licenseMintingFee);
-        StoryUSD.approve(address(spgNftContract), licenseMintingFee);
+        wrappedIP.deposit{ value: licenseMintingFee }();
+        wrappedIP.approve(address(spgNftContract), licenseMintingFee);
         (ipIdParent[0], , licenseTermsIds) = licenseAttachmentWorkflows.mintAndRegisterIpAndAttachPILTerms({
             spgNftContract: address(spgNftContract),
             recipient: testSender,

--- a/yarn.lock
+++ b/yarn.lock
@@ -75,181 +75,181 @@
     micro-ftch "^0.3.1"
 
 "@ethersproject/abi@^5.0.9":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.7.0.tgz#b3f3e045bbbeed1af3947335c247ad625a44e449"
-  integrity sha512-351ktp42TiRcYB3H1OP8yajPeAQstMW/yCFokj/AthP9bLHzQFPlOrxOcwYEDkUAICmOHljvN4K39OMTMUa9RA==
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abi/-/abi-5.8.0.tgz#e79bb51940ac35fe6f3262d7fe2cdb25ad5f07d9"
+  integrity sha512-b9YS/43ObplgyV6SlyQsG53/vkSal0MNA1fskSC4mbnCMi8R+NkcH8K9FPYNESf6jUefBUniE4SOKms0E/KK1Q==
   dependencies:
-    "@ethersproject/address" "^5.7.0"
-    "@ethersproject/bignumber" "^5.7.0"
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/constants" "^5.7.0"
-    "@ethersproject/hash" "^5.7.0"
-    "@ethersproject/keccak256" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
-    "@ethersproject/properties" "^5.7.0"
-    "@ethersproject/strings" "^5.7.0"
+    "@ethersproject/address" "^5.8.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/constants" "^5.8.0"
+    "@ethersproject/hash" "^5.8.0"
+    "@ethersproject/keccak256" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/strings" "^5.8.0"
 
-"@ethersproject/abstract-provider@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.7.0.tgz#b0a8550f88b6bf9d51f90e4795d48294630cb9ef"
-  integrity sha512-R41c9UkchKCpAqStMYUpdunjo3pkEvZC3FAwZn5S5MGbXoMQOHIdHItezTETxAO5bevtMApSyEhn9+CHcDsWBw==
+"@ethersproject/abstract-provider@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-provider/-/abstract-provider-5.8.0.tgz#7581f9be601afa1d02b95d26b9d9840926a35b0c"
+  integrity sha512-wC9SFcmh4UK0oKuLJQItoQdzS/qZ51EJegK6EmAWlh+OptpQ/npECOR3QqECd8iGHC0RJb4WKbVdSfif4ammrg==
   dependencies:
-    "@ethersproject/bignumber" "^5.7.0"
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
-    "@ethersproject/networks" "^5.7.0"
-    "@ethersproject/properties" "^5.7.0"
-    "@ethersproject/transactions" "^5.7.0"
-    "@ethersproject/web" "^5.7.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/networks" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/transactions" "^5.8.0"
+    "@ethersproject/web" "^5.8.0"
 
-"@ethersproject/abstract-signer@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.7.0.tgz#13f4f32117868452191a4649723cb086d2b596b2"
-  integrity sha512-a16V8bq1/Cz+TGCkE2OPMTOUDLS3grCpdjoJCYNnVBbdYEMSgKrU0+B90s8b6H+ByYTBZN7a3g76jdIJi7UfKQ==
+"@ethersproject/abstract-signer@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.8.0.tgz#8d7417e95e4094c1797a9762e6789c7356db0754"
+  integrity sha512-N0XhZTswXcmIZQdYtUnd79VJzvEwXQw6PK0dTl9VoYrEBxxCPXqS0Eod7q5TNKRxe1/5WUMuR0u0nqTF/avdCA==
   dependencies:
-    "@ethersproject/abstract-provider" "^5.7.0"
-    "@ethersproject/bignumber" "^5.7.0"
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
-    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/abstract-provider" "^5.8.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
 
-"@ethersproject/address@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.7.0.tgz#19b56c4d74a3b0a46bfdbb6cfcc0a153fc697f37"
-  integrity sha512-9wYhYt7aghVGo758POM5nqcOMaE168Q6aRLJZwUmiqSrAungkG74gSSeKEIR7ukixesdRZGPgVqme6vmxs1fkA==
+"@ethersproject/address@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.8.0.tgz#3007a2c352eee566ad745dca1dbbebdb50a6a983"
+  integrity sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==
   dependencies:
-    "@ethersproject/bignumber" "^5.7.0"
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/keccak256" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
-    "@ethersproject/rlp" "^5.7.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/keccak256" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/rlp" "^5.8.0"
 
-"@ethersproject/base64@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.7.0.tgz#ac4ee92aa36c1628173e221d0d01f53692059e1c"
-  integrity sha512-Dr8tcHt2mEbsZr/mwTPIQAf3Ai0Bks/7gTw9dSqk1mQvhW3XvRlmDJr/4n+wg1JmCl16NZue17CDh8xb/vZ0sQ==
+"@ethersproject/base64@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/base64/-/base64-5.8.0.tgz#61c669c648f6e6aad002c228465d52ac93ee83eb"
+  integrity sha512-lN0oIwfkYj9LbPx4xEkie6rAMJtySbpOAFXSDVQaBnAzYfB4X2Qr+FXJGxMoc3Bxp2Sm8OwvzMrywxyw0gLjIQ==
   dependencies:
-    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/bytes" "^5.8.0"
 
-"@ethersproject/bignumber@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.7.0.tgz#e2f03837f268ba655ffba03a57853e18a18dc9c2"
-  integrity sha512-n1CAdIHRWjSucQO3MC1zPSVgV/6dy/fjL9pMrPP9peL+QxEg9wOsVqwD4+818B6LUEtaXzVHQiuivzRoxPxUGw==
+"@ethersproject/bignumber@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bignumber/-/bignumber-5.8.0.tgz#c381d178f9eeb370923d389284efa19f69efa5d7"
+  integrity sha512-ZyaT24bHaSeJon2tGPKIiHszWjD/54Sz8t57Toch475lCLljC6MgPmxk7Gtzz+ddNN5LuHea9qhAe0x3D+uYPA==
   dependencies:
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
     bn.js "^5.2.1"
 
-"@ethersproject/bytes@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.7.0.tgz#a00f6ea8d7e7534d6d87f47188af1148d71f155d"
-  integrity sha512-nsbxwgFXWh9NyYWo+U8atvmMsSdKJprTcICAkvbBffT75qDocbuggBU0SJiVK2MuTrp0q+xvLkTnGMPK1+uA9A==
+"@ethersproject/bytes@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.8.0.tgz#9074820e1cac7507a34372cadeb035461463be34"
+  integrity sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==
   dependencies:
-    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/logger" "^5.8.0"
 
-"@ethersproject/constants@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.7.0.tgz#df80a9705a7e08984161f09014ea012d1c75295e"
-  integrity sha512-DHI+y5dBNvkpYUMiRQyxRBYBefZkJfo70VUkUAsRjcPs47muV9evftfZ0PJVCXYbAiCgght0DtcF9srFQmIgWA==
+"@ethersproject/constants@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/constants/-/constants-5.8.0.tgz#12f31c2f4317b113a4c19de94e50933648c90704"
+  integrity sha512-wigX4lrf5Vu+axVTIvNsuL6YrV4O5AXl5ubcURKMEME5TnWBouUh0CDTWxZ2GpnRn1kcCgE7l8O5+VbV9QTTcg==
   dependencies:
-    "@ethersproject/bignumber" "^5.7.0"
+    "@ethersproject/bignumber" "^5.8.0"
 
-"@ethersproject/hash@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.7.0.tgz#eb7aca84a588508369562e16e514b539ba5240a7"
-  integrity sha512-qX5WrQfnah1EFnO5zJv1v46a8HW0+E5xuBBDTwMFZLuVTx0tbU2kkx15NqdjxecrLGatQN9FGQKpb1FKdHCt+g==
+"@ethersproject/hash@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/hash/-/hash-5.8.0.tgz#b8893d4629b7f8462a90102572f8cd65a0192b4c"
+  integrity sha512-ac/lBcTbEWW/VGJij0CNSw/wPcw9bSRgCB0AIBz8CvED/jfvDoV9hsIIiWfvWmFEi8RcXtlNwp2jv6ozWOsooA==
   dependencies:
-    "@ethersproject/abstract-signer" "^5.7.0"
-    "@ethersproject/address" "^5.7.0"
-    "@ethersproject/base64" "^5.7.0"
-    "@ethersproject/bignumber" "^5.7.0"
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/keccak256" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
-    "@ethersproject/properties" "^5.7.0"
-    "@ethersproject/strings" "^5.7.0"
+    "@ethersproject/abstract-signer" "^5.8.0"
+    "@ethersproject/address" "^5.8.0"
+    "@ethersproject/base64" "^5.8.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/keccak256" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/strings" "^5.8.0"
 
-"@ethersproject/keccak256@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.7.0.tgz#3186350c6e1cd6aba7940384ec7d6d9db01f335a"
-  integrity sha512-2UcPboeL/iW+pSg6vZ6ydF8tCnv3Iu/8tUmLLzWWGzxWKFFqOBQFLo6uLUv6BDrLgCDfN28RJ/wtByx+jZ4KBg==
+"@ethersproject/keccak256@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/keccak256/-/keccak256-5.8.0.tgz#d2123a379567faf2d75d2aaea074ffd4df349e6a"
+  integrity sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==
   dependencies:
-    "@ethersproject/bytes" "^5.7.0"
+    "@ethersproject/bytes" "^5.8.0"
     js-sha3 "0.8.0"
 
-"@ethersproject/logger@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.7.0.tgz#6ce9ae168e74fecf287be17062b590852c311892"
-  integrity sha512-0odtFdXu/XHtjQXJYA3u9G0G8btm0ND5Cu8M7i5vhEcE8/HmF4Lbdqanwyv4uQTr2tx6b7fQRmgLrsnpQlmnig==
+"@ethersproject/logger@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.8.0.tgz#f0232968a4f87d29623a0481690a2732662713d6"
+  integrity sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA==
 
-"@ethersproject/networks@^5.7.0":
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.7.1.tgz#118e1a981d757d45ccea6bb58d9fd3d9db14ead6"
-  integrity sha512-n/MufjFYv3yFcUyfhnXotyDlNdFb7onmkSy8aQERi2PjNcnWQ66xXxa3XlS8nCcA8aJKJjIIMNJTC7tu80GwpQ==
+"@ethersproject/networks@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/networks/-/networks-5.8.0.tgz#8b4517a3139380cba9fb00b63ffad0a979671fde"
+  integrity sha512-egPJh3aPVAzbHwq8DD7Po53J4OUSsA1MjQp8Vf/OZPav5rlmWUaFLiq8cvQiGK0Z5K6LYzm29+VA/p4RL1FzNg==
   dependencies:
-    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/logger" "^5.8.0"
 
-"@ethersproject/properties@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.7.0.tgz#a6e12cb0439b878aaf470f1902a176033067ed30"
-  integrity sha512-J87jy8suntrAkIZtecpxEPxY//szqr1mlBaYlQ0r4RCaiD2hjheqF9s1LVE8vVuJCXisjIP+JgtK/Do54ej4Sw==
+"@ethersproject/properties@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/properties/-/properties-5.8.0.tgz#405a8affb6311a49a91dabd96aeeae24f477020e"
+  integrity sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw==
   dependencies:
-    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/logger" "^5.8.0"
 
-"@ethersproject/rlp@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.7.0.tgz#de39e4d5918b9d74d46de93af80b7685a9c21304"
-  integrity sha512-rBxzX2vK8mVF7b0Tol44t5Tb8gomOHkj5guL+HhzQ1yBh/ydjGnpw6at+X6Iw0Kp3OzzzkcKp8N9r0W4kYSs9w==
+"@ethersproject/rlp@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/rlp/-/rlp-5.8.0.tgz#5a0d49f61bc53e051532a5179472779141451de5"
+  integrity sha512-LqZgAznqDbiEunaUvykH2JAoXTT9NV0Atqk8rQN9nx9SEgThA/WMx5DnW8a9FOufo//6FZOCHZ+XiClzgbqV9Q==
   dependencies:
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
 
-"@ethersproject/signing-key@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.7.0.tgz#06b2df39411b00bc57c7c09b01d1e41cf1b16ab3"
-  integrity sha512-MZdy2nL3wO0u7gkB4nA/pEf8lu1TlFswPNmy8AiYkfKTdO6eXBJyUdmHO/ehm/htHw9K/qF8ujnTyUAD+Ry54Q==
+"@ethersproject/signing-key@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/signing-key/-/signing-key-5.8.0.tgz#9797e02c717b68239c6349394ea85febf8893119"
+  integrity sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w==
   dependencies:
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
-    "@ethersproject/properties" "^5.7.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
     bn.js "^5.2.1"
-    elliptic "6.5.4"
+    elliptic "6.6.1"
     hash.js "1.1.7"
 
-"@ethersproject/strings@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.7.0.tgz#54c9d2a7c57ae8f1205c88a9d3a56471e14d5ed2"
-  integrity sha512-/9nu+lj0YswRNSH0NXYqrh8775XNyEdUQAuf3f+SmOrnVewcJ5SBNAjF7lpgehKi4abvNNXyf+HX86czCdJ8Mg==
+"@ethersproject/strings@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/strings/-/strings-5.8.0.tgz#ad79fafbf0bd272d9765603215ac74fd7953908f"
+  integrity sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg==
   dependencies:
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/constants" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/constants" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
 
-"@ethersproject/transactions@^5.7.0":
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.7.0.tgz#91318fc24063e057885a6af13fdb703e1f993d3b"
-  integrity sha512-kmcNicCp1lp8qanMTC3RIikGgoJ80ztTyvtsFvCYpSCfkjhD0jZ2LOrnbcuxuToLIUYYf+4XwD1rP+B/erDIhQ==
+"@ethersproject/transactions@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/transactions/-/transactions-5.8.0.tgz#1e518822403abc99def5a043d1c6f6fe0007e46b"
+  integrity sha512-UglxSDjByHG0TuU17bDfCemZ3AnKO2vYrL5/2n2oXvKzvb7Cz+W9gOWXKARjp2URVwcWlQlPOEQyAviKwT4AHg==
   dependencies:
-    "@ethersproject/address" "^5.7.0"
-    "@ethersproject/bignumber" "^5.7.0"
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/constants" "^5.7.0"
-    "@ethersproject/keccak256" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
-    "@ethersproject/properties" "^5.7.0"
-    "@ethersproject/rlp" "^5.7.0"
-    "@ethersproject/signing-key" "^5.7.0"
+    "@ethersproject/address" "^5.8.0"
+    "@ethersproject/bignumber" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/constants" "^5.8.0"
+    "@ethersproject/keccak256" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/rlp" "^5.8.0"
+    "@ethersproject/signing-key" "^5.8.0"
 
-"@ethersproject/web@^5.7.0":
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.7.1.tgz#de1f285b373149bee5928f4eb7bcb87ee5fbb4ae"
-  integrity sha512-Gueu8lSvyjBWL4cYsWsjh6MtMwM0+H4HvqFPZfB6dV8ctbP9zFAO73VG1cMWae0FLPCtz0peKPpZY8/ugJJX2w==
+"@ethersproject/web@^5.8.0":
+  version "5.8.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/web/-/web-5.8.0.tgz#3e54badc0013b7a801463a7008a87988efce8a37"
+  integrity sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw==
   dependencies:
-    "@ethersproject/base64" "^5.7.0"
-    "@ethersproject/bytes" "^5.7.0"
-    "@ethersproject/logger" "^5.7.0"
-    "@ethersproject/properties" "^5.7.0"
-    "@ethersproject/strings" "^5.7.0"
+    "@ethersproject/base64" "^5.8.0"
+    "@ethersproject/bytes" "^5.8.0"
+    "@ethersproject/logger" "^5.8.0"
+    "@ethersproject/properties" "^5.8.0"
+    "@ethersproject/strings" "^5.8.0"
 
 "@humanwhocodes/config-array@^0.13.0":
   version "0.13.0"
@@ -471,9 +471,9 @@
   integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
 "@types/node@*":
-  version "22.13.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.13.1.tgz#a2a3fefbdeb7ba6b89f40371842162fac0934f33"
-  integrity sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==
+  version "22.13.9"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.13.9.tgz#5d9a8f7a975a5bd3ef267352deb96fb13ec02eca"
+  integrity sha512-acBjXdRJ3A6Pb3tqnw9HZmyR3Fiol3aGxRCK1x3d+6CDAMjl7I649wpSd+yNURCjbOUGu9tqtLKnTGxmK6CyGw==
   dependencies:
     undici-types "~6.20.0"
 
@@ -517,9 +517,9 @@ acorn-walk@^8.1.1:
     acorn "^8.11.0"
 
 acorn@^8.11.0, acorn@^8.4.1, acorn@^8.9.0:
-  version "8.14.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.0.tgz#063e2c70cac5fb4f6467f0b11152e04c682795b0"
-  integrity sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==
+  version "8.14.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.1.tgz#721d5dc10f7d5b5609a891773d47731796935dfb"
+  integrity sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==
 
 aes-js@4.0.0-beta.5:
   version "4.0.0-beta.5"
@@ -726,9 +726,9 @@ camelcase@^6.0.0:
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 chai@^5.0.3:
-  version "5.1.2"
-  resolved "https://registry.yarnpkg.com/chai/-/chai-5.1.2.tgz#3afbc340b994ae3610ca519a6c70ace77ad4378d"
-  integrity sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-5.2.0.tgz#1358ee106763624114addf84ab02697e411c9c05"
+  integrity sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==
   dependencies:
     assertion-error "^2.0.1"
     check-error "^2.1.1"
@@ -948,10 +948,10 @@ dotenv@^16.4.1:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.7.tgz#0e20c5b82950140aa99be360a8a5f52335f53c26"
   integrity sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==
 
-elliptic@6.5.4:
-  version "6.5.4"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
-  integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
+elliptic@6.6.1:
+  version "6.6.1"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.6.1.tgz#3b8ffb02670bf69e382c7f65bf524c97c5405c06"
+  integrity sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==
   dependencies:
     bn.js "^4.11.9"
     brorand "^1.1.0"
@@ -1193,9 +1193,9 @@ fast-uri@^3.0.1:
   integrity sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==
 
 fastq@^1.6.0:
-  version "1.19.0"
-  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.19.0.tgz#a82c6b7c2bb4e44766d865f07997785fecfdcb89"
-  integrity sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.19.1.tgz#d50eaba803c8846a883c16492821ebcd2cda55f5"
+  integrity sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==
   dependencies:
     reusify "^1.0.4"
 
@@ -1243,9 +1243,9 @@ flat@^5.0.2:
   integrity sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==
 
 flatted@^3.2.9:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.2.tgz#adba1448a9841bec72b42c532ea23dbbedef1a27"
-  integrity sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.3.tgz#67c8fad95454a7c7abebf74bb78ee74a44023358"
+  integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
 
 form-data-encoder@^2.1.2:
   version "2.1.4"
@@ -2070,9 +2070,9 @@ prettier@^2.3.1, prettier@^2.8.3:
   integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
 prettier@^3.0.0:
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.4.2.tgz#a5ce1fb522a588bf2b78ca44c6e6fe5aa5a2b13f"
-  integrity sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.5.3.tgz#4fc2ce0d657e7a02e602549f053b239cb7dfe1b5"
+  integrity sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==
 
 proto-list@~1.2.1:
   version "1.2.4"
@@ -2193,9 +2193,9 @@ responselike@^3.0.0:
     lowercase-keys "^3.0.0"
 
 reusify@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
-  integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.1.0.tgz#0fe13b9522e1473f51b558ee796e08f11f9b489f"
+  integrity sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==
 
 rimraf@^3.0.2:
   version "3.0.2"
@@ -2629,6 +2629,10 @@ which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
+
+"wip@github:piplabs/wip#main":
+  version "0.0.0"
+  resolved "https://codeload.github.com/piplabs/wip/tar.gz/81232394c823ebe5deed2bf3b5377f6c1028b699"
 
 word-wrap@^1.2.5, word-wrap@~1.2.3:
   version "1.2.5"


### PR DESCRIPTION
## Overview
This PR integrates the Wrapped IP token (WIP) into our testing and deployment infrastructure, replacing the previous mock ERC20 (SUSD) token. It also removes the unused Story NFT deployment addresses from `StoryProtocolPeripheryAddressManager`

## Changes
- Added WIP token dependency from piplabs/wip repository
- Updated remappings to include WIP and Solady token paths
- Updated CREATE3_DEPLOYER address in Story NFT deployment scripts
- Migrated from SUSD to WIP token in all integration tests
- Simplified address management by moving unused Story NFT addresses
- Updated token amounts and fee handling to work with wrapped token pattern

## Testing
All integration tests have been updated to use the WIP token instead of SUSD. The token interaction pattern has changed from direct minting to deposit-and-wrap:
- `StoryUSD.mint()` → `wrappedIP.deposit{ value: amount }()`
- Fee amounts adjusted to reflect WIP token value
- All token approvals and balance checks updated accordingly

## Notes
The organization NFT addresses have been temporarily marked as TODOs and will need to be updated when upgrading Story NFTs in the future.

## Related Issues
- Closes #171 

