### PR TITLE
Update integration tests for release 1.3.3

### DIFF
--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RPC_URL: ${{ needs.set-devnet-constants.outputs.RPCURL }}
-      TEST_SENDER_ADDRESS: ${{ secrets.TEST_SENDER_ADDRESS }}
+      TEST_SENDER_ADDRESS: 0x7D01c62110fb498e6450A7857DD172dDd41EAbD3
       TEST_SENDER_SECRETKEY: ${{ secrets.TEST_SENDER_SECRETKEY }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -124,7 +124,8 @@ jobs:
               "RoyaltyWorkflows": "0x9515faE61E0c0447C6AC6dEe5628A2097aFE1890",
               "SPGNFTBeacon": "0xD2926B9ecaE85fF59B6FB0ff02f568a680c01218",
               "SPGNFTImpl": "0x6Cfa03Bc64B1a76206d0Ea10baDed31D520449F5",
-              "TokenizerModule": "0xAC937CeEf893986A026f701580144D9289adAC4C"
+              "TokenizerModule": "0xAC937CeEf893986A026f701580144D9289adAC4C",
+              "TotalLicenseTokenLimitHook": "0xB72C9812114a0Fc74D49e01385bd266A75960Cda"
             }
           }'
 

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -138,17 +138,17 @@ jobs:
         run: |
           forge build
 
-      - name: Run DerivativeIntegration Tests
-        run: |
-          forge script test/integration/workflows/DerivativeIntegration.t.sol:DerivativeIntegration --rpc-url=${{ env.RPC_URL }} -vvvv --broadcast --priority-gas-price=1 --legacy --skip-simulation
+      # - name: Run DerivativeIntegration Tests
+      #   run: |
+      #     forge script test/integration/workflows/DerivativeIntegration.t.sol:DerivativeIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation
 
       # - name: Run GroupingIntegration Tests
       #   run: |
       #     forge script test/integration/workflows/GroupingIntegration.t.sol:GroupingIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> test-results.log
 
-      # - name: Run LicenseAttachmentIntegration Tests
-      #   run: |
-      #     forge script test/integration/workflows/LicenseAttachmentIntegration.t.sol:LicenseAttachmentIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> test-results.log
+      - name: Run LicenseAttachmentIntegration Tests
+        run: |
+          forge script test/integration/workflows/LicenseAttachmentIntegration.t.sol:LicenseAttachmentIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation
 
       # - name: Run RegistrationIntegration Tests
       #   run: |

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -138,23 +138,19 @@ jobs:
         run: |
           forge build
 
-      # - name: Run DerivativeIntegration Tests
-      #   run: |
-      #     forge script test/integration/workflows/DerivativeIntegration.t.sol:DerivativeIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation
+      - name: Run DerivativeIntegration Tests
+        run: |
+          forge script test/integration/workflows/DerivativeIntegration.t.sol:DerivativeIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation
 
-      # - name: Run GroupingIntegration Tests
-      #   run: |
-      #     forge script test/integration/workflows/GroupingIntegration.t.sol:GroupingIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> test-results.log
-
-      # - name: Run LicenseAttachmentIntegration Tests
-      #   run: |
-      #     forge script test/integration/workflows/LicenseAttachmentIntegration.t.sol:LicenseAttachmentIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> test-results.log
+      - name: Run GroupingIntegration Tests
+        run: |
+          forge script test/integration/workflows/GroupingIntegration.t.sol:GroupingIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> test-results.log
 
       - name: Run LicenseAttachmentIntegration Tests
         id: license_attachment_test
         continue-on-error: true
         run: |
-          forge script test/integration/workflows/LicenseAttachmentIntegration.t.sol:LicenseAttachmentIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> license_attachment_test.log
+          forge script test/integration/workflows/LicenseAttachmentIntegration.t.sol:LicenseAttachmentIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation > license_attachment_test.log
   
       - name: Check LicenseAttachmentIntegration Results and Append Log
         run: |
@@ -169,17 +165,17 @@ jobs:
             fi
           fi
 
