### PR TITLE
chore: add upgrade collection functions' declaration to `IRegistrationWorkflows` interface

### DIFF
--- a/contracts/interfaces/workflows/IRegistrationWorkflows.sol
+++ b/contracts/interfaces/workflows/IRegistrationWorkflows.sol
@@ -45,6 +45,16 @@ interface IRegistrationWorkflows {
         WorkflowStructs.SignatureData calldata sigMetadata
     ) external returns (address ipId);
 
+    /// @notice Sets the NFT contract beacon address.
+    /// @dev Restricted to be only callable by the protocol admin and upgrader.
+    /// @param newNftContractBeacon The address of the new NFT contract beacon.
+    function setNftContractBeacon(address newNftContractBeacon) external;
+
+    /// @notice Upgrades the NFT contract beacon.
+    /// @dev Restricted to be only callable by the protocol admin and upgrader.
+    /// @param newNftContract The address of the new NFT contract implementation.
+    function upgradeCollections(address newNftContract) external;
+
     ////////////////////////////////////////////////////////////////////////////
     //                   DEPRECATED, WILL BE REMOVED IN V1.4                  //
     ////////////////////////////////////////////////////////////////////////////

--- a/contracts/workflows/RegistrationWorkflows.sol
+++ b/contracts/workflows/RegistrationWorkflows.sol
@@ -81,7 +81,8 @@ contract RegistrationWorkflows is
         __Multicall_init();
     }
 
-    /// @dev Sets the NFT contract beacon address.
+    /// @notice Sets the NFT contract beacon address.
+    /// @dev Restricted to be only callable by the protocol admin and upgrader.
     /// @param newNftContractBeacon The address of the new NFT contract beacon.
     function setNftContractBeacon(address newNftContractBeacon) external restricted {
         if (newNftContractBeacon == address(0)) revert Errors.RegistrationWorkflows__ZeroAddressParam();
@@ -89,9 +90,10 @@ contract RegistrationWorkflows is
         $.nftContractBeacon = newNftContractBeacon;
     }
 
-    /// @dev Upgrades the NFT contract beacon. Restricted to only the protocol access manager.
+    /// @notice Upgrades the NFT contract beacon.
+    /// @dev Restricted to be only callable by the protocol admin and upgrader.
     /// @param newNftContract The address of the new NFT contract implementation.
-    function upgradeCollections(address newNftContract) public restricted {
+    function upgradeCollections(address newNftContract) external restricted {
         // UpgradeableBeacon checks for newImplementation.bytecode.length > 0, so no need to check for zero address.
         UpgradeableBeacon(_getRegistrationWorkflowsStorage().nftContractBeacon).upgradeTo(newNftContract);
     }


### PR DESCRIPTION
## Description
This PR adds `setNftContractBeacon` and `upgradeCollections` to `IRegistrationWorkflows` interface to improve visibility.

## Changes
- Added missing interface declarations for `setNftContractBeacon` and `upgradeCollections` functions in `IRegistrationWorkflows.sol`
- Improved function documentation to clearly indicate restricted access requirements
- Changed visibility of `upgradeCollections` function from `public` to `external` for consistency interface usage
- Updated function documentation for `setNftContractBeacon` and `upgradeCollections` to use `@notice` tags instead of `@dev` for better NatSpec documentation
- Improved documentation by using standardized phrasing for restricted access notes

## Notes
This PR is part of the solution to address [issue #178](https://github.com/storyprotocol/protocol-periphery-v1/issues/178).
