### PR TITLE
Implement IP Registration Fee Payment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ typechain
 
 # converage
 lcov.info
+
+.cursor

--- a/contracts/interfaces/story-nft/IOrgNFT.sol
+++ b/contracts/interfaces/story-nft/IOrgNFT.sol
@@ -47,22 +47,26 @@ interface IOrgNFT is IERC721Metadata {
     ////////////////////////////////////////////////////////////////////////////
     /// @notice Mints the root organization token and register it as an IP.
     /// @param recipient The address of the recipient of the root organization token.
+    /// @param registrationFeePayer The address of the payer of the registration fee.
     /// @param orgIpMetadata OPTIONAL. The desired metadata for the newly minted OrgNFT and registered IP.
     /// @return rootOrgTokenId The ID of the root organization token.
     /// @return rootOrgIpId The ID of the root organization IP.
     function mintRootOrgNft(
         address recipient,
+        address registrationFeePayer,
         WorkflowStructs.IPMetadata calldata orgIpMetadata
     ) external returns (uint256 rootOrgTokenId, address rootOrgIpId);
 
     /// @notice Mints an organization token, register it as an IP,
     /// and makes the IP as a derivative of the root organization IP.
     /// @param recipient The address of the recipient of the minted organization token.
+    /// @param registrationFeePayer The address of the payer of the registration fee.
     /// @param orgIpMetadata OPTIONAL. The desired metadata for the newly minted OrgNFT and registered IP.
     /// @return orgTokenId The ID of the minted organization token.
     /// @return orgIpId The ID of the organization IP.
     function mintOrgNft(
         address recipient,
+        address registrationFeePayer,
         WorkflowStructs.IPMetadata calldata orgIpMetadata
     ) external returns (uint256 orgTokenId, address orgIpId);
 

--- a/contracts/story-nft/OrgStoryNFTFactory.sol
+++ b/contracts/story-nft/OrgStoryNFTFactory.sol
@@ -278,9 +278,9 @@ contract OrgStoryNFTFactory is IOrgStoryNFTFactory, AccessManagedUpgradeable, UU
 
         // Mint the organization NFT and register it as an IP
         if (isRootOrg) {
-            (orgTokenId, orgIpId) = ORG_NFT.mintRootOrgNft(orgNftRecipient, orgIpMetadata);
+            (orgTokenId, orgIpId) = ORG_NFT.mintRootOrgNft(orgNftRecipient, msg.sender, orgIpMetadata);
         } else {
-            (orgTokenId, orgIpId) = ORG_NFT.mintOrgNft(orgNftRecipient, orgIpMetadata);
+            (orgTokenId, orgIpId) = ORG_NFT.mintOrgNft(orgNftRecipient, msg.sender, orgIpMetadata);
         }
 
         orgNft = address(ORG_NFT);

--- a/contracts/workflows/DerivativeWorkflows.sol
+++ b/contracts/workflows/DerivativeWorkflows.sol
@@ -114,6 +114,7 @@ contract DerivativeWorkflows is
             allowDuplicates: allowDuplicates
         });
 
+        _collectRegistrationFeeAndApprove(msg.sender);
         ipId = IP_ASSET_REGISTRY.register(block.chainid, spgNftContract, tokenId);
 
         MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);
@@ -146,6 +147,7 @@ contract DerivativeWorkflows is
         if (msg.sender != sigMetadataAndRegister.signer)
             revert Errors.DerivativeWorkflows__CallerNotSigner(msg.sender, sigMetadataAndRegister.signer);
 
+        _collectRegistrationFeeAndApprove(msg.sender);
         ipId = IP_ASSET_REGISTRY.register(block.chainid, nftContract, tokenId);
 
         address[] memory modules = new address[](2);
@@ -202,6 +204,7 @@ contract DerivativeWorkflows is
             allowDuplicates: allowDuplicates
         });
 
+        _collectRegistrationFeeAndApprove(msg.sender);
         ipId = IP_ASSET_REGISTRY.register(block.chainid, spgNftContract, tokenId);
         MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);
 
