### PR TITLE
fix(hooks): set `TotalLicenseTokenLimitHook` to per-IP limit

### DIFF
--- a/contracts/hooks/TotalLicenseTokenLimitHook.sol
+++ b/contracts/hooks/TotalLicenseTokenLimitHook.sol
@@ -24,10 +24,7 @@ contract TotalLicenseTokenLimitHook is BaseModule, AccessControlled, ILicensingH
     /// @notice Emitted when the total license token limit is set
     /// @param licensorIpId The licensor IP id
     /// @param limit The total license token limit for the specific license of the licensor IP
-    event SetTotalLicenseTokenLimit(
-        address indexed licensorIpId,
-        uint256 limit
-    );
+    event SetTotalLicenseTokenLimit(address indexed licensorIpId, uint256 limit);
 
     /// @notice Emitted when the total license token limit is exceeded
     /// @param totalSupply The total supply of the license tokens
@@ -61,10 +58,7 @@ contract TotalLicenseTokenLimitHook is BaseModule, AccessControlled, ILicensingH
     /// @notice Set the total license token limit for a specific licensor IP
     /// @param licensorIpId The licensor IP id
     /// @param limit The total license token limit, 0 means no limit
-    function setTotalLicenseTokenLimit(
-        address licensorIpId,
-        uint256 limit
-    ) external verifyPermission(licensorIpId) {
+    function setTotalLicenseTokenLimit(address licensorIpId, uint256 limit) external verifyPermission(licensorIpId) {
         uint256 totalSupply = _getTotalSupply(licensorIpId);
         if (limit != 0 && limit < totalSupply)
             revert TotalLicenseTokenLimitHook_LimitLowerThanTotalSupply(totalSupply, limit);
@@ -93,7 +87,7 @@ contract TotalLicenseTokenLimitHook is BaseModule, AccessControlled, ILicensingH
         address receiver,
         bytes calldata hookData
     ) external returns (uint256 totalMintingFee) {
-        _checkTotalTokenLimit(licensorIpId,  amount);
+        _checkTotalTokenLimit(licensorIpId, amount);
         return _calculateFee(licenseTemplate, licenseTermsId, amount);
     }
 
@@ -115,7 +109,7 @@ contract TotalLicenseTokenLimitHook is BaseModule, AccessControlled, ILicensingH
         uint256 licenseTermsId,
         bytes calldata hookData
     ) external returns (uint256 mintingFee) {
-        _checkTotalTokenLimit(parentIpId,  1);
+        _checkTotalTokenLimit(parentIpId, 1);
         return _calculateFee(licenseTemplate, licenseTermsId, 1);
     }
 
@@ -151,16 +145,11 @@ contract TotalLicenseTokenLimitHook is BaseModule, AccessControlled, ILicensingH
     /// @notice Get the total license token limit for a specific licensor IP
     /// @param licensorIpId The licensor IP id
     /// @return limit The total license token limit
-    function getTotalLicenseTokenLimit(
-        address licensorIpId
-    ) external view returns (uint256 limit) {
+    function getTotalLicenseTokenLimit(address licensorIpId) external view returns (uint256 limit) {
         limit = ipIdToTotalLicenseTokenLimit[licensorIpId];
     }
 
-    function _checkTotalTokenLimit(
-        address licensorIpId,
-        uint256 amount
-    ) internal view {
+    function _checkTotalTokenLimit(address licensorIpId, uint256 amount) internal view {
         uint256 limit = ipIdToTotalLicenseTokenLimit[licensorIpId];
         if (limit != 0) {
             // derivative IPs are also considered as minted license tokens
@@ -184,7 +173,6 @@ contract TotalLicenseTokenLimitHook is BaseModule, AccessControlled, ILicensingH
         return
             LICENSE_REGISTRY.getDerivativeIpCount(licensorIpId) + LICENSE_TOKEN.getTotalTokensByLicensor(licensorIpId);
     }
-
 
     ////////////////////////////////////////////////////////////////////////////
     //       DEPRECATED FUNCTIONS, WILL BE REMOVED IN THE NEXT RELEASE        //
@@ -222,5 +210,4 @@ contract TotalLicenseTokenLimitHook is BaseModule, AccessControlled, ILicensingH
     ) external view returns (uint256 limit) {
         limit = ipIdToTotalLicenseTokenLimit[licensorIpId];
     }
-
 }

--- a/contracts/hooks/TotalLicenseTokenLimitHook.sol
+++ b/contracts/hooks/TotalLicenseTokenLimitHook.sol
@@ -18,18 +18,14 @@ contract TotalLicenseTokenLimitHook is BaseModule, AccessControlled, ILicensingH
     /// @notice The address of the License Token.
     ILicenseToken public immutable LICENSE_TOKEN;
 
-    // keccak256(licensorIpId, licenseTemplate, licenseTermsId) => totalLicenseTokenLimit
-    mapping(bytes32 => uint256) public totalLicenseTokenLimit;
+    // ipId => totalLicenseTokenLimit
+    mapping(address => uint256) public ipIdToTotalLicenseTokenLimit;
 
     /// @notice Emitted when the total license token limit is set
     /// @param licensorIpId The licensor IP id
-    /// @param licenseTemplate The license template address
-    /// @param licenseTermsId The license terms id
     /// @param limit The total license token limit for the specific license of the licensor IP
     event SetTotalLicenseTokenLimit(
         address indexed licensorIpId,
-        address indexed licenseTemplate,
-        uint256 indexed licenseTermsId,
         uint256 limit
     );
 
@@ -62,23 +58,18 @@ contract TotalLicenseTokenLimitHook is BaseModule, AccessControlled, ILicensingH
         LICENSE_TOKEN = ILicenseToken(licenseToken);
     }
 
