### PR TITLE
fix(test): add multicall tests and IP account state prediction

### DIFF
--- a/test/integration/workflows/GroupingIntegration.t.sol
+++ b/test/integration/workflows/GroupingIntegration.t.sol
@@ -15,6 +15,8 @@ import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
 // contracts
 import { ISPGNFT } from "../../../contracts/interfaces/ISPGNFT.sol";
 import { LicensingHelper } from "../../../contracts/lib/LicensingHelper.sol";
+import { IGroupingWorkflows } from "../../../contracts/interfaces/workflows/IGroupingWorkflows.sol";
+import { IRegistrationWorkflows } from "../../../contracts/interfaces/workflows/IRegistrationWorkflows.sol";
 import { WorkflowStructs } from "../../../contracts/lib/WorkflowStructs.sol";
 
 // test
@@ -43,6 +45,8 @@ contract GroupingIntegration is BaseIntegration {
         _test_GroupingIntegration_registerGroupAndAttachLicense();
         _test_GroupingIntegration_registerGroupAndAttachLicenseAndAddIps();
         _test_GroupingIntegration_collectRoyaltiesAndClaimReward();
+        _test_GroupingIntegration_multicall_mintAndRegisterIpAndAttachLicenseAndAddToGroup();
+        _test_GroupingIntegration_multicall_registerIpAndAttachLicenseAndAddToGroup();
         _endBroadcast();
     }
 
