### PR TITLE
fix(royalty token dist workflows): use correct recipient for license token

### DIFF
--- a/contracts/workflows/RoyaltyTokenDistributionWorkflows.sol
+++ b/contracts/workflows/RoyaltyTokenDistributionWorkflows.sol
@@ -134,7 +134,7 @@ contract RoyaltyTokenDistributionWorkflows is
             licenseTermsData: licenseTermsData
         });
 
-        _deployRoyaltyVault(ipId);
+        _deployRoyaltyVault(ipId, recipient);
         _distributeRoyaltyTokens({
             ipId: ipId,
             royaltyShares: royaltyShares,
@@ -169,7 +169,7 @@ contract RoyaltyTokenDistributionWorkflows is
             derivData: derivData
         });
 
-        _deployRoyaltyVault(ipId);
+        _deployRoyaltyVault(ipId, recipient);
         _distributeRoyaltyTokens({
             ipId: ipId,
             royaltyShares: royaltyShares,
@@ -230,7 +230,7 @@ contract RoyaltyTokenDistributionWorkflows is
             licenseTermsData: licenseTermsData
         });
 
-        ipRoyaltyVault = _deployRoyaltyVault(ipId);
+        ipRoyaltyVault = _deployRoyaltyVault(ipId, msg.sender);
     }
 
     /// @notice Register an IP, make a derivative, and deploy a royalty vault.
@@ -277,7 +277,7 @@ contract RoyaltyTokenDistributionWorkflows is
             derivData: derivData
         });
 
-        ipRoyaltyVault = _deployRoyaltyVault(ipId);
+        ipRoyaltyVault = _deployRoyaltyVault(ipId, msg.sender);
     }
 
     /// @notice Distribute royalty tokens to the authors of the IP.
@@ -300,8 +300,9 @@ contract RoyaltyTokenDistributionWorkflows is
 
     /// @dev Deploys a royalty vault for the IP.
     /// @param ipId The ID of the IP.
+    /// @param licenseTokenReceiver The address to receive the license token.
     /// @return ipRoyaltyVault The address of the deployed royalty vault.
-    function _deployRoyaltyVault(address ipId) internal returns (address ipRoyaltyVault) {
+    function _deployRoyaltyVault(address ipId, address licenseTokenReceiver) internal returns (address ipRoyaltyVault) {
         if (ROYALTY_MODULE.ipRoyaltyVaults(ipId) == address(0)) {
             uint256 licenseTermsId = PIL_TEMPLATE.registerLicenseTerms(
                 PILFlavors.commercialUse({ mintingFee: 0, currencyToken: WIP, royaltyPolicy: ROYALTY_POLICY_LRP })
@@ -331,7 +332,7 @@ contract RoyaltyTokenDistributionWorkflows is
                 licenseTemplate: address(PIL_TEMPLATE),
                 licenseTermsId: licenseTermsId,
                 amount: 1,
-                receiver: msg.sender,
+                receiver: licenseTokenReceiver,
                 royaltyContext: "",
                 maxMintingFee: 0,
                 maxRevenueShare: 0

--- a/test/workflows/RoyaltyTokenDistributionWorkflows.t.sol
+++ b/test/workflows/RoyaltyTokenDistributionWorkflows.t.sol
@@ -58,6 +58,8 @@ contract RoyaltyTokenDistributionWorkflowsTest is BaseTest {
         assertMetadata(ipId, ipMetadataDefault);
         _assertAttachedLicenseTerms(ipId, licenseTermsIds);
         _assertRoyaltyTokenDistribution(ipId);
+        // check that the license token used for royalty vault deployment was minted to the IP owner
+        assertEq(licenseToken.ownerOf(licenseToken.totalMintedTokens() - 1), u.alice);
     }
 
     function test_RoyaltyTokenDistributionWorkflows_mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens()
@@ -161,6 +163,8 @@ contract RoyaltyTokenDistributionWorkflowsTest is BaseTest {
         assertMetadata(ipId, ipMetadataDefault);
         _assertAttachedLicenseTerms(ipId, licenseTermsIds);
         _assertRoyaltyTokenDistribution(ipId);
+        // check that the license token used for royalty vault deployment was minted to the IP owner
+        assertEq(licenseToken.ownerOf(licenseToken.totalMintedTokens() - 1), u.alice);
     }
 
     function test_RoyaltyTokenDistributionWorkflows_registerIpAndMakeDerivativeAndDistributeRoyaltyTokens() public {


### PR DESCRIPTION
## Description

This PR addresses an issue in `RoyaltyTokenDistributionWorkflows` where the deployment of a royalty vault could revert. Previously, the internal license token required for vault deployment was minted directly to `msg.sender`. This caused failures when `msg.sender` was a contract that did not implement the `onERC721Received` hook (e.g., when called via Multicall3).

The fix modifies the `_deployRoyaltyVault` function to accept an additional `licenseTokenReceiver` parameter. The workflows now pass the appropriate recipient (the IP owner) to this function, ensuring the license token is sent to an address capable of receiving it, resolving the revert condition and improving integration possibilities. Tests have been updated to verify the license token is minted to the correct owner.

## Related Issue
- Closes #205