-    /// @notice Set the total license token limit for a specific license
+    /// @notice Set the total license token limit for a specific licensor IP
     /// @param licensorIpId The licensor IP id
-    /// @param licenseTemplate The license template address
-    /// @param licenseTermsId The license terms id
     /// @param limit The total license token limit, 0 means no limit
     function setTotalLicenseTokenLimit(
         address licensorIpId,
-        address licenseTemplate,
-        uint256 licenseTermsId,
         uint256 limit
     ) external verifyPermission(licensorIpId) {
-        bytes32 key = keccak256(abi.encodePacked(licensorIpId, licenseTemplate, licenseTermsId));
         uint256 totalSupply = _getTotalSupply(licensorIpId);
         if (limit != 0 && limit < totalSupply)
             revert TotalLicenseTokenLimitHook_LimitLowerThanTotalSupply(totalSupply, limit);
-        totalLicenseTokenLimit[key] = limit;
-        emit SetTotalLicenseTokenLimit(licensorIpId, licenseTemplate, licenseTermsId, limit);
+        ipIdToTotalLicenseTokenLimit[licensorIpId] = limit;
+        emit SetTotalLicenseTokenLimit(licensorIpId, limit);
     }
 
     /// @notice This function is called when the LicensingModule mints license tokens.
@@ -102,7 +93,7 @@ contract TotalLicenseTokenLimitHook is BaseModule, AccessControlled, ILicensingH
         address receiver,
         bytes calldata hookData
     ) external returns (uint256 totalMintingFee) {
-        _checkTotalTokenLimit(licensorIpId, licenseTemplate, licenseTermsId, amount);
+        _checkTotalTokenLimit(licensorIpId,  amount);
         return _calculateFee(licenseTemplate, licenseTermsId, amount);
     }
 
@@ -124,7 +115,7 @@ contract TotalLicenseTokenLimitHook is BaseModule, AccessControlled, ILicensingH
         uint256 licenseTermsId,
         bytes calldata hookData
     ) external returns (uint256 mintingFee) {
-        _checkTotalTokenLimit(parentIpId, licenseTemplate, licenseTermsId, 1);
+        _checkTotalTokenLimit(parentIpId,  1);
         return _calculateFee(licenseTemplate, licenseTermsId, 1);
     }
 
@@ -157,28 +148,20 @@ contract TotalLicenseTokenLimitHook is BaseModule, AccessControlled, ILicensingH
         return interfaceId == type(ILicensingHook).interfaceId || super.supportsInterface(interfaceId);
     }
 
-    /// @notice Get the total license token limit for a specific license
+    /// @notice Get the total license token limit for a specific licensor IP
     /// @param licensorIpId The licensor IP id