-      # - name: Run RegistrationIntegration Tests
-      #   run: |
-      #     forge script test/integration/workflows/RegistrationIntegration.t.sol:RegistrationIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> test-results.log
+      - name: Run RegistrationIntegration Tests
+        run: |
+          forge script test/integration/workflows/RegistrationIntegration.t.sol:RegistrationIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> test-results.log
 
-      # - name: Run RoyaltyIntegration Tests
-      #   run: |
-      #     forge script test/integration/workflows/RoyaltyIntegration.t.sol:RoyaltyIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> test-results.log
+      - name: Run RoyaltyIntegration Tests
+        run: |
+          forge script test/integration/workflows/RoyaltyIntegration.t.sol:RoyaltyIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> test-results.log
 
-      # - name: Run RoyaltyTokenDistributionIntegration Tests
-      #   run: |
-      #     forge script test/integration/workflows/RoyaltyTokenDistributionIntegration.t.sol:RoyaltyTokenDistributionIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> test-results.log
+      - name: Run RoyaltyTokenDistributionIntegration Tests
+        run: |
+          forge script test/integration/workflows/RoyaltyTokenDistributionIntegration.t.sol:RoyaltyTokenDistributionIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> test-results.log
 
       - name: Merge Test Results
         run: |

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -146,13 +146,32 @@ jobs:
       #   run: |
       #     forge script test/integration/workflows/GroupingIntegration.t.sol:GroupingIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> test-results.log
 
-      - name: Run LicenseAttachmentIntegration Tests
-        run: |
-          forge script test/integration/workflows/LicenseAttachmentIntegration.t.sol:LicenseAttachmentIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> test-results.log
+      # - name: Run LicenseAttachmentIntegration Tests
+      #   run: |
+      #     forge script test/integration/workflows/LicenseAttachmentIntegration.t.sol:LicenseAttachmentIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> test-results.log
 
-      - name: Run RegistrationIntegration Tests
+      - name: Run LicenseAttachmentIntegration Tests
+        id: license_attachment_test
+        continue-on-error: true
         run: |
-          forge script test/integration/workflows/RegistrationIntegration.t.sol:RegistrationIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> test-results.log
+          forge script test/integration/workflows/LicenseAttachmentIntegration.t.sol:LicenseAttachmentIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation > license_attachment_test.log
+  
+      - name: Check LicenseAttachmentIntegration Results and Append Log
+        run: |
+          cat license_attachment_test.log >> test-results.log
+          if [[ "${{ steps.license_attachment_test.outcome }}" == "failure" ]]; then
+            if grep -q "SUCCESS: Correctly reverted when exceeding the token limit." license_attachment_test.log; then
+              echo "✅ Transaction failed as expected. Continuing workflow."
+              exit 0
+            else
+              echo "❌ Transaction failed with an unexpected error."
+              exit 1
+            fi
+          fi
+
+      # - name: Run RegistrationIntegration Tests
+      #   run: |
+      #     forge script test/integration/workflows/RegistrationIntegration.t.sol:RegistrationIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> test-results.log
 
       # - name: Run RoyaltyIntegration Tests
       #   run: |

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -97,7 +97,7 @@ jobs:
               "LicenseRegistry": "0x529a750E02d8E2f15649c13D69a465286a780e24",
               "LicenseToken": "0xFe3838BFb30B34170F00030B52eA4893d8aAC6bC",
               "LicensingModule": "0x04fbd8a2e56dd85CFD5500A4A4DfA955B9f1dE6f",
-              "MockERC20": "0x688abA77b2daA886c0aF029961Dc5fd219cEc3f6",
+              "MockERC20": "0x1514000000000000000000000000000000000000",
               "ModuleRegistry": "0x022DBAAeA5D8fB31a0Ad793335e39Ced5D631fa5",
               "PILicenseTemplate": "0x2E896b0b2Fdb7457499B56AAaA4AE55BCB4Cd316",
               "ProtocolAccessManager": "0xFdece7b8a2f55ceC33b53fd28936B4B1e3153d53",

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -148,11 +148,11 @@ jobs:
 
       - name: Run LicenseAttachmentIntegration Tests
         run: |
