### PR TITLE
feat(spgnft): emit `ContractURIUpdated` event during initialization

### DIFF
--- a/contracts/SPGNFT.sol
+++ b/contracts/SPGNFT.sol
@@ -117,7 +117,7 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
         $._mintOpen = initParams.mintOpen;
         $._publicMinting = initParams.isPublicMinting;
         $._baseURI = initParams.baseURI;
-        $._contractURI = initParams.contractURI;
+        _setContractURI(initParams.contractURI);
 
         __ERC721_init(initParams.name, initParams.symbol);
         __AccessControl_init();
@@ -342,6 +342,18 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
         _safeMint(to, tokenId);
 
         if (bytes(nftMetadataURI).length > 0) _setTokenURI(tokenId, nftMetadataURI);
+    }
+
+    /// @dev Sets the contract URI for the collection.
+    /// @param contractURI The new URI string to set for the contract's metadata. Follows ERC-7572 standard.
+    ///        See https://eips.ethereum.org/EIPS/eip-7572
+    function _setContractURI(string memory contractURI) internal {
+        SPGNFTStorage storage $ = _getSPGNFTStorage();
+
+        if (keccak256(abi.encodePacked($._contractURI)) != keccak256(abi.encodePacked(contractURI))) {
+            $._contractURI = contractURI;
+            emit ContractURIUpdated();
+        }
     }
 
     /// @dev Base URI for computing tokenURI.

--- a/contracts/SPGNFT.sol
+++ b/contracts/SPGNFT.sol
@@ -236,9 +236,7 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
     /// @param contractURI The new contract URI for the collection. Follows ERC-7572 standard.
     ///        See https://eips.ethereum.org/EIPS/eip-7572
     function setContractURI(string memory contractURI) external onlyRole(SPGNFTLib.ADMIN_ROLE) {
-        _getSPGNFTStorage()._contractURI = contractURI;
-
-        emit ContractURIUpdated();
+        _setContractURI(contractURI);
     }
 
     /// @notice Mints an NFT from the collection. Only callable when public minting is enabled or when the caller has minter role.

--- a/test/SPGNFT.t.sol
+++ b/test/SPGNFT.t.sol
@@ -7,6 +7,7 @@ import { UpgradeableBeacon } from "@openzeppelin/contracts/proxy/beacon/Upgradea
 import { IAccessControl } from "@openzeppelin/contracts/access/IAccessControl.sol";
 import { IERC20Errors } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 
+import { IERC7572 } from "../contracts/interfaces/story-nft/IERC7572.sol";
 import { ISPGNFT } from "../contracts/interfaces/ISPGNFT.sol";
 import { SPGNFT } from "../contracts/SPGNFT.sol";
 import { SPGNFTLib } from "../contracts/lib/SPGNFTLib.sol";
@@ -54,6 +55,8 @@ contract SPGNFTTest is BaseTest {
         address NFT_CONTRACT_BEACON = address(new UpgradeableBeacon(testSpgNftImpl, deployer));
         SPGNFT anotherNftContract = SPGNFT(address(new BeaconProxy(NFT_CONTRACT_BEACON, "")));
 
+        vm.expectEmit(address(anotherNftContract));
+        emit IERC7572.ContractURIUpdated();
         anotherNftContract.initialize(
             ISPGNFT.InitParams({
                 name: "Test Collection",
@@ -273,9 +276,13 @@ contract SPGNFTTest is BaseTest {
         assertEq(nftContract.contractURI(), testContractURI);
 
         vm.startPrank(u.alice); // owner (admin) of the collection
+        vm.expectEmit(address(nftContract));
+        emit IERC7572.ContractURIUpdated();
         nftContract.setContractURI("test");
         assertEq(nftContract.contractURI(), "test");
 
+        vm.expectEmit(address(nftContract));
+        emit IERC7572.ContractURIUpdated();
         nftContract.setContractURI(testContractURI);
         assertEq(nftContract.contractURI(), testContractURI);
         vm.stopPrank();


### PR DESCRIPTION
## Description

This PR enhances the `SPGNFT` contract to emit the `ContractURIUpdated` event during its `initialize` function.

A new internal helper function `_setContractURI` has been introduced. This function is now responsible for setting the contract URI and handles the emission of the `ContractURIUpdated` event. The event is only emitted if the provided contract URI is different from the one currently stored.

## Changes

- **`contracts/SPGNFT.sol`**:
    - The `initialize` function now calls the new `_setContractURI` internal function to set the `contractURI` and handle event emission.
    - Added the `_setContractURI(string memory contractURI)` internal function. This function checks if the new `contractURI` differs from the existing one (by comparing their `keccak256` hashes) before updating the storage variable and emitting the `ContractURIUpdated` event.
- **`test/SPGNFT.t.sol`**:
    - In `test_SPGNFT_initialize`, added `vm.expectEmit` to assert that `ContractURIUpdated` is emitted when `anotherNftContract.initialize` is called.
    - In `test_SPGNFT_setContractURI`, added `vm.expectEmit` before each call to `nftContract.setContractURI` to ensure the event is emitted upon URI changes.