@@ -234,6 +237,7 @@ contract DerivativeWorkflows is
             revert Errors.DerivativeWorkflows__CallerNotSigner(msg.sender, sigMetadataAndRegister.signer);
 
         _collectLicenseTokens(licenseTokenIds, address(LICENSE_TOKEN));
+        _collectRegistrationFeeAndApprove(msg.sender);
         ipId = IP_ASSET_REGISTRY.register(block.chainid, nftContract, tokenId);
 
         address[] memory modules = new address[](2);

--- a/contracts/workflows/GroupingWorkflows.sol
+++ b/contracts/workflows/GroupingWorkflows.sol
@@ -134,6 +134,7 @@ contract GroupingWorkflows is
             allowDuplicates: allowDuplicates
         });
 
+        _collectRegistrationFeeAndApprove(msg.sender);
         ipId = IP_ASSET_REGISTRY.register(block.chainid, spgNftContract, tokenId);
         MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);
 
@@ -182,6 +183,7 @@ contract GroupingWorkflows is
         if (msg.sender != sigAddToGroup.signer)
             revert Errors.GroupingWorkflows__CallerNotSigner(msg.sender, sigAddToGroup.signer);
 
+        _collectRegistrationFeeAndApprove(msg.sender);
         ipId = IP_ASSET_REGISTRY.register(block.chainid, nftContract, tokenId);
 
         address[] memory modules = new address[](3);
@@ -226,6 +228,7 @@ contract GroupingWorkflows is
         address groupPool,
         WorkflowStructs.LicenseData calldata licenseData
     ) external returns (address groupId) {
+        _collectRegistrationFeeAndApprove(msg.sender);
         groupId = GROUPING_MODULE.registerGroup(groupPool);
 
         LicensingHelper.attachLicenseTermsAndSetConfigs(
@@ -253,6 +256,7 @@ contract GroupingWorkflows is
         uint256 maxAllowedRewardShare,
         WorkflowStructs.LicenseData calldata licenseData
     ) external returns (address groupId) {
+        _collectRegistrationFeeAndApprove(msg.sender);
         groupId = GROUPING_MODULE.registerGroup(groupPool);
 
         LicensingHelper.attachLicenseTermsAndSetConfigs(

--- a/contracts/workflows/LicenseAttachmentWorkflows.sol
+++ b/contracts/workflows/LicenseAttachmentWorkflows.sol
@@ -148,6 +148,7 @@ contract LicenseAttachmentWorkflows is
             allowDuplicates: allowDuplicates
         });
 
+        _collectRegistrationFeeAndApprove(msg.sender);
         ipId = IP_ASSET_REGISTRY.register(block.chainid, spgNftContract, tokenId);
         MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);
 
@@ -186,6 +187,7 @@ contract LicenseAttachmentWorkflows is
         if (msg.sender != sigMetadataAndAttachAndConfig.signer)
             revert Errors.LicenseAttachmentWorkflows__CallerNotSigner(msg.sender, sigMetadataAndAttachAndConfig.signer);
 
+        _collectRegistrationFeeAndApprove(msg.sender);
         ipId = IP_ASSET_REGISTRY.register(block.chainid, nftContract, tokenId);
 
         address[] memory modules = new address[](3);
@@ -236,6 +238,7 @@ contract LicenseAttachmentWorkflows is
             allowDuplicates: allowDuplicates
         });
 
+        _collectRegistrationFeeAndApprove(msg.sender);
         ipId = IP_ASSET_REGISTRY.register(block.chainid, spgNftContract, tokenId);
         MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);
 
@@ -260,6 +263,7 @@ contract LicenseAttachmentWorkflows is
         if (msg.sender != sigMetadataAndDefaultTerms.signer)
             revert Errors.LicenseAttachmentWorkflows__CallerNotSigner(msg.sender, sigMetadataAndDefaultTerms.signer);
 
+        _collectRegistrationFeeAndApprove(msg.sender);
         ipId = IP_ASSET_REGISTRY.register(block.chainid, nftContract, tokenId);
 
         address[] memory modules = new address[](2);

--- a/contracts/workflows/RegistrationWorkflows.sol
+++ b/contracts/workflows/RegistrationWorkflows.sol
@@ -129,6 +129,7 @@ contract RegistrationWorkflows is
             allowDuplicates: allowDuplicates
         });
 
