### PR TITLE
fix(upgrade): add upgrade permissions for Licensing Hooks

### DIFF
--- a/script/utils/DeployHelper.sol
+++ b/script/utils/DeployHelper.sol
@@ -615,6 +615,13 @@ contract DeployHelper is
             ProtocolAdmin.UPGRADER_ROLE
         );
 
+        // Module Registry
+        // Upgrading Licensing Hooks requires both removeModule and registerModule
+        selectors = new bytes4[](2);
+        selectors[0] = ModuleRegistry.removeModule.selector;
+        selectors[1] = bytes4(keccak256("registerModule(string,address)"));
+        AccessManager(protocolAccessManagerAddr).setTargetFunctionRole(moduleRegistryAddr, selectors, ProtocolAdmin.UPGRADER_ROLE);
+
         selectors = new bytes4[](2);
         selectors[0] = ProtocolPausableUpgradeable.pause.selector;
         selectors[1] = ProtocolPausableUpgradeable.unpause.selector;

--- a/script/utils/StoryProtocolPeripheryAddressManager.sol
+++ b/script/utils/StoryProtocolPeripheryAddressManager.sol
@@ -15,6 +15,7 @@ contract StoryProtocolPeripheryAddressManager is Script {
     address internal royaltyTokenDistributionWorkflowsAddr;
     address internal spgNftBeaconAddr;
     address internal spgNftImplAddr;
+    address internal ownableERC20BeaconAddr;
     address internal ownableERC20TemplateAddr;
     address internal tokenizerModuleAddr;
 
@@ -33,6 +34,7 @@ contract StoryProtocolPeripheryAddressManager is Script {
         royaltyTokenDistributionWorkflowsAddr = json.readAddress(".main.RoyaltyTokenDistributionWorkflows");
         spgNftBeaconAddr = json.readAddress(".main.SPGNFTBeacon");
         spgNftImplAddr = json.readAddress(".main.SPGNFTImpl");
+        ownableERC20BeaconAddr = json.readAddress(".main.OwnableERC20Beacon");
         ownableERC20TemplateAddr = json.readAddress(".main.OwnableERC20Template");
         tokenizerModuleAddr = json.readAddress(".main.TokenizerModule");
     }


### PR DESCRIPTION
## Description
This PR adds the necessary permissions to the ModuleRegistry contract to properly handle Licensing Hook upgrades. It grants the UPGRADER_ROLE the ability to call both `removeModule` and `registerModule` functions on the ModuleRegistry, which are required operations when upgrading Licensing Hooks.
