### PR TITLE
fix(rt-dist,grouping): use decoupled royalty vault deployment

### DIFF
--- a/contracts/workflows/GroupingWorkflows.sol
+++ b/contracts/workflows/GroupingWorkflows.sol
@@ -283,23 +283,6 @@ contract GroupingWorkflows is
             0
         );
 
-        for (uint256 i = 0; i < memberIpIds.length; i++) {
-            // check if given member IPs already have a royalty vault
-            if (ROYALTY_MODULE.ipRoyaltyVaults(memberIpIds[i]) == address(0)) {
-                // mint license tokens to the member IPs if they don't have a royalty vault
-                LICENSING_MODULE.mintLicenseTokens({
-                    licensorIpId: memberIpIds[i],
-                    licenseTemplate: groupLicenseTemplate,
-                    licenseTermsId: groupLicenseTermsId,
-                    amount: 1,
-                    receiver: msg.sender,
-                    royaltyContext: "",
-                    maxMintingFee: 0,
-                    maxRevenueShare: 0
-                });
-            }
-        }
-
         collectedRoyalties = new uint256[](currencyTokens.length);
         for (uint256 i = 0; i < currencyTokens.length; i++) {
             if (currencyTokens[i] == address(0)) revert Errors.GroupingWorkflows__ZeroAddressParam();

--- a/test/workflows/RoyaltyTokenDistributionWorkflows.t.sol
+++ b/test/workflows/RoyaltyTokenDistributionWorkflows.t.sol
@@ -9,7 +9,6 @@ import { IIPAccount } from "@storyprotocol/core/interfaces/IIPAccount.sol";
 import { Licensing } from "@storyprotocol/core/lib/Licensing.sol";
 import { MetaTx } from "@storyprotocol/core/lib/MetaTx.sol";
 import { PILFlavors } from "@storyprotocol/core/lib/PILFlavors.sol";
-import { PILTerms } from "@storyprotocol/core/interfaces/modules/licensing/IPILicenseTemplate.sol";
 
 // contracts
 import { Errors } from "../../contracts/lib/Errors.sol";
@@ -58,8 +57,6 @@ contract RoyaltyTokenDistributionWorkflowsTest is BaseTest {
         assertMetadata(ipId, ipMetadataDefault);
         _assertAttachedLicenseTerms(ipId, licenseTermsIds);
         _assertRoyaltyTokenDistribution(ipId);
-        // check that the license token used for royalty vault deployment was minted to the IP owner
-        assertEq(licenseToken.ownerOf(licenseToken.totalMintedTokens() - 1), u.alice);
     }
 
     function test_RoyaltyTokenDistributionWorkflows_mintAndRegisterIpAndMakeDerivativeAndDistributeRoyaltyTokens()
@@ -163,8 +160,6 @@ contract RoyaltyTokenDistributionWorkflowsTest is BaseTest {
         assertMetadata(ipId, ipMetadataDefault);
         _assertAttachedLicenseTerms(ipId, licenseTermsIds);
         _assertRoyaltyTokenDistribution(ipId);
-        // check that the license token used for royalty vault deployment was minted to the IP owner
-        assertEq(licenseToken.ownerOf(licenseToken.totalMintedTokens() - 1), u.alice);
     }
 
     function test_RoyaltyTokenDistributionWorkflows_registerIpAndMakeDerivativeAndDistributeRoyaltyTokens() public {


### PR DESCRIPTION
## Description

This PR refactors the `GroupingWorkflows` and `RoyaltyTokenDistributionWorkflows` to align with the new decoupled royalty vault deployment process introduced in [storyprotocol/protocol-core-v1#435](https://github.com/storyprotocol/protocol-core-v1/pull/435).

By leveraging the `deployVault` function now available in the core protocol, periphery contracts no longer need to trigger royalty vault deployment through license token minting. This change significantly improves the user experience (UX) by simplifying workflows and avoids the need to attach additional licenses solely for the purpose of royalty vault deployment.

### Key Changes

*   **Refactored `RoyaltyTokenDistributionWorkflows`:**
    *   The workflow has been updated to utilize the core `deployVault` function for deploying royalty vaults.
*   **Refactored `GroupingWorkflows`:**
    *   Internal vault deployment logic has been removed from the grouping workflows. This is because royalty vaults for member IPs are now automatically deployed within the core protocol's `GroupingModule` during reward claims (for details, see [storyprotocol/protocol-core-v1#445](https://github.com/storyprotocol/protocol-core-v1/pull/445)). 
*   **Adjustments to `RoyaltyTokenDistributionWorkflows.t.sol` (Tests):**
    *   The tests have been updated by removing a check that previously asserted the ownership of the license token used for royalty vault deployment. This change reflects the new decoupled deployment mechanism where vault creation is no longer directly tied to a license mint initiated by the IP owner for that specific purpose.