+        _collectRegistrationFeeAndApprove(msg.sender);
         ipId = IP_ASSET_REGISTRY.register(block.chainid, spgNftContract, tokenId);
         MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);
         ISPGNFT(spgNftContract).safeTransferFrom(address(this), recipient, tokenId, "");
@@ -149,6 +150,7 @@ contract RegistrationWorkflows is
         if (msg.sender != address(0) && msg.sender != sigMetadata.signer)
             revert Errors.RegistrationWorkflows__CallerNotSigner(msg.sender, sigMetadata.signer);
 
+        _collectRegistrationFeeAndApprove(msg.sender);
         ipId = IP_ASSET_REGISTRY.register(block.chainid, nftContract, tokenId);
         MetadataHelper.setMetadataWithSig(
             ipId,

--- a/contracts/workflows/RoyaltyTokenDistributionWorkflows.sol
+++ b/contracts/workflows/RoyaltyTokenDistributionWorkflows.sol
@@ -203,6 +203,7 @@ contract RoyaltyTokenDistributionWorkflows is
                 sigMetadataAndAttachAndConfig.signer
             );
 
+        _collectRegistrationFeeAndApprove(msg.sender);
         ipId = IP_ASSET_REGISTRY.register(block.chainid, nftContract, tokenId);
 
         address[] memory modules = new address[](3);
@@ -252,6 +253,7 @@ contract RoyaltyTokenDistributionWorkflows is
         if (msg.sender != sigMetadataAndRegister.signer)
             revert Errors.RoyaltyTokenDistributionWorkflows__CallerNotSigner(msg.sender, sigMetadataAndRegister.signer);
 
+        _collectRegistrationFeeAndApprove(msg.sender);
         ipId = IP_ASSET_REGISTRY.register(block.chainid, nftContract, tokenId);
 
         address[] memory modules = new address[](2);
@@ -421,6 +423,8 @@ contract RoyaltyTokenDistributionWorkflows is
             nftMetadataHash: ipMetadata.nftMetadataHash,
             allowDuplicates: allowDuplicates
         });
+
+        _collectRegistrationFeeAndApprove(msg.sender);
         ipId = IP_ASSET_REGISTRY.register(block.chainid, spgNftContract, tokenId);
         MetadataHelper.setMetadata(ipId, address(CORE_METADATA_MODULE), ipMetadata);
     }

--- a/test/story-nft/OrgNFT.t.sol
+++ b/test/story-nft/OrgNFT.t.sol
@@ -114,7 +114,7 @@ contract OrgNFTTest is BaseTest {
                 address(orgStoryNftFactory)
             )
         );
-        orgNft.mintRootOrgNft(u.bob, ipMetadataDefault);
+        orgNft.mintRootOrgNft(u.bob, u.bob, ipMetadataDefault);
 
         vm.expectRevert(
             abi.encodeWithSelector(
@@ -123,7 +123,7 @@ contract OrgNFTTest is BaseTest {
                 address(orgStoryNftFactory)
             )
         );
-        orgNft.mintOrgNft(u.bob, ipMetadataDefault);
+        orgNft.mintOrgNft(u.bob, u.bob, ipMetadataDefault);
         vm.stopPrank();
     }
 }

--- a/test/story-nft/StoryBadgeNFT.t.sol
+++ b/test/story-nft/StoryBadgeNFT.t.sol
@@ -342,4 +342,28 @@ contract StoryBadgeNFTTest is BaseTest {
         );
         rootOrgStoryNft.mint(u.carl, signature);
     }
+
+    function test_StoryBadgeNFT_mint_WithRegistrationFee() public {
+        uint96 registrationFee = 1 ether;
+        address treasury = address(0x12345);
+
+        vm.startPrank(u.admin);
+        ipAssetRegistry.setRegistrationFee(treasury, address(mockToken), registrationFee);
+        vm.stopPrank();
+
+        bytes memory signature = _signAddress(rootOrgStoryNftSignerSk, u.carl, address(rootOrgStoryNft));
+
+        vm.startPrank(u.carl);
+        mockToken.mint(u.carl, registrationFee);
+        mockToken.approve(address(rootOrgStoryNft), registrationFee);
+
+        uint256 carlBalanceBefore = mockToken.balanceOf(u.carl);
+        uint256 treasuryBalanceBefore = mockToken.balanceOf(treasury);
+
+        rootOrgStoryNft.mint(u.carl, signature);
+
+        assertEq(mockToken.balanceOf(treasury), treasuryBalanceBefore + registrationFee);
+        assertEq(mockToken.balanceOf(u.carl), carlBalanceBefore - registrationFee);
+        vm.stopPrank();
+    }
 }

