### PR TITLE
fix(test): add missing tests for SPGNFT

### DIFF
--- a/test/SPGNFT.t.sol
+++ b/test/SPGNFT.t.sol
@@ -230,6 +230,17 @@ contract SPGNFTTest is BaseTest {
         vm.stopPrank();
     }
 
+    function test_SPGNFT_mint_revert_MintingDenied() public {
+        vm.startPrank(u.bob);
+        mockToken.mint(address(u.bob), 1000 * 10 ** mockToken.decimals());
+        mockToken.approve(address(nftContract), 1000 * 10 ** mockToken.decimals());
+
+        vm.expectRevert(Errors.SPGNFT__MintingDenied.selector);
+        nftContract.mint(u.bob, ipMetadataDefault.nftMetadataURI, ipMetadataDefault.nftMetadataHash, false);
+
+        vm.stopPrank();
+    }
+
     function test_SPGNFT_setBaseURI() public {
         vm.startPrank(u.alice);
         mockToken.mint(address(u.alice), 1000 * 10 ** mockToken.decimals());
@@ -450,6 +461,42 @@ contract SPGNFTTest is BaseTest {
         vm.expectRevert(abi.encodeWithSelector(Errors.SPGNFT__CallerNotOwner.selector, tokenId, u.bob, u.alice));
         nftContract.setTokenURI(tokenId, "newTokenURI");
 
+        vm.stopPrank();
+    }
+
+    function test_SPGNFT_setMintOpen() public {
+        vm.startPrank(u.alice);
+        nftContract.setMintOpen(false);
+        assertEq(nftContract.mintOpen(), false);
+
+        nftContract.setMintOpen(true);
+        assertEq(nftContract.mintOpen(), true);
+
+        vm.stopPrank();
+
+        vm.startPrank(u.bob);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, u.bob, SPGNFTLib.ADMIN_ROLE)
+        );
+        nftContract.setMintOpen(false);
+        vm.stopPrank();
+    }
+
+    function test_SPGNFT_setPublicMinting() public {
+        vm.startPrank(u.alice);
+        nftContract.setPublicMinting(false);
+        assertEq(nftContract.publicMinting(), false);
+
+        nftContract.setPublicMinting(true);
+        assertEq(nftContract.publicMinting(), true);
+
+        vm.stopPrank();
+
+        vm.startPrank(u.bob);
+        vm.expectRevert(
+            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, u.bob, SPGNFTLib.ADMIN_ROLE)
+        );
+        nftContract.setPublicMinting(false);
         vm.stopPrank();
     }
 }


### PR DESCRIPTION
## Description
This PR adds three new test functions to improve test coverage and validation for the SPGNFT contract, focusing on access control and minting permissions.

## Tests added
1. test_SPGNFT_mint_revert_MintingDenied()
Purpose: Validates that minting is properly denied when a user without minter role attempts to mint from a collection with public minting disabled. 

2. test_SPGNFT_setMintOpen()
Purpose: Validates the setMintOpen() function and its access control. Tests both successful state changes and access control violations.

3. test_SPGNFT_setPublicMinting()
Purpose: Validates the setPublicMinting() function and its access control. Tests both successful state changes and access control violations.


## Coverage improvement

Before:
![Screenshot 2025-06-23 at 12 01 18 PM](https://github.com/user-attachments/assets/547a9f9e-12aa-4bd6-8eba-acd1e3efa6e1)

After:

![Screenshot 2025-06-23 at 11 59 57 AM](https://github.com/user-attachments/assets/27b5205b-71c1-48be-bddb-167ed00d21e3)

