### PR TITLE
feat: enable token template upgrades through `TokenizerModule`

### DIFF
--- a/contracts/interfaces/modules/tokenizer/ITokenizerModule.sol
+++ b/contracts/interfaces/modules/tokenizer/ITokenizerModule.sol
@@ -28,6 +28,12 @@ interface ITokenizerModule is IModule {
     /// @return token The address of the newly created token
     function tokenize(address ipId, address tokenTemplate, bytes calldata initData) external returns (address token);
 
+    /// @dev Upgrades a whitelisted token template
+    /// @dev Enforced to be only callable by the upgrader admin
+    /// @param tokenTemplate The address of the token template to upgrade
+    /// @param newTokenImplementation The address of the new token implementation
+    function upgradeWhitelistedTokenTemplate(address tokenTemplate, address newTokenImplementation) external;
+
     /// @notice Returns the fractionalized token for an IP
     /// @param ipId The address of the IP
     /// @return token The address of the token

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -142,6 +142,9 @@ library Errors {
     /// @notice Zero token template provided.
     error TokenizerModule__ZeroTokenTemplate();
 
+    /// @notice Zero token template implementation provided.
+    error TokenizerModule__ZeroTokenTemplateImplementation();
+
     /// @notice Zero protocol access manager provided.
     error TokenizerModule__ZeroProtocolAccessManager();
 

--- a/contracts/modules/tokenizer/TokenizerModule.sol
+++ b/contracts/modules/tokenizer/TokenizerModule.sol
@@ -133,7 +133,10 @@ contract TokenizerModule is
     /// @dev Enforced to be only callable by the upgrader admin
     /// @param tokenTemplate The address of the token template to upgrade
     /// @param newTokenImplementation The address of the new token implementation
-    function upgradeWhitelistedTokenTemplate(address tokenTemplate, address newTokenImplementation) external restricted {
+    function upgradeWhitelistedTokenTemplate(
+        address tokenTemplate,
+        address newTokenImplementation
+    ) external restricted {
         if (tokenTemplate == address(0)) revert Errors.TokenizerModule__ZeroTokenTemplate();
         if (newTokenImplementation == address(0)) revert Errors.TokenizerModule__ZeroTokenTemplateImplementation();
         if (!_getTokenizerModuleStorage().isWhitelistedTokenTemplate[tokenTemplate])

--- a/script/utils/DeployHelper.sol
+++ b/script/utils/DeployHelper.sol
@@ -195,6 +195,9 @@ contract DeployHelper is
             if (spgNftBeacon.owner() != address(registrationWorkflows))
                 revert DeploymentConfigError("RegistrationWorkflows is not the owner of SPGNFTBeacon");
 
+            if (UpgradeableBeacon(ownableERC20Beacon).owner() != address(tokenizerModule))
+                revert DeploymentConfigError("TokenizerModule is not the owner of OwnableERC20Beacon");
+
             if (writeDeploys) _writeDeployment(); // JsonDeploymentHandler.s.sol
             _endBroadcast(); // BroadcastManager.s.sol
         }
@@ -547,6 +550,7 @@ contract DeployHelper is
     function _configurePeripheryContracts() private {
        // Transfer ownership of beacon proxy to RegistrationWorkflows
        spgNftBeacon.transferOwnership(address(registrationWorkflows));
+       UpgradeableBeacon(ownableERC20Beacon).transferOwnership(address(tokenizerModule));
        registrationWorkflows.setNftContractBeacon(address(spgNftBeacon));
        tokenizerModule.whitelistTokenTemplate(address(ownableERC20Template), true);
        IModuleRegistry(moduleRegistryAddr).registerModule("TOKENIZER_MODULE", address(tokenizerModule));

--- a/test/modules/tokenizer/TokenizerModule.t.sol
+++ b/test/modules/tokenizer/TokenizerModule.t.sol
@@ -327,7 +327,9 @@ contract TokenizerModuleTest is BaseTest {
         address newTokenTemplateImpl = address(new OwnableERC20(address(ownableERC20Beacon)));
 
         vm.startPrank(u.admin);
-        vm.expectRevert(abi.encodeWithSelector(Errors.TokenizerModule__TokenTemplateNotWhitelisted.selector, address(0x1234)));
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.TokenizerModule__TokenTemplateNotWhitelisted.selector, address(0x1234))
+        );
         tokenizerModule.upgradeWhitelistedTokenTemplate(address(0x1234), address(newTokenTemplateImpl));
         vm.stopPrank();
     }


### PR DESCRIPTION
## Description
This PR adds the ability to upgrade whitelisted token template implementations in the `TokenizerModule`. The enhancement enables controlled upgrades of token implementations while maintaining system security through proper access controls.

## Changes
- Added `upgradeWhitelistedTokenTemplate` function to the `TokenizerModule` and its interface
- Updated the Errors library with a new error for zero token implementation validation
- Transferred ownership of the `ownableERC20Beacon` to the `TokenizerModule`
- Added tests to verify upgrade functionality works correctly

## Security Considerations
- Function is restricted to be called only by the upgrader admin through the `restricted` modifier
- Multiple validation checks ensure that:
  - Token template address is not zero
  - New implementation address is not zero 
  - Token template is whitelisted

## Testing
Added two test cases:
1. Successfully upgrading a whitelisted token template
2. Verifying reversion when attempting to upgrade a non-whitelisted template