--- a/test/workflows/LicenseAttachmentWorkflows.t.sol
+++ b/test/workflows/LicenseAttachmentWorkflows.t.sol
@@ -406,6 +406,174 @@ contract LicenseAttachmentWorkflowsTest is BaseTest {
         assertEq(licenseTermsId, licenseTemplates[0]);
     }
 
+    function test_LicenseAttachmentWorkflows_mintAndRegisterIpAndAttachPILTerms_withRegistrationFee()
+        public
+        withCollection
+        whenCallerHasMinterRole
+        withEnoughTokens(address(licenseAttachmentWorkflows))
+    {
+        vm.stopPrank();
+
+        uint96 registrationFee = 1 ether;
+        address treasury = address(0x12345);
+
+        vm.prank(u.admin);
+        ipAssetRegistry.setRegistrationFee(treasury, address(mockToken), registrationFee);
+
+        uint256 treasuryBalanceBefore = mockToken.balanceOf(treasury);
+        uint256 callerBalanceBefore = mockToken.balanceOf(caller);
+
+        vm.prank(caller);
+        licenseAttachmentWorkflows.mintAndRegisterIpAndAttachPILTerms({
+            spgNftContract: address(nftContract),
+            recipient: caller,
+            ipMetadata: ipMetadataEmpty,
+            licenseTermsData: commTermsData,
+            allowDuplicates: true
+        });
+
+        assertEq(mockToken.balanceOf(treasury), treasuryBalanceBefore + registrationFee);
+        assertEq(mockToken.balanceOf(caller), callerBalanceBefore - registrationFee - nftContract.mintFee());
+    }
+
+    function test_LicenseAttachmentWorkflows_registerIpAndAttachPILTerms_withRegistrationFee()
+        public
+        withCollection
+        whenCallerHasMinterRole
+        withEnoughTokens(address(licenseAttachmentWorkflows))
+    {
+        vm.stopPrank();
+
+        uint96 registrationFee = 1 ether;
+        address treasury = address(0x12345);
+
+        vm.prank(u.admin);
+        ipAssetRegistry.setRegistrationFee(treasury, address(mockToken), registrationFee);
+
+        vm.prank(caller);
+        uint256 tokenId = nftContract.mint({
+            to: caller,
+            nftMetadataURI: ipMetadataEmpty.nftMetadataURI,
+            nftMetadataHash: ipMetadataEmpty.nftMetadataHash,
+            allowDuplicates: true
+        });
+        address payable ipId = payable(ipAssetRegistry.ipId(block.chainid, address(nftContract), tokenId));
+
+        uint256 deadline = block.timestamp + 1000;
+
+        (bytes memory sigMetadataAndAttachAndConfig, , ) = _getSetBatchPermissionSigForPeriphery({
+            ipId: ipId,
+            permissionList: _getMetadataAndAttachTermsAndConfigPermissionList(
+                ipId,
+                address(licenseAttachmentWorkflows)
+            ),
+            deadline: deadline,
+            state: bytes32(0),
+            signerSk: sk.alice
+        });
+
+        vm.startPrank(caller);
+
+        uint256 callerBalanceBefore = mockToken.balanceOf(caller);
+        uint256 treasuryBalanceBefore = mockToken.balanceOf(treasury);
+
+        licenseAttachmentWorkflows.registerIpAndAttachPILTerms({
+            nftContract: address(nftContract),
+            tokenId: tokenId,
+            ipMetadata: ipMetadataDefault,
+            licenseTermsData: commTermsData,
+            sigMetadataAndAttachAndConfig: WorkflowStructs.SignatureData({
+                signer: u.alice,
+                deadline: deadline,
+                signature: sigMetadataAndAttachAndConfig
+            })
+        });
+
+        assertEq(mockToken.balanceOf(treasury), treasuryBalanceBefore + registrationFee);
+        assertEq(mockToken.balanceOf(caller), callerBalanceBefore - registrationFee);
+    }
+
+    function test_LicenseAttachmentWorkflows_mintAndRegisterIpAndAttachDefaultTerms_withRegistrationFee()
+        public
+        withCollection
+        whenCallerHasMinterRole
+        withEnoughTokens(address(licenseAttachmentWorkflows))
+    {
+        vm.stopPrank();
+
+        uint96 registrationFee = 1 ether;
+        address treasury = address(0x12345);
+
+        vm.prank(u.admin);
+        ipAssetRegistry.setRegistrationFee(treasury, address(mockToken), registrationFee);
+
+        uint256 callerBalanceBefore = mockToken.balanceOf(caller);
+        uint256 treasuryBalanceBefore = mockToken.balanceOf(treasury);
+
+        vm.prank(caller);
+        licenseAttachmentWorkflows.mintAndRegisterIpAndAttachDefaultTerms({
+            spgNftContract: address(nftContract),
+            recipient: caller,
+            ipMetadata: ipMetadataEmpty,
+            allowDuplicates: true
+        });
+
+        assertEq(mockToken.balanceOf(treasury), treasuryBalanceBefore + registrationFee);
+        assertEq(mockToken.balanceOf(caller), callerBalanceBefore - registrationFee - nftContract.mintFee());
+    }
+
+    function test_LicenseAttachmentWorkflows_registerIpAndAttachDefaultTerms_withRegistrationFee()
+        public
+        withCollection
+        whenCallerHasMinterRole
+        withEnoughTokens(address(licenseAttachmentWorkflows))
+    {
+        vm.stopPrank();
+
+        uint96 registrationFee = 1 ether;
+        address treasury = address(0x12345);
+
+        vm.prank(u.admin);
+        ipAssetRegistry.setRegistrationFee(treasury, address(mockToken), registrationFee);
+
+        vm.prank(caller);
+        uint256 tokenId = nftContract.mint({
+            to: caller,
+            nftMetadataURI: ipMetadataEmpty.nftMetadataURI,
+            nftMetadataHash: ipMetadataEmpty.nftMetadataHash,
+            allowDuplicates: true
+        });
+        address payable ipId = payable(ipAssetRegistry.ipId(block.chainid, address(nftContract), tokenId));
+
+        uint256 deadline = block.timestamp + 1000;
+
+        (bytes memory sigMetadataAndDefaultTerms, , ) = _getSetBatchPermissionSigForPeriphery({
+            ipId: ipId,
+            permissionList: _getMetadataAndDefaultTermsPermissionList(ipId, address(licenseAttachmentWorkflows)),
+            deadline: deadline,
+            state: bytes32(0),
+            signerSk: sk.alice
+        });
+
+        uint256 callerBalanceBefore = mockToken.balanceOf(caller);
+        uint256 treasuryBalanceBefore = mockToken.balanceOf(treasury);
+
+        vm.prank(caller);
+        licenseAttachmentWorkflows.registerIpAndAttachDefaultTerms({
+            nftContract: address(nftContract),
+            tokenId: tokenId,
+            ipMetadata: ipMetadataDefault,
+            sigMetadataAndDefaultTerms: WorkflowStructs.SignatureData({
+                signer: u.alice,
+                deadline: deadline,
+                signature: sigMetadataAndDefaultTerms
+            })
+        });
+
+        assertEq(mockToken.balanceOf(treasury), treasuryBalanceBefore + registrationFee);
+        assertEq(mockToken.balanceOf(caller), callerBalanceBefore - registrationFee);
+    }
+
     function _assertAttachedLicenseTerms(address ipId, uint256[] memory licenseTermsIds) internal {
         for (uint256 i = 0; i < commTermsData.length; i++) {
             (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId, i);

--- a/test/workflows/RegistrationWorkflows.t.sol
+++ b/test/workflows/RegistrationWorkflows.t.sol
@@ -271,4 +271,74 @@ contract RegistrationWorkflowsTest is BaseTest {
             assertMetadata(ipIds[i], ipMetadataDefault);
         }
     }
+
+    function test_mintAndRegisterIp_withRegistrationFee() public withCollection whenCallerHasMinterRole {
+        vm.stopPrank();
+
+        uint96 registrationFee = 1 ether;
+        address treasury = address(0x12345);
+
+        vm.prank(u.admin);
+        ipAssetRegistry.setRegistrationFee(treasury, address(mockToken), registrationFee);
+
+        vm.startPrank(caller);
+        mockToken.mint(address(caller), nftContract.mintFee() + registrationFee);
+        mockToken.approve(address(nftContract), nftContract.mintFee());
+        mockToken.approve(address(registrationWorkflows), registrationFee);
+
+        uint256 callerBalanceBefore = mockToken.balanceOf(caller);
+        uint256 treasuryBalanceBefore = mockToken.balanceOf(treasury);
+
+        (address ipId1, uint256 tokenId1) = registrationWorkflows.mintAndRegisterIp({
+            spgNftContract: address(nftContract),
+            recipient: u.bob,
+            ipMetadata: ipMetadataEmpty,
+            allowDuplicates: true
+        });
+        vm.stopPrank();
+
+        assertEq(mockToken.balanceOf(treasury), treasuryBalanceBefore + registrationFee);
+        assertEq(mockToken.balanceOf(caller), callerBalanceBefore - registrationFee - nftContract.mintFee());
+    }
+
+    function test_registerIp_withRegistrationFee() public {
+        uint96 registrationFee = 1 ether;
+        address treasury = address(0x12345);
+
+        vm.prank(u.admin);
+        ipAssetRegistry.setRegistrationFee(treasury, address(mockToken), registrationFee);
+
+        uint256 tokenId = mockNft.mint(address(u.alice));
+        address expectedIpId = ipAssetRegistry.ipId(block.chainid, address(mockNft), tokenId);
+
+        uint256 deadline = block.timestamp + 1000;
+
+        (bytes memory sigMetadata, , ) = _getSetPermissionSigForPeriphery({
+            ipId: expectedIpId,
+            to: address(registrationWorkflows),
+            module: address(coreMetadataModule),
+            selector: ICoreMetadataModule.setAll.selector,
+            deadline: deadline,
+            state: bytes32(0),
+            signerSk: sk.alice
+        });
+
+        vm.startPrank(u.alice);
+        mockToken.mint(u.alice, registrationFee);
+        mockToken.approve(address(registrationWorkflows), registrationFee);
+
+        uint256 aliceBalanceBefore = mockToken.balanceOf(u.alice);
+        uint256 treasuryBalanceBefore = mockToken.balanceOf(treasury);
+
+        address actualIpId = registrationWorkflows.registerIp({
+            nftContract: address(mockNft),
+            tokenId: tokenId,
+            ipMetadata: ipMetadataDefault,
+            sigMetadata: WorkflowStructs.SignatureData({ signer: u.alice, deadline: deadline, signature: sigMetadata })
+        });
+        vm.stopPrank();
+
+        assertEq(mockToken.balanceOf(treasury), treasuryBalanceBefore + registrationFee);
+        assertEq(mockToken.balanceOf(u.alice), aliceBalanceBefore - registrationFee);
+    }
 }

