### PR TITLE
fix(hooks): enforce per-IP, per-license limits in `TotalLicenseTokenLimitHook`

### DIFF
--- a/contracts/hooks/TotalLicenseTokenLimitHook.sol
+++ b/contracts/hooks/TotalLicenseTokenLimitHook.sol
@@ -1,30 +1,35 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
-import { IERC165 } from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import { BaseModule } from "@storyprotocol/core/modules/BaseModule.sol";
 import { AccessControlled } from "@storyprotocol/core/access/AccessControlled.sol";
 import { ILicensingHook } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingHook.sol";
-import { ILicenseRegistry } from "@storyprotocol/core/interfaces/registries/ILicenseRegistry.sol";
-import { ILicenseToken } from "@storyprotocol/core/interfaces/ILicenseToken.sol";
 import { ILicenseTemplate } from "@storyprotocol/core/interfaces/modules/licensing/ILicenseTemplate.sol";
 
 contract TotalLicenseTokenLimitHook is BaseModule, AccessControlled, ILicensingHook {
     string public constant override name = "TOTAL_LICENSE_TOKEN_LIMIT_HOOK";
 
-    /// @notice The address of the License Registry.
-    ILicenseRegistry public immutable LICENSE_REGISTRY;
+    /// @notice Stores the total license token limit for a given license.
+    /// @dev The key is keccak256(licensorIpId, licenseTemplate, licenseTermsId).
+    mapping(bytes32 => uint256) private totalLicenseTokenLimit;
 
-    /// @notice The address of the License Token.
-    ILicenseToken public immutable LICENSE_TOKEN;
-
-    // ipId => totalLicenseTokenLimit
-    mapping(address => uint256) public ipIdToTotalLicenseTokenLimit;
+    /// @notice Stores the total number of license tokens minted for a given license.
+    /// @dev The key is keccak256(licensorIpId, licenseTemplate, licenseTermsId).
+    /// @dev Derivative IPs are also considered as minted license tokens.
+    mapping(bytes32 => uint256) private totalLicenseTokenMinted;
 
     /// @notice Emitted when the total license token limit is set
     /// @param licensorIpId The licensor IP id
+    /// @param licenseTemplate The license template address
+    /// @param licenseTermsId The license terms id
     /// @param limit The total license token limit for the specific license of the licensor IP
-    event SetTotalLicenseTokenLimit(address indexed licensorIpId, uint256 limit);
+    event SetTotalLicenseTokenLimit(
+        address indexed licensorIpId,
+        address indexed licenseTemplate,
+        uint256 indexed licenseTermsId,
+        uint256 limit
+    );
 
     /// @notice Emitted when the total license token limit is exceeded
     /// @param totalSupply The total supply of the license tokens
@@ -37,33 +42,28 @@ contract TotalLicenseTokenLimitHook is BaseModule, AccessControlled, ILicensingH
     /// @param limit The total license token limit
     error TotalLicenseTokenLimitHook_LimitLowerThanTotalSupply(uint256 totalSupply, uint256 limit);
 
-    /// @notice Emitted when the license registry is the zero address
-    error TotalLicenseTokenLimitHook_ZeroLicenseRegistry();
-
-    /// @notice Emitted when the license token is the zero address
-    error TotalLicenseTokenLimitHook_ZeroLicenseToken();
-
     constructor(
-        address licenseRegistry,
-        address licenseToken,
         address accessController,
         address ipAssetRegistry
-    ) AccessControlled(accessController, ipAssetRegistry) {
-        if (licenseRegistry == address(0)) revert TotalLicenseTokenLimitHook_ZeroLicenseRegistry();
-        if (licenseToken == address(0)) revert TotalLicenseTokenLimitHook_ZeroLicenseToken();
-        LICENSE_REGISTRY = ILicenseRegistry(licenseRegistry);
-        LICENSE_TOKEN = ILicenseToken(licenseToken);
-    }
+    ) AccessControlled(accessController, ipAssetRegistry) {}
 