-          forge script test/integration/workflows/LicenseAttachmentIntegration.t.sol:LicenseAttachmentIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation
+          forge script test/integration/workflows/LicenseAttachmentIntegration.t.sol:LicenseAttachmentIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> test-results.log
 
-      # - name: Run RegistrationIntegration Tests
-      #   run: |
-      #     forge script test/integration/workflows/RegistrationIntegration.t.sol:RegistrationIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> test-results.log
+      - name: Run RegistrationIntegration Tests
+        run: |
+          forge script test/integration/workflows/RegistrationIntegration.t.sol:RegistrationIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> test-results.log
 
       # - name: Run RoyaltyIntegration Tests
       #   run: |

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -139,20 +139,24 @@ jobs:
           forge build
 
       - name: Run DerivativeIntegration Tests
+        if: always() && !cancelled()
         run: |
           forge script test/integration/workflows/DerivativeIntegration.t.sol:DerivativeIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation
 
       - name: Run GroupingIntegration Tests
+        if: always() && !cancelled()
         run: |
           forge script test/integration/workflows/GroupingIntegration.t.sol:GroupingIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> test-results.log
 
       - name: Run LicenseAttachmentIntegration Tests
+        if: always() && !cancelled()
         id: license_attachment_test
         continue-on-error: true
         run: |
           forge script test/integration/workflows/LicenseAttachmentIntegration.t.sol:LicenseAttachmentIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation > license_attachment_test.log
   
       - name: Check LicenseAttachmentIntegration Results and Append Log
+        if: always() && !cancelled()
         run: |
           cat license_attachment_test.log >> test-results.log
           if [[ "${{ steps.license_attachment_test.outcome }}" == "failure" ]]; then
@@ -166,14 +170,17 @@ jobs:
           fi
 
       - name: Run RegistrationIntegration Tests
+        if: always() && !cancelled()
         run: |
           forge script test/integration/workflows/RegistrationIntegration.t.sol:RegistrationIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> test-results.log
 
       - name: Run RoyaltyIntegration Tests
+        if: always() && !cancelled()
         run: |
           forge script test/integration/workflows/RoyaltyIntegration.t.sol:RoyaltyIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> test-results.log
 
       - name: Run RoyaltyTokenDistributionIntegration Tests
+        if: always() && !cancelled()
         run: |
           forge script test/integration/workflows/RoyaltyTokenDistributionIntegration.t.sol:RoyaltyTokenDistributionIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> test-results.log
 

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -154,7 +154,7 @@ jobs:
         id: license_attachment_test
         continue-on-error: true
         run: |
-          forge script test/integration/workflows/LicenseAttachmentIntegration.t.sol:LicenseAttachmentIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation > license_attachment_test.log
+          forge script test/integration/workflows/LicenseAttachmentIntegration.t.sol:LicenseAttachmentIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> license_attachment_test.log
   
       - name: Check LicenseAttachmentIntegration Results and Append Log
         run: |
@@ -192,3 +192,4 @@ jobs:
           name: test-results
           path: |
             ./test-results.log