--- a/test/workflows/RoyaltyTokenDistributionWorkflows.t.sol
+++ b/test/workflows/RoyaltyTokenDistributionWorkflows.t.sol
@@ -333,6 +333,165 @@ contract RoyaltyTokenDistributionWorkflowsTest is BaseTest {
         assertEq(licensingConfig.disabled, false);
     }
 
+    function test_mintAndRegisterIpAndAttachPILTermsAndDistributeRoyaltyTokens_withRegistrationFee() public {
+        uint96 registrationFee = 1 ether;
+        address treasury = address(0x12345);
+
+        vm.startPrank(u.admin);
+        ipAssetRegistry.setRegistrationFee(treasury, address(mockToken), registrationFee);
+        vm.stopPrank();
+
+        vm.startPrank(u.alice);
+        mockToken.mint(u.alice, nftMintingFee + registrationFee);
+        mockToken.approve(address(spgNftPublic), nftMintingFee);
+        mockToken.approve(address(royaltyTokenDistributionWorkflows), registrationFee);
+
+        uint256 aliceBalanceBefore = mockToken.balanceOf(u.alice);
+        uint256 treasuryBalanceBefore = mockToken.balanceOf(treasury);
+
+        royaltyTokenDistributionWorkflows.mintAndRegisterIpAndAttachPILTermsAndDistributeRoyaltyTokens({
+            spgNftContract: address(spgNftPublic),
+            recipient: u.alice,
+            ipMetadata: ipMetadataDefault,
+            licenseTermsData: commRemixTermsData,
+            royaltyShares: royaltyShares,
+            allowDuplicates: true
+        });
+        vm.stopPrank();
+
+        assertEq(mockToken.balanceOf(treasury), treasuryBalanceBefore + registrationFee);
+        assertEq(mockToken.balanceOf(u.alice), aliceBalanceBefore - registrationFee - nftMintingFee);
+    }
+
+    function test_mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens_withRegistrationFee() public {
+        uint96 registrationFee = 1 ether;
+        address treasury = address(0x12345);
+
+        vm.startPrank(u.admin);
+        ipAssetRegistry.setRegistrationFee(treasury, address(mockToken), registrationFee);
+        vm.stopPrank();
+
+        vm.startPrank(u.alice);
+        mockToken.mint(u.alice, nftMintingFee + licenseMintingFee + registrationFee);
+        mockToken.approve(address(spgNftPublic), nftMintingFee);
+        mockToken.approve(address(royaltyTokenDistributionWorkflows), registrationFee + licenseMintingFee);
+
+        uint256 aliceBalanceBefore = mockToken.balanceOf(u.alice);
+        uint256 treasuryBalanceBefore = mockToken.balanceOf(treasury);
+
+        royaltyTokenDistributionWorkflows.mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens({
+            spgNftContract: address(spgNftPublic),
+            recipient: u.alice,
+            ipMetadata: ipMetadataDefault,
+            derivData: derivativeData,
+            royaltyShares: royaltyShares,
+            allowDuplicates: true
+        });
+        vm.stopPrank();
+
+        assertEq(mockToken.balanceOf(treasury), treasuryBalanceBefore + registrationFee);
+        assertEq(
+            mockToken.balanceOf(u.alice),
+            aliceBalanceBefore - registrationFee - nftMintingFee - licenseMintingFee
+        );
+    }
+
+    function test_registerIpAndAttachPILTermsAndDeployRoyaltyVault_withRegistrationFee() public {
+        uint96 registrationFee = 1 ether;
+        address treasury = address(0x12345);
+
+        vm.startPrank(u.admin);
+        ipAssetRegistry.setRegistrationFee(treasury, address(mockToken), registrationFee);
+        vm.stopPrank();
+
+        uint256 tokenId = mockNft.mint(u.alice);
+        address expectedIpId = ipAssetRegistry.ipId(block.chainid, address(mockNft), tokenId);
+
+        uint256 deadline = block.timestamp + 1000;
+
+        (bytes memory signatureMetadataAndAttachAndConfig, , ) = _getSetBatchPermissionSigForPeriphery({
+            ipId: expectedIpId,
+            permissionList: _getMetadataAndAttachTermsAndConfigPermissionList(
+                expectedIpId,
+                address(royaltyTokenDistributionWorkflows)
+            ),
+            deadline: deadline,
+            state: bytes32(0),
+            signerSk: sk.alice
+        });
+
+        vm.startPrank(u.alice);
+        mockToken.mint(u.alice, registrationFee);
+        mockToken.approve(address(royaltyTokenDistributionWorkflows), registrationFee);
+
+        uint256 aliceBalanceBefore = mockToken.balanceOf(u.alice);
+        uint256 treasuryBalanceBefore = mockToken.balanceOf(treasury);
+
+        royaltyTokenDistributionWorkflows.registerIpAndAttachPILTermsAndDeployRoyaltyVault({
+            nftContract: address(mockNft),
+            tokenId: tokenId,
+            ipMetadata: ipMetadataDefault,
+            licenseTermsData: commRemixTermsData,
+            sigMetadataAndAttachAndConfig: WorkflowStructs.SignatureData({
+                signer: u.alice,
+                deadline: deadline,
+                signature: signatureMetadataAndAttachAndConfig
+            })
+        });
+        vm.stopPrank();
+
+        assertEq(mockToken.balanceOf(treasury), treasuryBalanceBefore + registrationFee);
+        assertEq(mockToken.balanceOf(u.alice), aliceBalanceBefore - registrationFee);
+    }
+
+    function test_registerIpAndMakeDerivativeAndDeployRoyaltyVault_withRegistrationFee() public {
+        uint96 registrationFee = 1 ether;
+        address treasury = address(0x12345);
+
+        vm.startPrank(u.admin);
+        ipAssetRegistry.setRegistrationFee(treasury, address(mockToken), registrationFee);
+        vm.stopPrank();
+
+        uint256 tokenId = mockNft.mint(u.alice);
+        address expectedIpId = ipAssetRegistry.ipId(block.chainid, address(mockNft), tokenId);
+
+        uint256 deadline = block.timestamp + 1000;
+
+        (bytes memory signatureMetadataAndRegister, , ) = _getSetBatchPermissionSigForPeriphery({
+            ipId: expectedIpId,
+            permissionList: _getMetadataAndDerivativeRegistrationPermissionList(
+                expectedIpId,
+                address(royaltyTokenDistributionWorkflows),
+                false
+            ),
+            deadline: deadline,
+            state: bytes32(0),
+            signerSk: sk.alice
+        });
+
+        vm.startPrank(u.alice);
+        mockToken.mint(u.alice, licenseMintingFee + registrationFee);
+        mockToken.approve(address(royaltyTokenDistributionWorkflows), licenseMintingFee + registrationFee);
+
+        uint256 aliceBalanceBefore = mockToken.balanceOf(u.alice);
+        uint256 treasuryBalanceBefore = mockToken.balanceOf(treasury);
+        royaltyTokenDistributionWorkflows.registerIpAndMakeDerivativeAndDeployRoyaltyVault({
+            nftContract: address(mockNft),
+            tokenId: tokenId,
+            ipMetadata: ipMetadataDefault,
+            derivData: derivativeData,
+            sigMetadataAndRegister: WorkflowStructs.SignatureData({
+                signer: u.alice,
+                deadline: deadline,
+                signature: signatureMetadataAndRegister
+            })
+        });
+        vm.stopPrank();
+
+        assertEq(mockToken.balanceOf(treasury), treasuryBalanceBefore + registrationFee);
+        assertEq(mockToken.balanceOf(u.alice), aliceBalanceBefore - registrationFee - licenseMintingFee);
+    }
+
     function _setUpTest() private {
         nftMintingFee = 1 * 10 ** mockToken.decimals();
         licenseMintingFee = 1 * 10 ** mockToken.decimals();


### PR DESCRIPTION
## Description
This PR adds support for potential IP registration fees by integrating payment logic into interactions with the IPAssetRegistry. While the fee is currently zero, this prepares the system for future requirements and allows the protocol to enable registration fees when needed.

## Changes
- Added a reusable internal function `_collectRegistrationFeeAndApprove` in `BaseWorkflow` to handle fee collection and approval
- Updated `IOrgNFT` interface to include `registrationFeePayer` parameter in mint functions
- Added fee collection logic to `OrgNFT` and `BaseStoryNFT` contracts
- Integrated fee collection into all workflow contracts that register IPs
- Added SafeERC20 utility for secure token transfers

## Implementation Details
- The fee is collected from the specified payer (typically `msg.sender`) using `safeTransferFrom`
- The workflow contract then approves the IP Asset Registry to spend the collected fee
- Fee collection happens immediately before calling `IP_ASSET_REGISTRY.register()`
- Zero fee amounts are handled gracefully (no transfers occur)

## Testing
- Updated existing StoryNFT tests to accommodate the new `registrationFeePayer` parameter
- Verified fee collection works properly when `IpAssetRegistry.getFeeAmount()` returns non-zero values
- Confirmed existing functionality works when fee amount is zero