-    /// @param licenseTemplate The license template address
-    /// @param licenseTermsId The license terms id
     /// @return limit The total license token limit
     function getTotalLicenseTokenLimit(
-        address licensorIpId,
-        address licenseTemplate,
-        uint256 licenseTermsId
+        address licensorIpId
     ) external view returns (uint256 limit) {
-        bytes32 key = keccak256(abi.encodePacked(licensorIpId, licenseTemplate, licenseTermsId));
-        limit = totalLicenseTokenLimit[key];
+        limit = ipIdToTotalLicenseTokenLimit[licensorIpId];
     }
 
     function _checkTotalTokenLimit(
         address licensorIpId,
-        address licenseTemplate,
-        uint256 licenseTermsId,
         uint256 amount
     ) internal view {
-        bytes32 key = keccak256(abi.encodePacked(licensorIpId, licenseTemplate, licenseTermsId));
-        uint256 limit = totalLicenseTokenLimit[key];
+        uint256 limit = ipIdToTotalLicenseTokenLimit[licensorIpId];
         if (limit != 0) {
             // derivative IPs are also considered as minted license tokens
             uint256 totalSupply = _getTotalSupply(licensorIpId);
@@ -201,4 +184,43 @@ contract TotalLicenseTokenLimitHook is BaseModule, AccessControlled, ILicensingH
         return
             LICENSE_REGISTRY.getDerivativeIpCount(licensorIpId) + LICENSE_TOKEN.getTotalTokensByLicensor(licensorIpId);
     }
+
+
+    ////////////////////////////////////////////////////////////////////////////
+    //       DEPRECATED FUNCTIONS, WILL BE REMOVED IN THE NEXT RELEASE        //
+    ////////////////////////////////////////////////////////////////////////////
+
+    /// @notice Set the total license token limit for a specific licensor IP
+    /// @dev Deprecated function, will be removed in the next release
+    /// @param licensorIpId The licensor IP id
+    /// @param licenseTemplate Deprecated, no longer used
+    /// @param licenseTermsId Deprecated, no longer used
+    /// @param limit The total license token limit, 0 means no limit
+    function setTotalLicenseTokenLimit(
+        address licensorIpId,
+        address licenseTemplate,
+        uint256 licenseTermsId,
+        uint256 limit
+    ) external verifyPermission(licensorIpId) {
+        uint256 totalSupply = _getTotalSupply(licensorIpId);
+        if (limit != 0 && limit < totalSupply)
+            revert TotalLicenseTokenLimitHook_LimitLowerThanTotalSupply(totalSupply, limit);
+        ipIdToTotalLicenseTokenLimit[licensorIpId] = limit;
+        emit SetTotalLicenseTokenLimit(licensorIpId, limit);
+    }
+
+    /// @notice Get the total license token limit for a specific licensor IP
+    /// @dev Deprecated function, will be removed in the next release
+    /// @param licensorIpId The licensor IP id
+    /// @param licenseTemplate Deprecated, no longer used
+    /// @param licenseTermsId Deprecated, no longer used
+    /// @return limit The total license token limit
+    function getTotalLicenseTokenLimit(
+        address licensorIpId,
+        address licenseTemplate,
+        uint256 licenseTermsId
+    ) external view returns (uint256 limit) {
+        limit = ipIdToTotalLicenseTokenLimit[licensorIpId];
+    }
+
 }

--- a/test/hooks/TotalLicenseTokenLimitHook.t.sol
+++ b/test/hooks/TotalLicenseTokenLimitHook.t.sol
@@ -57,19 +57,19 @@ contract TotalLicenseTokenLimitHookTest is BaseTest {
 
         vm.startPrank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), commUseTermsId, licensingConfig);
-        totalLicenseTokenLimitHook.setTotalLicenseTokenLimit(ipId1, address(pilTemplate), commUseTermsId, 10);
-        assertEq(totalLicenseTokenLimitHook.getTotalLicenseTokenLimit(ipId1, address(pilTemplate), commUseTermsId), 10);
+        totalLicenseTokenLimitHook.setTotalLicenseTokenLimit(ipId1, 10);
+        assertEq(totalLicenseTokenLimitHook.getTotalLicenseTokenLimit(ipId1), 10);
         vm.stopPrank();
 
         vm.startPrank(ipOwner2);
         licensingModule.setLicensingConfig(ipId2, address(pilTemplate), commUseTermsId, licensingConfig);
-        totalLicenseTokenLimitHook.setTotalLicenseTokenLimit(ipId2, address(pilTemplate), commUseTermsId, 20);
-        assertEq(totalLicenseTokenLimitHook.getTotalLicenseTokenLimit(ipId2, address(pilTemplate), commUseTermsId), 20);
+        totalLicenseTokenLimitHook.setTotalLicenseTokenLimit(ipId2, 20);
+        assertEq(totalLicenseTokenLimitHook.getTotalLicenseTokenLimit(ipId2), 20);
         vm.stopPrank();
 
         vm.startPrank(ipOwner3);
         licensingModule.setLicensingConfig(ipId3, address(pilTemplate), commUseTermsId, licensingConfig);
