### PR TITLE
fix(test): add test case to total license token limit hook

### DIFF
--- a/test/hooks/TotalLicenseTokenLimitHook.t.sol
+++ b/test/hooks/TotalLicenseTokenLimitHook.t.sol
@@ -477,4 +477,34 @@ contract TotalLicenseTokenLimitHookTest is BaseTest {
             maxRevenueShare
         );
     }
+
+    function test_TotalLicenseTokenLimitHook_beforeRegisterDerivative_incrementTotalLicenseTokenSupply() public {
+        address[] memory parentIpIds = new address[](1);
+        parentIpIds[0] = ipId1;
+        uint256[] memory licenseTermsIds = new uint256[](1);
+        licenseTermsIds[0] = commRemixTermsId;
+
+        uint256 totalLicenseTokenMintedBefore = totalLicenseTokenLimitHook.getTotalLicenseTokenSupply(
+            ipId1,
+            address(pilTemplate),
+            commRemixTermsId
+        );
+
+        totalLicenseTokenLimitHook.beforeRegisterDerivative(
+            derivativeOwner,
+            derivativeIpId,
+            ipId1,
+            address(pilTemplate),
+            commRemixTermsId,
+            ""
+        );
+
+        uint256 totalLicenseTokenMintedAfter = totalLicenseTokenLimitHook.getTotalLicenseTokenSupply(
+            ipId1,
+            address(pilTemplate),
+            commRemixTermsId
+        );
+
+        assertEq(totalLicenseTokenMintedAfter, totalLicenseTokenMintedBefore + 1);
+    }
 }

--- a/test/workflows/DerivativeWorkflows.t.sol
+++ b/test/workflows/DerivativeWorkflows.t.sol
@@ -156,7 +156,7 @@ contract DerivativeWorkflowsTest is BaseTest {
 
     function test_DerivativeWorkflows_revert_CallerNotSigner_registerIpAndMakeDerivative()
         public
-        whenCallerHasMinterRole        
+        whenCallerHasMinterRole
         withCollection
         withEnoughTokens(address(derivativeWorkflows))
         withNonCommercialParentIp
@@ -198,13 +198,7 @@ contract DerivativeWorkflowsTest is BaseTest {
 
         vm.startPrank(u.bob);
 
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                Errors.DerivativeWorkflows__CallerNotSigner.selector,
-                u.bob,
-                u.alice
-            )
-        );
+        vm.expectRevert(abi.encodeWithSelector(Errors.DerivativeWorkflows__CallerNotSigner.selector, u.bob, u.alice));
 
         derivativeWorkflows.registerIpAndMakeDerivative({
             nftContract: address(nftContract),
@@ -229,7 +223,7 @@ contract DerivativeWorkflowsTest is BaseTest {
 
     function test_DerivativeWorkflows_revert_CallerNotSigner_registerIpAndMakeDerivativeWithLicenseTokens()
         public
-        whenCallerHasMinterRole        
+        whenCallerHasMinterRole
         withCollection
         withEnoughTokens(address(derivativeWorkflows))
         withNonCommercialParentIp
@@ -280,13 +274,7 @@ contract DerivativeWorkflowsTest is BaseTest {
 
         vm.startPrank(u.bob);
 
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                Errors.DerivativeWorkflows__CallerNotSigner.selector,
-                u.bob,
-                u.alice
-            )
-        );
+        vm.expectRevert(abi.encodeWithSelector(Errors.DerivativeWorkflows__CallerNotSigner.selector, u.bob, u.alice));
 
         derivativeWorkflows.registerIpAndMakeDerivativeWithLicenseTokens({
             nftContract: address(nftContract),


### PR DESCRIPTION
## Description
This PR adds a new test function to improve test coverage for the totalLicenseTokenLimit hook, ensuring its correct behavior during derivative registration.

It also includes a couple of linter styling changes

## Test added
test_TotalLicenseTokenLimitHook_beforeRegisterDerivative_incrementTotalLicenseTokenSupply()
Purpose: Validates that the beforeRegisterDerivative() hook correctly increments the total license token supply when a new derivative is registered.

## Coverage improvement

Before:
<img width="1196" alt="Screenshot 2025-06-23 at 11 35 09 AM" src="https://github.com/user-attachments/assets/d60e5df1-e126-40ad-8c76-d76c67a9d792" />
After:
<img width="1197" alt="Screenshot 2025-06-23 at 11 33 47 AM" src="https://github.com/user-attachments/assets/5417e980-9fc1-43f3-8221-12fa4c928407" />