-    /// @notice Set the total license token limit for a specific licensor IP
+    /// @notice Set the total license token limit for a specific license
     /// @param licensorIpId The licensor IP id
+    /// @param licenseTemplate The license template address
+    /// @param licenseTermsId The license terms id
     /// @param limit The total license token limit, 0 means no limit
-    function setTotalLicenseTokenLimit(address licensorIpId, uint256 limit) external verifyPermission(licensorIpId) {
-        uint256 totalSupply = _getTotalSupply(licensorIpId);
+    function setTotalLicenseTokenLimit(
+        address licensorIpId,
+        address licenseTemplate,
+        uint256 licenseTermsId,
+        uint256 limit
+    ) external verifyPermission(licensorIpId) {
+        bytes32 key = keccak256(abi.encodePacked(licensorIpId, licenseTemplate, licenseTermsId));
+        uint256 totalSupply = _getTotalSupply(licensorIpId, licenseTemplate, licenseTermsId);
         if (limit != 0 && limit < totalSupply)
             revert TotalLicenseTokenLimitHook_LimitLowerThanTotalSupply(totalSupply, limit);
-        ipIdToTotalLicenseTokenLimit[licensorIpId] = limit;
-        emit SetTotalLicenseTokenLimit(licensorIpId, limit);
+        totalLicenseTokenLimit[key] = limit;
+        emit SetTotalLicenseTokenLimit(licensorIpId, licenseTemplate, licenseTermsId, limit);
     }
 
     /// @notice This function is called when the LicensingModule mints license tokens.
@@ -87,7 +87,8 @@ contract TotalLicenseTokenLimitHook is BaseModule, AccessControlled, ILicensingH
         address receiver,
         bytes calldata hookData
     ) external returns (uint256 totalMintingFee) {
-        _checkTotalTokenLimit(licensorIpId, amount);
+        _checkTotalTokenLimit(licensorIpId, licenseTemplate, licenseTermsId, amount);
+        totalLicenseTokenMinted[keccak256(abi.encodePacked(licensorIpId, licenseTemplate, licenseTermsId))] += amount;
         return _calculateFee(licenseTemplate, licenseTermsId, amount);
     }
 
@@ -109,7 +110,9 @@ contract TotalLicenseTokenLimitHook is BaseModule, AccessControlled, ILicensingH
         uint256 licenseTermsId,
         bytes calldata hookData
     ) external returns (uint256 mintingFee) {
-        _checkTotalTokenLimit(parentIpId, 1);
+        _checkTotalTokenLimit(parentIpId, licenseTemplate, licenseTermsId, 1);
+        // derivative IPs are also considered as minted license tokens
+        totalLicenseTokenMinted[keccak256(abi.encodePacked(parentIpId, licenseTemplate, licenseTermsId))] += 1;
         return _calculateFee(licenseTemplate, licenseTermsId, 1);
     }
 
@@ -142,24 +145,61 @@ contract TotalLicenseTokenLimitHook is BaseModule, AccessControlled, ILicensingH
         return interfaceId == type(ILicensingHook).interfaceId || super.supportsInterface(interfaceId);
     }
 
-    /// @notice Get the total license token limit for a specific licensor IP
+    /// @notice Get the total license token limit for a specific license
     /// @param licensorIpId The licensor IP id
+    /// @param licenseTemplate The license template address
+    /// @param licenseTermsId The license terms id
     /// @return limit The total license token limit