+            ./license_attachment_test.log

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RPC_URL: ${{ needs.set-devnet-constants.outputs.RPCURL }}
-      TEST_SENDER_ADDRESS: 0x7D01c62110fb498e6450A7857DD172dDd41EAbD3
+      TEST_SENDER_ADDRESS: "0x7D01c62110fb498e6450A7857DD172dDd41EAbD3"
       TEST_SENDER_SECRETKEY: ${{ secrets.TEST_SENDER_SECRETKEY }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -140,27 +140,27 @@ jobs:
 
       - name: Run DerivativeIntegration Tests
         run: |
-          forge script test/integration/workflows/DerivativeIntegration.t.sol:DerivativeIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation > test-results.log
+          forge script test/integration/workflows/DerivativeIntegration.t.sol:DerivativeIntegration --rpc-url=${{ env.RPC_URL }} -vvvv --broadcast --priority-gas-price=1 --legacy --skip-simulation
 
-      - name: Run GroupingIntegration Tests
-        run: |
-          forge script test/integration/workflows/GroupingIntegration.t.sol:GroupingIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> test-results.log
+      # - name: Run GroupingIntegration Tests
+      #   run: |
+      #     forge script test/integration/workflows/GroupingIntegration.t.sol:GroupingIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> test-results.log
 
-      - name: Run LicenseAttachmentIntegration Tests
-        run: |
-          forge script test/integration/workflows/LicenseAttachmentIntegration.t.sol:LicenseAttachmentIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> test-results.log
+      # - name: Run LicenseAttachmentIntegration Tests
+      #   run: |
+      #     forge script test/integration/workflows/LicenseAttachmentIntegration.t.sol:LicenseAttachmentIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> test-results.log
 
-      - name: Run RegistrationIntegration Tests
-        run: |
-          forge script test/integration/workflows/RegistrationIntegration.t.sol:RegistrationIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> test-results.log
+      # - name: Run RegistrationIntegration Tests
+      #   run: |
+      #     forge script test/integration/workflows/RegistrationIntegration.t.sol:RegistrationIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> test-results.log
 
-      - name: Run RoyaltyIntegration Tests
-        run: |
-          forge script test/integration/workflows/RoyaltyIntegration.t.sol:RoyaltyIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> test-results.log
+      # - name: Run RoyaltyIntegration Tests
+      #   run: |
+      #     forge script test/integration/workflows/RoyaltyIntegration.t.sol:RoyaltyIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> test-results.log
 
-      - name: Run RoyaltyTokenDistributionIntegration Tests
-        run: |
-          forge script test/integration/workflows/RoyaltyTokenDistributionIntegration.t.sol:RoyaltyTokenDistributionIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> test-results.log
+      # - name: Run RoyaltyTokenDistributionIntegration Tests
+      #   run: |
+      #     forge script test/integration/workflows/RoyaltyTokenDistributionIntegration.t.sol:RoyaltyTokenDistributionIntegration --rpc-url=${{ env.RPC_URL }} -vvv --broadcast --priority-gas-price=1 --legacy --skip-simulation >> test-results.log
 
       - name: Merge Test Results
         run: |

--- a/script/utils/StoryProtocolPeripheryAddressManager.sol
+++ b/script/utils/StoryProtocolPeripheryAddressManager.sol
@@ -18,7 +18,7 @@ contract StoryProtocolPeripheryAddressManager is Script {
     address internal ownableERC20BeaconAddr;
     address internal ownableERC20TemplateAddr;
     address internal tokenizerModuleAddr;
-
+    address internal totalLicenseTokenLimitHookAddr;
     function _readStoryProtocolPeripheryAddresses() internal {
         string memory root = vm.projectRoot();
         string memory path = string.concat(
@@ -37,5 +37,6 @@ contract StoryProtocolPeripheryAddressManager is Script {
         ownableERC20BeaconAddr = json.readAddress(".main.OwnableERC20Beacon");
         ownableERC20TemplateAddr = json.readAddress(".main.OwnableERC20Template");
         tokenizerModuleAddr = json.readAddress(".main.TokenizerModule");
+        totalLicenseTokenLimitHookAddr = json.readAddress(".main.TotalLicenseTokenLimitHook");
     }
 }

--- a/test/hooks/TotalLicenseTokenLimitHook.t.sol
+++ b/test/hooks/TotalLicenseTokenLimitHook.t.sol
@@ -420,7 +420,7 @@ contract TotalLicenseTokenLimitHookTest is BaseTest {
             expectMinimumGroupRewardShare: 0,
             expectGroupRewardPool: address(0) // not allowed to be added to any group
         });
-        
+
         uint256 limitIp1Terms = 10;
 
         vm.startPrank(ipOwner1);

--- a/test/hooks/TotalLicenseTokenLimitHook.t.sol
+++ b/test/hooks/TotalLicenseTokenLimitHook.t.sol
@@ -420,7 +420,7 @@ contract TotalLicenseTokenLimitHookTest is BaseTest {
             expectMinimumGroupRewardShare: 0,
             expectGroupRewardPool: address(0) // not allowed to be added to any group
         });
-
+        
         uint256 limitIp1Terms = 10;
 
         vm.startPrank(ipOwner1);

--- a/test/integration/BaseIntegration.t.sol
+++ b/test/integration/BaseIntegration.t.sol
@@ -27,6 +27,7 @@ import { RegistrationWorkflows } from "../../contracts/workflows/RegistrationWor
 import { RoyaltyWorkflows } from "../../contracts/workflows/RoyaltyWorkflows.sol";
 import { RoyaltyTokenDistributionWorkflows } from "../../contracts/workflows/RoyaltyTokenDistributionWorkflows.sol";
 import { WorkflowStructs } from "../../contracts/lib/WorkflowStructs.sol";
+import { TotalLicenseTokenLimitHook } from "../../contracts/hooks/TotalLicenseTokenLimitHook.sol";
 
 // script
 import { TestHelper } from "../utils/TestHelper.t.sol";
@@ -61,6 +62,7 @@ contract BaseIntegration is
     RegistrationWorkflows internal registrationWorkflows;
     RoyaltyWorkflows internal royaltyWorkflows;
     RoyaltyTokenDistributionWorkflows internal royaltyTokenDistributionWorkflows;
+    TotalLicenseTokenLimitHook internal totalLicenseTokenLimitHook;
 
     /// @dev Wrapped IP token
     WIP internal wrappedIP = WIP(payable(0x1514000000000000000000000000000000000000));
@@ -119,6 +121,7 @@ contract BaseIntegration is
         registrationWorkflows = RegistrationWorkflows(registrationWorkflowsAddr);
         royaltyWorkflows = RoyaltyWorkflows(royaltyWorkflowsAddr);
         royaltyTokenDistributionWorkflows = RoyaltyTokenDistributionWorkflows(royaltyTokenDistributionWorkflowsAddr);
+        totalLicenseTokenLimitHook = TotalLicenseTokenLimitHook(totalLicenseTokenLimitHookAddr);
 
         // set up test data
         testCollectionName = "Test Collection";

--- a/test/integration/workflows/DerivativeIntegration.t.sol
+++ b/test/integration/workflows/DerivativeIntegration.t.sol
@@ -298,7 +298,7 @@ contract DerivativeIntegration is BaseIntegration {
         private
         logTest("test_DerivativeIntegration_multicall_mintAndRegisterIpAndMakeDerivative")
     {
-        uint256 numCalls = 10;
+        uint256 numCalls = 2;
         bytes[] memory data = new bytes[](numCalls);
         for (uint256 i = 0; i < numCalls; i++) {
             data[i] = abi.encodeWithSelector(

--- a/test/integration/workflows/GroupingIntegration.t.sol
+++ b/test/integration/workflows/GroupingIntegration.t.sol
@@ -30,7 +30,7 @@ contract GroupingIntegration is BaseIntegration {
     WorkflowStructs.LicenseData[] private testLicensesData;
     WorkflowStructs.LicenseData[] internal testGroupLicenseData;
     uint32 private revShare;
-    uint256 private numIps = 10;
+    uint256 private numIps = 2;
     address[] private ipIds;
 
     /// @dev To use, run the following command:
@@ -317,7 +317,7 @@ contract GroupingIntegration is BaseIntegration {
         logTest("test_GroupingIntegration_multicall_mintAndRegisterIpAndAttachLicenseAndAddToGroup")
     {
         uint256 deadline = block.timestamp + 1000;
-        uint256 numCalls = 10;
+        uint256 numCalls = 2;
         // Get the signatures for setting the permission for calling `addIp` function in `GroupingModule`
         // from the Group IP owner
         bytes[] memory sigsAddToGroup = new bytes[](numCalls);
@@ -388,7 +388,7 @@ contract GroupingIntegration is BaseIntegration {
         private
         logTest("test_GroupingIntegration_multicall_registerIpAndAttachLicenseAndAddToGroup")
     {
-        uint256 numCalls = 10;
+        uint256 numCalls = 2;
 
         wrappedIP.deposit{ value: testMintFee * numCalls }();
         wrappedIP.approve(address(spgNftContract), testMintFee * numCalls);

--- a/test/integration/workflows/LicenseAttachmentIntegration.t.sol
+++ b/test/integration/workflows/LicenseAttachmentIntegration.t.sol
@@ -288,10 +288,7 @@ contract LicenseAttachmentIntegration is BaseIntegration {
         );
     }
 
-    function _test_revert_TotalLicenseTokenLimitHook()
-        private
-        logTest("_test_revert_TotalLicenseTokenLimitHook")
-    {
+    function _test_revert_TotalLicenseTokenLimitHook() private logTest("_test_revert_TotalLicenseTokenLimitHook") {
         // 1. register IP
         wrappedIP.deposit{ value: testMintFee }();
         wrappedIP.approve(address(spgNftContract), testMintFee);
@@ -301,7 +298,7 @@ contract LicenseAttachmentIntegration is BaseIntegration {
             ipMetadata: testIpMetadata,
             allowDuplicates: true
         });
-        
+
         // 2. register terms and attach to IP
         uint256 deadline = block.timestamp + 1000;
         (bytes memory signature, , ) = _getSetBatchPermissionSigForPeriphery({
@@ -324,14 +321,14 @@ contract LicenseAttachmentIntegration is BaseIntegration {
 
         // 3. set limit
         address licenseTemplate = pilTemplateAddr;
-        uint256 licenseTermsId = licenseTermsIds[0];  // use the ID returned after registration
+        uint256 licenseTermsId = licenseTermsIds[0]; // use the ID returned after registration
         totalLicenseTokenLimitHook.setTotalLicenseTokenLimit(ipId, licenseTemplate, licenseTermsId, 2);
-        
+
         emit DebugLog("Hook address", address(totalLicenseTokenLimitHook));
         emit DebugLog("License Template", licenseTemplate);
         emit DebugLog("IP ID", ipId);
         emit DebugLogUint("License Terms ID", licenseTermsId);
-        
+
         // 4. record the number of tokens before minting
         uint256 supplyBefore = totalLicenseTokenLimitHook.getTotalLicenseTokenSupply(
             ipId,
@@ -339,11 +336,11 @@ contract LicenseAttachmentIntegration is BaseIntegration {
             licenseTermsId
         );
         emit DebugLogUint("Supply Before", supplyBefore);
-        
+
         // 5. mint tokens
         wrappedIP.deposit{ value: testMintFee * 3 }();
-        wrappedIP.approve(royaltyModuleAddr, testMintFee * 3); 
-        
+        wrappedIP.approve(royaltyModuleAddr, testMintFee * 3);
+
         licensingModule.mintLicenseTokens({
             licensorIpId: ipId,
             licenseTemplate: licenseTemplate,
@@ -354,7 +351,7 @@ contract LicenseAttachmentIntegration is BaseIntegration {
             maxMintingFee: 0,
             maxRevenueShare: 0
         });
-        
+
         // 6. record the number of tokens after minting
         uint256 supplyAfter = totalLicenseTokenLimitHook.getTotalLicenseTokenSupply(
             ipId,
@@ -362,28 +359,30 @@ contract LicenseAttachmentIntegration is BaseIntegration {
             licenseTermsId
         );
         emit DebugLogUint("Supply After", supplyAfter);
-        
+
         // 7. verify the number of tokens increased
         assertEq(supplyAfter, supplyBefore + 2, "Supply should increase by 2");
 
         // 8. test exceeding the limit using try/catch for live network testing
         bytes memory expectedError = abi.encodeWithSelector(
             TotalLicenseTokenLimitHook.TotalLicenseTokenLimitHook_TotalLicenseTokenLimitExceeded.selector,
-            2,  // currentSupply (after minting 2 tokens)
-            1,  // amount trying to mint
-            2   // limit we set
+            2, // currentSupply (after minting 2 tokens)
+            1, // amount trying to mint
+            2 // limit we set
         );
 
-        try licensingModule.mintLicenseTokens{gas: 500000}({
-            licensorIpId: ipId,
-            licenseTemplate: licenseTemplate,
-            licenseTermsId: licenseTermsId,
-            amount: 1,
-            receiver: testSender,
-            royaltyContext: "",
-            maxMintingFee: 0,
-            maxRevenueShare: 0
-        }) {
+        try
+            licensingModule.mintLicenseTokens{ gas: 500000 }({
+                licensorIpId: ipId,
+                licenseTemplate: licenseTemplate,
+                licenseTermsId: licenseTermsId,
+                amount: 1,
+                receiver: testSender,
+                royaltyContext: "",
+                maxMintingFee: 0,
+                maxRevenueShare: 0
+            })
+        {
             // If this block is reached, the transaction did not revert, which is an error in our test logic.
             revert MintingDidNotRevert();
         } catch (bytes memory reason) {
@@ -396,12 +395,12 @@ contract LicenseAttachmentIntegration is BaseIntegration {
         }
 
         // Add a final, successful state change to signal a successful script execution to Forge.
-        emit DebugLog("Revert test completed successfully", address(this));
+        emit DebugLog("Revert test completed successfully", address(0));
     }
 
     function _setUpTest() private {
         delete commTermsData;
-        
+
         spgNftContract = ISPGNFT(
             registrationWorkflows.createCollection(
                 ISPGNFT.InitParams({

--- a/test/integration/workflows/LicenseAttachmentIntegration.t.sol
+++ b/test/integration/workflows/LicenseAttachmentIntegration.t.sol
@@ -35,7 +35,6 @@ contract LicenseAttachmentIntegration is BaseIntegration {
     function run() public override {
         super.run();
 
-        // Transaction 1: Setup and all successful tests.
         _beginBroadcast();
         _setUpTest();
         _test_LicenseAttachmentIntegration_registerPILTermsAndAttach();
@@ -394,8 +393,6 @@ contract LicenseAttachmentIntegration is BaseIntegration {
     }
 
     function _setUpTest() private {
-        delete commTermsData;
-
         spgNftContract = ISPGNFT(
             registrationWorkflows.createCollection(
                 ISPGNFT.InitParams({
@@ -414,8 +411,6 @@ contract LicenseAttachmentIntegration is BaseIntegration {
             )
         );
 
-        assertTrue(address(spgNftContract) != address(0), "createCollection returned address(0)");
-
         commTermsData.push(
             WorkflowStructs.LicenseTermsData({
                 terms: PILFlavors.commercialUse({
@@ -426,7 +421,6 @@ contract LicenseAttachmentIntegration is BaseIntegration {
                 licensingConfig: Licensing.LicensingConfig({
                     isSet: true,
                     mintingFee: testMintFee,
-                    // licensingHook: address(0),
                     licensingHook: address(totalLicenseTokenLimitHook),
                     hookData: "",
                     commercialRevShare: 0,

--- a/test/integration/workflows/LicenseAttachmentIntegration.t.sol
+++ b/test/integration/workflows/LicenseAttachmentIntegration.t.sol
@@ -43,11 +43,6 @@ contract LicenseAttachmentIntegration is BaseIntegration {
         _test_LicenseAttachmentIntegration_registerIpAndAttachPILTerms();
         _test_LicenseAttachmentIntegration_mintAndRegisterIpAndAttachDefaultTerms();
         _test_LicenseAttachmentIntegration_registerIpAndAttachDefaultTerms();
-        _endBroadcast();
-
-        // Transaction 2: The isolated revert test.
-        _beginBroadcast();
-        _setUpTest();
         _test_revert_TotalLicenseTokenLimitHook();
         _endBroadcast();
     }

--- a/test/integration/workflows/RegistrationIntegration.t.sol
+++ b/test/integration/workflows/RegistrationIntegration.t.sol
@@ -143,7 +143,7 @@ contract RegistrationIntegration is BaseIntegration {
         private
         logTest("test_RegistrationIntegration_multicall_createCollection")
     {
-        uint256 totalCollections = 10;
+        uint256 totalCollections = 2;
 
         ISPGNFT[] memory nftContracts = new ISPGNFT[](totalCollections);
         bytes[] memory data = new bytes[](totalCollections);
@@ -189,7 +189,7 @@ contract RegistrationIntegration is BaseIntegration {
         private
         logTest("test_RegistrationIntegration_multicall_mintAndRegisterIp")
     {
-        uint256 totalIps = 10;
+        uint256 totalIps = 2;
         wrappedIP.deposit{ value: testMintFee * totalIps }();
         wrappedIP.approve(address(spgNftContract), testMintFee * totalIps);
 

--- a/test/integration/workflows/SpgNftIntegration.t.sol
+++ b/test/integration/workflows/SpgNftIntegration.t.sol
@@ -11,6 +11,7 @@ import { console2 } from "forge-std/console2.sol";
 import { ISPGNFT } from "../../../contracts/interfaces/ISPGNFT.sol";
 import { SPGNFTLib } from "../../../contracts/lib/SPGNFTLib.sol";
 import { WorkflowStructs } from "../../../contracts/lib/WorkflowStructs.sol";
+import { IERC7572 } from "../../../contracts/interfaces/story-nft/IERC7572.sol";
 
 // test
 import { BaseIntegration } from "../BaseIntegration.t.sol";
@@ -34,8 +35,9 @@ contract SpgNftIntegration is BaseIntegration {
         // Create SPG NFT collection
         spgNftContract = _createNftCollection();
 
-        // Run the test
+        // Run the tests
         _test_SpgNftIntegration_setTokenURI();
+        _test_SpgNftIntegration_contractURI();
         _endBroadcast();
     }
 
@@ -68,6 +70,27 @@ contract SpgNftIntegration is BaseIntegration {
         console2.log("Updated token URI:", updatedUri);
 
         assertEq(updatedUri, string.concat(testBaseURI, CUSTOM_TOKEN_URI));
+    }
+
+    /**
+     * @dev Test function to verify the contractURI functionality and ContractURIUpdated event
+     */
+    function _test_SpgNftIntegration_contractURI() private logTest("test_SpgNftIntegration_contractURI") {
+        // Verify initial contract URI
+        assertEq(spgNftContract.contractURI(), testContractURI);
+
+        // Test setting new contract URI
+        string memory newContractURI = "new-contract-uri";
+        vm.expectEmit(address(spgNftContract));
+        emit IERC7572.ContractURIUpdated();
+        spgNftContract.setContractURI(newContractURI);
+        assertEq(spgNftContract.contractURI(), newContractURI);
+
+        // Test setting back to original contract URI
+        vm.expectEmit(address(spgNftContract));
+        emit IERC7572.ContractURIUpdated();
+        spgNftContract.setContractURI(testContractURI);
+        assertEq(spgNftContract.contractURI(), testContractURI);
     }
 
     /**


### PR DESCRIPTION
## Description
<!-- Add a description of the changes that this PR introduces -->

1. Updated integration tests for v1.3.3 changes ([221](https://github.com/storyprotocol/protocol-periphery-v1/pull/221), [222](https://github.com/storyprotocol/protocol-periphery-v1/pull/222)):
 - Added new test in LicenseAttachmentIntegration for TotalLicenseTokenLimitHook
 - Added new test SpgNftIntegration for contractURI

2. Updated integration test workflow.

3. Reduce multicall number to avoid gas fee issue - `server returned an error response: error code -32000: tx fee (4.03 ether) exceeds the configured cap (1.00 ether)`:
Original multicall number is 10: https://github.com/jia57b/protocol-periphery-v1/actions/runs/15725549668
Reducing the number of multiple calls to 2: https://github.com/jia57b/protocol-periphery-v1/actions/runs/15728009952

## Test Plan 
<!-- The test plan section indicates detailed steps on how to verify and test code changes. 
You can list the test cases or test steps that need to be performed.-->

## Related Issue
<!-- The related Issue section can indicate which issue or task the Pull Request is related with -->

## Notes
<!-- The Important Matters section can alert others to special requirements or matters that need extra attention -->

Run integration tests and passed: https://github.com/jia57b/protocol-periphery-v1/actions/runs/15728009952