@@ -54,7 +58,7 @@ contract GroupingIntegration is BaseIntegration {
 
         // Get the signature for setting the permission for calling `addIp` function in `GroupingModule`
         // from the Group IP owner
-        (bytes memory sigAddToGroup, , ) = _getSetPermissionSigForPeriphery({
+        (bytes memory sigAddToGroup, bytes32 expectedState, ) = _getSetPermissionSigForPeriphery({
             ipId: groupId,
             to: groupingWorkflowsAddr,
             module: groupingModuleAddr,
@@ -81,6 +85,17 @@ contract GroupingIntegration is BaseIntegration {
             allowDuplicates: true
         });
 
+        address[] memory ipIdsForGroup = new address[](1);
+        ipIdsForGroup[0] = ipId;
+        assertEq(
+            IIPAccount(payable(groupId)).state(),
+            _predictNextState(
+                address(groupingWorkflows),
+                address(groupingModule),
+                expectedState,
+                abi.encodeWithSelector(IGroupingModule.addIp.selector, groupId, ipIdsForGroup, 100e6)
+            )
+        );
         assertTrue(ipAssetRegistry.isRegistered(ipId));
         assertTrue(IGroupIPAssetRegistry(ipAssetRegistryAddr).containsIp(groupId, ipId));
         assertEq(spgNftContract.tokenURI(tokenId), string.concat(testBaseURI, testIpMetadata.nftMetadataURI));
@@ -294,6 +309,184 @@ contract GroupingIntegration is BaseIntegration {
                 wrappedIP.balanceOf(royaltyModule.ipRoyaltyVaults(ipIds[i])),
                 collectedRoyalties[0] / ipIds.length
             );
+        }
+    }
+
+    function _test_GroupingIntegration_multicall_mintAndRegisterIpAndAttachLicenseAndAddToGroup()
+        private
+        logTest("test_GroupingIntegration_multicall_mintAndRegisterIpAndAttachLicenseAndAddToGroup")
+    {
+        uint256 deadline = block.timestamp + 1000;
+        uint256 numCalls = 10;
+        // Get the signatures for setting the permission for calling `addIp` function in `GroupingModule`
+        // from the Group IP owner
+        bytes[] memory sigsAddToGroup = new bytes[](numCalls);
+        bytes32 expectedStates = IIPAccount(payable(groupId)).state();
+        for (uint256 i = 0; i < numCalls; i++) {
+            (sigsAddToGroup[i], expectedStates, ) = _getSetPermissionSigForPeriphery({
+                ipId: groupId,
+                to: groupingWorkflowsAddr,
+                module: groupingModuleAddr,
+                selector: IGroupingModule.addIp.selector,
+                deadline: deadline,
+                state: expectedStates,
+                signerSk: testSenderSk
+            });
+            address[] memory predictedIpIdsForGroup = new address[](1);
+            predictedIpIdsForGroup[0] = ipAssetRegistry.ipId(
+                block.chainid,
+                address(spgNftContract),
+                spgNftContract.totalSupply() + i + 1
+            );
+            expectedStates = _predictNextState(
+                address(groupingWorkflows),
+                address(groupingModule),
+                expectedStates,
+                abi.encodeWithSelector(IGroupingModule.addIp.selector, groupId, predictedIpIdsForGroup, 100e6)
+            );
+        }
+
+        // setup call data for batch calling `numCalls` `mintAndRegisterIpAndAttachLicenseAndAddToGroup`
+        bytes[] memory data = new bytes[](numCalls);
+        for (uint256 i = 0; i < numCalls; i++) {
+            data[i] = abi.encodeWithSelector(
+                IGroupingWorkflows.mintAndRegisterIpAndAttachLicenseAndAddToGroup.selector,
+                address(spgNftContract),
+                groupId,
+                testSender,
+                100e6, // 100%
+                testLicensesData,
+                testIpMetadata,
+                WorkflowStructs.SignatureData({ signer: testSender, deadline: deadline, signature: sigsAddToGroup[i] })
+            );
+        }
+
+        wrappedIP.deposit{ value: testMintFee * numCalls }();
+        wrappedIP.approve(address(spgNftContract), testMintFee * numCalls);
+
+        // batch call `mintAndRegisterIpAndAttachLicenseAndAddToGroup`
+        bytes[] memory results = groupingWorkflows.multicall(data);
+
+        // check each IP is registered, added to the group, and metadata is set, license terms are attached
+        address ipId;
+        uint256 tokenId;
+        for (uint256 i = 0; i < numCalls; i++) {
+            (ipId, tokenId) = abi.decode(results[i], (address, uint256));
+            assertTrue(ipAssetRegistry.isRegistered(ipId));
+            assertTrue(IGroupIPAssetRegistry(ipAssetRegistryAddr).containsIp(groupId, ipId));
+            assertEq(spgNftContract.tokenURI(tokenId), string.concat(testBaseURI, testIpMetadata.nftMetadataURI));
+            assertMetadata(ipId, testIpMetadata);
+            for (uint256 j = 0; j < testLicensesData.length; j++) {
+                (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId, j);
+                assertEq(licenseTemplate, testLicensesData[j].licenseTemplate);
+                assertEq(licenseTermsId, testLicensesData[j].licenseTermsId);
+            }
+        }
+    }
+
+    function _test_GroupingIntegration_multicall_registerIpAndAttachLicenseAndAddToGroup()
+        private
+        logTest("test_GroupingIntegration_multicall_registerIpAndAttachLicenseAndAddToGroup")
+    {
+        uint256 numCalls = 10;
+
+        wrappedIP.deposit{ value: testMintFee * numCalls }();
+        wrappedIP.approve(address(spgNftContract), testMintFee * numCalls);
+        // mint a NFT from the spgNftContract
+        uint256[] memory tokenIds = new uint256[](numCalls);
+        for (uint256 i = 0; i < numCalls; i++) {
+            tokenIds[i] = spgNftContract.mint({
+                to: testSender,
+                nftMetadataURI: testIpMetadata.nftMetadataURI,
+                nftMetadataHash: testIpMetadata.nftMetadataHash,
+                allowDuplicates: true
+            });
+        }
+
+        // get the expected IP ID
+        address[] memory expectedIpIds = new address[](numCalls);
+        for (uint256 i = 0; i < numCalls; i++) {
+            expectedIpIds[i] = ipAssetRegistry.ipId(block.chainid, address(spgNftContract), tokenIds[i]);
+        }
+
+        uint256 deadline = block.timestamp + 1000;
+
+        // Get the signatures for setting the permission for calling `setAll` (IP metadata) and `attachLicenseTerms`
+        // functions in `coreMetadataModule` and `licensingModule` from the IP owner
+        bytes[] memory sigsMetadataAndAttach = new bytes[](numCalls);
+        for (uint256 i = 0; i < numCalls; i++) {
+            (sigsMetadataAndAttach[i], , ) = _getSetBatchPermissionSigForPeriphery({
+                ipId: expectedIpIds[i],
+                permissionList: _getMetadataAndAttachTermsAndConfigPermissionList(
+                    expectedIpIds[i],
+                    address(groupingWorkflows)
+                ),
+                deadline: deadline,
+                state: bytes32(0),
+                signerSk: testSenderSk
+            });
+        }
+
+        // Get the signatures for setting the permission for calling `addIp` function in `GroupingModule`
+        // from the Group IP owner
+        bytes[] memory sigsAddToGroup = new bytes[](numCalls);
+        bytes32 expectedStates = IIPAccount(payable(groupId)).state();
+        for (uint256 i = 0; i < numCalls; i++) {
+            (sigsAddToGroup[i], expectedStates, ) = _getSetPermissionSigForPeriphery({
+                ipId: groupId,
+                to: groupingWorkflowsAddr,
+                module: groupingModuleAddr,
+                selector: IGroupingModule.addIp.selector,
+                deadline: deadline,
+                state: expectedStates,
+                signerSk: testSenderSk
+            });
+            address[] memory predictedIpIdsForGroup = new address[](1);
+            predictedIpIdsForGroup[0] = expectedIpIds[i];
+            expectedStates = _predictNextState(
+                address(groupingWorkflows),
+                address(groupingModule),
+                expectedStates,
+                abi.encodeWithSelector(IGroupingModule.addIp.selector, groupId, predictedIpIdsForGroup, 100e6)
+            );
+        }
+
+        // setup call data for batch calling 10 `registerIpAndAttachLicenseAndAddToGroup`
+        bytes[] memory data = new bytes[](numCalls);
+        for (uint256 i = 0; i < numCalls; i++) {
+            data[i] = abi.encodeWithSelector(
+                IGroupingWorkflows.registerIpAndAttachLicenseAndAddToGroup.selector,
+                address(spgNftContract),
+                tokenIds[i],
+                groupId,
+                100e6, // 100%
+                testLicensesData,
+                testIpMetadata,
+                WorkflowStructs.SignatureData({
+                    signer: testSender,
+                    deadline: deadline,
+                    signature: sigsMetadataAndAttach[i]
+                }),
+                WorkflowStructs.SignatureData({ signer: testSender, deadline: deadline, signature: sigsAddToGroup[i] })
+            );
+        }
+
+        // batch call `registerIpAndAttachLicenseAndAddToGroup`
+        bytes[] memory results = groupingWorkflows.multicall(data);
+
+        // check each IP is registered, added to the group, and metadata is set, license terms are attached
+        address ipId;
+        for (uint256 i = 0; i < numCalls; i++) {
+            ipId = abi.decode(results[i], (address));
+            assertEq(ipId, expectedIpIds[i]);
+            assertTrue(ipAssetRegistry.isRegistered(ipId));
+            assertTrue(IGroupIPAssetRegistry(ipAssetRegistryAddr).containsIp(groupId, ipId));
+            assertMetadata(ipId, testIpMetadata);
+            for (uint256 j = 0; j < testLicensesData.length; j++) {
+                (address licenseTemplate, uint256 licenseTermsId) = licenseRegistry.getAttachedLicenseTerms(ipId, j);
+                assertEq(licenseTemplate, testLicensesData[j].licenseTemplate);
+                assertEq(licenseTermsId, testLicensesData[j].licenseTermsId);
+            }
         }
     }
 

--- a/test/integration/workflows/RegistrationIntegration.t.sol
+++ b/test/integration/workflows/RegistrationIntegration.t.sol
@@ -119,6 +119,21 @@ contract RegistrationIntegration is BaseIntegration {
         });
 
         assertEq(actualIpId, expectedIpId);
+        assertEq(
+            IIPAccount(payable(actualIpId)).state(),
+            _predictNextState(
+                address(registrationWorkflowsAddr),
+                address(coreMetadataModuleAddr),
+                expectedState,
+                abi.encodeWithSelector(
+                    ICoreMetadataModule.setAll.selector,
+                    actualIpId,
+                    testIpMetadata.ipMetadataURI,
+                    testIpMetadata.ipMetadataHash,
+                    testIpMetadata.nftMetadataHash
+                )
+            )
+        );
         assertTrue(ipAssetRegistry.isRegistered(actualIpId));
         assertEq(spgNftContract.tokenURI(tokenId), string.concat(testBaseURI, tokenId.toString()));
         assertMetadata(actualIpId, testIpMetadata);

--- a/test/workflows/DerivativeWorkflows.t.sol
+++ b/test/workflows/DerivativeWorkflows.t.sol
@@ -551,9 +551,7 @@ contract DerivativeWorkflowsTest is BaseTest {
         licenseTermsIds[1] = licenseTermsIdParent;
 
         vm.expectRevert(
-            abi.encodeWithSelector(
-                LicensingHelper.LicensingHelper__ParentIpIdsAndLicenseTermsIdsMismatch.selector
-            )
+            abi.encodeWithSelector(LicensingHelper.LicensingHelper__ParentIpIdsAndLicenseTermsIdsMismatch.selector)
         );
         derivativeWorkflows.mintAndRegisterIpAndMakeDerivative({
             spgNftContract: address(nftContract),

--- a/test/workflows/RegistrationWorkflows.t.sol
+++ b/test/workflows/RegistrationWorkflows.t.sol
@@ -193,6 +193,21 @@ contract RegistrationWorkflowsTest is BaseTest {
         });
         vm.stopPrank();
 
+        assertEq(
+            IIPAccount(payable(actualIpId)).state(),
+            _predictNextState(
+                address(registrationWorkflows),
+                address(coreMetadataModule),
+                expectedState,
+                abi.encodeWithSelector(
+                    ICoreMetadataModule.setAll.selector,
+                    actualIpId,
+                    ipMetadataDefault.ipMetadataURI,
+                    ipMetadataDefault.ipMetadataHash,
+                    ipMetadataDefault.nftMetadataHash
+                )
+            )
+        );
         assertEq(actualIpId, expectedIpId);
         assertTrue(ipAssetRegistry.isRegistered(actualIpId));
         assertMetadata(actualIpId, ipMetadataDefault);


### PR DESCRIPTION
### Description

This PR introduces several enhancements to the integration tests, focusing on multicall functionality and IP Account state verification.

### Changes
-   **Multicall Tests:** Added new integration tests in `GroupingIntegration.t.sol` to cover the multicall scenarios for:
    -   `mintAndRegisterIpAndAttachLicenseAndAddToGroup`
    -   `registerIpAndAttachLicenseAndAddToGroup`
-   **IP Account State Prediction:**
    -   Implemented helper functions `_predictNextState` and `_predictStateSequence` in `TestHelper.t.sol`. These functions allow predicting the final state of an IP Account after one or more permissioned function calls, based on the logic in `IIPAccount.updateStateForValidSigner`.
    -   Integrated state prediction assertions into existing grouping and registration integration tests (`GroupingIntegration.t.sol`, `RegistrationIntegration.t.sol`). This verifies that the IP Account reaches the expected state after the tested workflow operations.

### Related Issue
- Closes #201 