### PR TITLE
Tests registration and royalty tokens distribution workflows

### DIFF
--- a/test/utils/TestHelper.t.sol
+++ b/test/utils/TestHelper.t.sol
@@ -48,6 +48,7 @@ contract TestHelper is Test {
     /// @dev Get the permission list for setting metadata and registering a derivative for the IP.
     /// @param ipId The ID of the IP that the permissions are for.
     /// @param to The address of the periphery contract to receive the permission.
+    /// @param withLicenseToken Whether to use license tokens for the derivative registration.
     /// @return permissionList The list of permissions for setting metadata and registering a derivative.
     function _getMetadataAndDerivativeRegistrationPermissionList(
         address ipId,


### PR DESCRIPTION
## Description
This PR adds tests to the registration and royalty token distribution workflow test files. The added tests ensure that the workflow functions taking a signature as a parameter can only be called by the signer.
This PR also includes a fix in the natspec doc of the test helper `_getMetadataAndDerivativeRegistrationPermissionList` function.

### Added tests
test/workflows/RegistrationWorkflows.t.sol: `test_RegistrationWorkflows_revert_registerIp_callerNotSigner`

test/workflows/RoyaltyTokenDistributionWorkflows.t.sol: `test_RoyaltyTokenDistributionWorkflows_revert_CallerNotSigner_registerIpAndAttachPILTermsAndDeployRoyaltyVault`, `test_RoyaltyTokenDistributionWorkflows_revert_CallerNotSigner_registerIpAndMakeDerivativeAndDeployRoyaltyVault`, `test_RoyaltyTokenDistributionWorkflows_revert_CallerNotSigner_distributeRoyaltyTokens`

## Coverage improvement

Before:
<img width="894" alt="Screenshot 2025-06-20 at 3 44 40 PM" src="https://github.com/user-attachments/assets/20148a17-f06f-4731-8d38-99024cb9ac4c" />

After:
<img width="895" alt="Screenshot 2025-06-20 at 3 42 58 PM" src="https://github.com/user-attachments/assets/3764f263-43ea-474c-8a94-20855b609662" />