-    function getTotalLicenseTokenLimit(address licensorIpId) external view returns (uint256 limit) {
-        limit = ipIdToTotalLicenseTokenLimit[licensorIpId];
+    function getTotalLicenseTokenLimit(
+        address licensorIpId,
+        address licenseTemplate,
+        uint256 licenseTermsId
+    ) external view returns (uint256 limit) {
+        bytes32 key = keccak256(abi.encodePacked(licensorIpId, licenseTemplate, licenseTermsId));
+        limit = totalLicenseTokenLimit[key];
     }
 
-    function _checkTotalTokenLimit(address licensorIpId, uint256 amount) internal view {
-        uint256 limit = ipIdToTotalLicenseTokenLimit[licensorIpId];
+    /// @notice Get the total license token supply (number of minted license tokens
+    ///         + number of derivative IPs) for a specific license
+    /// @param licensorIpId The licensor IP id
+    /// @param licenseTemplate The license template address
+    /// @param licenseTermsId The license terms id
+    /// @return supply The total license token supply
+    function getTotalLicenseTokenSupply(
+        address licensorIpId,
+        address licenseTemplate,
+        uint256 licenseTermsId
+    ) external view returns (uint256) {
+        return _getTotalSupply(licensorIpId, licenseTemplate, licenseTermsId);
+    }
+
+    /// @dev checks if the total license token limit is exceeded
+    /// @param licensorIpId The licensor IP id
+    /// @param licenseTemplate The license template address
+    /// @param licenseTermsId The license terms id
+    /// @param amount The amount of license tokens to mint
+    function _checkTotalTokenLimit(
+        address licensorIpId,
+        address licenseTemplate,
+        uint256 licenseTermsId,
+        uint256 amount
+    ) internal view {
+        bytes32 key = keccak256(abi.encodePacked(licensorIpId, licenseTemplate, licenseTermsId));
+        uint256 limit = totalLicenseTokenLimit[key];
         if (limit != 0) {
             // derivative IPs are also considered as minted license tokens
-            uint256 totalSupply = _getTotalSupply(licensorIpId);
+            uint256 totalSupply = _getTotalSupply(licensorIpId, licenseTemplate, licenseTermsId);
             if (totalSupply + amount > limit) {
                 revert TotalLicenseTokenLimitHook_TotalLicenseTokenLimitExceeded(totalSupply, amount, limit);
             }
         }
     }
 
+    /// @dev calculates the minting fee for a given license
+    /// @param licenseTemplate The license template address
+    /// @param licenseTermsId The license terms id
+    /// @param amount The amount of license tokens to mint
+    /// @return totalMintingFee The total minting fee to be paid when minting amount of license tokens
     function _calculateFee(
         address licenseTemplate,
         uint256 licenseTermsId,
@@ -169,45 +209,16 @@ contract TotalLicenseTokenLimitHook is BaseModule, AccessControlled, ILicensingH
         return amount * mintingFee;
     }
 
-    function _getTotalSupply(address licensorIpId) internal view returns (uint256) {
-        return
-            LICENSE_REGISTRY.getDerivativeIpCount(licensorIpId) + LICENSE_TOKEN.getTotalTokensByLicensor(licensorIpId);
-    }
-
-    ////////////////////////////////////////////////////////////////////////////
-    //       DEPRECATED FUNCTIONS, WILL BE REMOVED IN THE NEXT RELEASE        //
-    ////////////////////////////////////////////////////////////////////////////
-
-    /// @notice Set the total license token limit for a specific licensor IP
-    /// @dev Deprecated function, will be removed in the next release
+    /// @dev gets the total number of license tokens minted for a given license
     /// @param licensorIpId The licensor IP id
-    /// @param licenseTemplate Deprecated, no longer used
-    /// @param licenseTermsId Deprecated, no longer used
-    /// @param limit The total license token limit, 0 means no limit
-    function setTotalLicenseTokenLimit(
-        address licensorIpId,
-        address licenseTemplate,
-        uint256 licenseTermsId,
-        uint256 limit
-    ) external verifyPermission(licensorIpId) {
-        uint256 totalSupply = _getTotalSupply(licensorIpId);
-        if (limit != 0 && limit < totalSupply)
-            revert TotalLicenseTokenLimitHook_LimitLowerThanTotalSupply(totalSupply, limit);
-        ipIdToTotalLicenseTokenLimit[licensorIpId] = limit;
-        emit SetTotalLicenseTokenLimit(licensorIpId, limit);
-    }
-
-    /// @notice Get the total license token limit for a specific licensor IP
-    /// @dev Deprecated function, will be removed in the next release
-    /// @param licensorIpId The licensor IP id
-    /// @param licenseTemplate Deprecated, no longer used
-    /// @param licenseTermsId Deprecated, no longer used
-    /// @return limit The total license token limit
-    function getTotalLicenseTokenLimit(
+    /// @param licenseTemplate The license template address
+    /// @param licenseTermsId The license terms id
+    /// @return totalSupply The total number of license tokens minted for the given license
+    function _getTotalSupply(
         address licensorIpId,
         address licenseTemplate,
         uint256 licenseTermsId
-    ) external view returns (uint256 limit) {
-        limit = ipIdToTotalLicenseTokenLimit[licensorIpId];
+    ) internal view returns (uint256) {
+        return totalLicenseTokenMinted[keccak256(abi.encodePacked(licensorIpId, licenseTemplate, licenseTermsId))];
     }
 }

--- a/contracts/hooks/TotalLicenseTokenLimitHook.sol
+++ b/contracts/hooks/TotalLicenseTokenLimitHook.sol
@@ -7,6 +7,15 @@ import { AccessControlled } from "@storyprotocol/core/access/AccessControlled.so
 import { ILicensingHook } from "@storyprotocol/core/interfaces/modules/licensing/ILicensingHook.sol";
 import { ILicenseTemplate } from "@storyprotocol/core/interfaces/modules/licensing/ILicenseTemplate.sol";
 
+/// @title Total License Token Limit Hook
+/// @notice Enforces a maximum limit on the total number of license tokens that can be minted
+///         for a specific license attached to an IP. To use this hook, set the `licensingHook` field
+///         in the licensing config to the address of this hook.
+/// @dev This hook tracks and limits license token minting only for when this license hook is
+///      configured and active on a license. This hook does not account for tokens minted prior to
+///      its activation on a specific license. For instance, if a limit of 20 is set, and 10 tokens
+///      were minted before this hook was active for that license, the hook will still allow an
+///      additional 20 tokens to be minted.
 contract TotalLicenseTokenLimitHook is BaseModule, AccessControlled, ILicensingHook {
     string public constant override name = "TOTAL_LICENSE_TOKEN_LIMIT_HOOK";
 

--- a/script/utils/DeployHelper.sol
+++ b/script/utils/DeployHelper.sol
@@ -547,8 +547,6 @@ contract DeployHelper is
                 abi.encodePacked(
                     type(TotalLicenseTokenLimitHook).creationCode,
                     abi.encode(
-                        licenseRegistryAddr,
-                        licenseTokenAddr,
                         accessControllerAddr,
                         ipAssetRegistryAddr
                     )


### PR DESCRIPTION
## Description

This PR modifies the `TotalLicenseTokenLimitHook` to enforce license token limits on a more granular basis: per IP Asset, per license terms.

### Key Changes

*   **Hook Logic**:
    *   The `setTotalLicenseTokenLimit` and `getTotalLicenseTokenLimit` functions in `TotalLicenseTokenLimitHook.sol` now accept `licenseTemplate` (address) and `licenseTermsId` (uint256) as parameters. This allows setting distinct limits for different license configurations associated with the same IP.
*   **Testing:**
    *   Existing tests in `test/hooks/TotalLicenseTokenLimitHook.t.sol` have been updated to align with the new function signatures of the hook.
    *   A new test, `test_TotalLicenseTokenLimitHook_PerIpPerLicenseLimit`, has been added to specifically verify the behavior of limits across different IPs and different license terms for the same IP.
*   **Deployment:**
    *   The deployment scripts for the `TotalLicenseTokenLimitHook` have been updated to accommodate the changes in its interface and functionality.

### Reasoning

Previously with PR #216 , the `TotalLicenseTokenLimitHook` only supported setting a single token limit per IP Asset. This update provides more flexibility and control for IP owners, allowing them to define different license token caps for various licenses attached to the same IP.

### Related Issues
- Closes #219 