-        assertEq(totalLicenseTokenLimitHook.getTotalLicenseTokenLimit(ipId3, address(pilTemplate), commUseTermsId), 0);
+        assertEq(totalLicenseTokenLimitHook.getTotalLicenseTokenLimit(ipId3), 0);
         vm.stopPrank();
 
         licensingModule.mintLicenseTokens({
@@ -156,8 +156,8 @@ contract TotalLicenseTokenLimitHookTest is BaseTest {
 
         vm.startPrank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), commUseTermsId, licensingConfig);
-        totalLicenseTokenLimitHook.setTotalLicenseTokenLimit(ipId1, address(pilTemplate), commUseTermsId, 10);
-        assertEq(totalLicenseTokenLimitHook.getTotalLicenseTokenLimit(ipId1, address(pilTemplate), commUseTermsId), 10);
+        totalLicenseTokenLimitHook.setTotalLicenseTokenLimit(ipId1, 10);
+        assertEq(totalLicenseTokenLimitHook.getTotalLicenseTokenLimit(ipId1), 10);
         vm.stopPrank();
 
         vm.startPrank(ipOwner2);
@@ -167,10 +167,10 @@ contract TotalLicenseTokenLimitHookTest is BaseTest {
                 ipId1,
                 ipOwner2,
                 address(totalLicenseTokenLimitHook),
-                totalLicenseTokenLimitHook.setTotalLicenseTokenLimit.selector
+                bytes4(keccak256(bytes("setTotalLicenseTokenLimit(address,uint256)")))
             )
         );
-        totalLicenseTokenLimitHook.setTotalLicenseTokenLimit(ipId1, address(pilTemplate), commUseTermsId, 20);
+        totalLicenseTokenLimitHook.setTotalLicenseTokenLimit(ipId1, 20);
     }
 
     function test_TotalLicenseTokenLimitHook_revert_limitLowerThanTotalSupply_setLimit() public {
@@ -187,8 +187,8 @@ contract TotalLicenseTokenLimitHookTest is BaseTest {
 
         vm.startPrank(ipOwner1);
         licensingModule.setLicensingConfig(ipId1, address(pilTemplate), commUseTermsId, licensingConfig);
-        totalLicenseTokenLimitHook.setTotalLicenseTokenLimit(ipId1, address(pilTemplate), commUseTermsId, 10);
-        assertEq(totalLicenseTokenLimitHook.getTotalLicenseTokenLimit(ipId1, address(pilTemplate), commUseTermsId), 10);
+        totalLicenseTokenLimitHook.setTotalLicenseTokenLimit(ipId1, 10);
+        assertEq(totalLicenseTokenLimitHook.getTotalLicenseTokenLimit(ipId1), 10);
 
         licensingModule.mintLicenseTokens({
             licensorIpId: ipId1,
@@ -208,6 +208,6 @@ contract TotalLicenseTokenLimitHookTest is BaseTest {
                 5
             )
         );
-        totalLicenseTokenLimitHook.setTotalLicenseTokenLimit(ipId1, address(pilTemplate), commUseTermsId, 5);
+        totalLicenseTokenLimitHook.setTotalLicenseTokenLimit(ipId1, 5);
     }
 }


### PR DESCRIPTION
## Description

This change corrects the `TotalLicenseTokenLimitHook` to enforce per-IP total license token limits.

### Key Changes

*    Replaced `totalLicenseTokenLimit` (keyed by `licensorIpId`, `licenseTemplate`, `licenseTermsId`) with `ipIdToTotalLicenseTokenLimit` (keyed by `licensorIpId`), reflecting core protocol query limitations.
*  `SetTotalLicenseTokenLimit` event no longer includes `licenseTemplate` and `licenseTermsId` parameters.
*   Modified Function Signatures:
    *   `setTotalLicenseTokenLimit(address licensorIpId, uint256 limit)`
    *   `getTotalLicenseTokenLimit(address licensorIpId)`
    *   Internal functions (`_checkTotalTokenLimit`) and hook callbacks (`postMintHook`, `postRegisterDerivativeHook`) updated accordingly.
*   Backward Compatibility:
    *   Retained deprecated versions of `setTotalLicenseTokenLimit` and `getTotalLicenseTokenLimit` (with `licenseTemplate`, `licenseTermsId`) for smoother transition. These now use the new per-IP logic, ignoring the extra parameters for limit operations. They will be removed in a future release.
*  `TotalLicenseTokenLimitHook.t.sol` tests updated for the new per-IP limit logic.

## Motivation

The core protocol lacks efficient querying for total license tokens on a per-IP, per-license-terms basis. The previous hook design, attempting this granularity, operated incorrectly as it couldn't accurately track supply. This change simplifies to a per-IP limit, reliably enforced via existing protocol functions (`LICENSE_REGISTRY.getDerivativeIpCount(licensorIpId)` and `LICENSE_TOKEN.getTotalTokensByLicensor(licensorIpId)`).

## Testing

The `TotalLicenseTokenLimitHook.t.sol` test suite updated to cover corrected per-IP functionality

## Related Issue
- Closes #203