### PR TITLE
fix(test): add test case to tokenizer module tests

### DIFF
--- a/test/modules/tokenizer/TokenizerModule.t.sol
+++ b/test/modules/tokenizer/TokenizerModule.t.sol
@@ -311,6 +311,27 @@ contract TokenizerModuleTest is BaseTest {
         );
     }
 
+    function test_TokenizerModule_revert_tokenize_TokenTemplateNotWhitelisted() public {
+        mockToken.mint(address(this), 1 * 10 ** mockToken.decimals());
+        mockToken.approve(address(spgNftPublic), 1 * 10 ** mockToken.decimals());
+        (address ipId, ) = registrationWorkflows.mintAndRegisterIp({
+            spgNftContract: address(spgNftPublic),
+            recipient: u.alice,
+            ipMetadata: ipMetadataDefault,
+            allowDuplicates: true
+        });
+
+        vm.prank(u.alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.TokenizerModule__TokenTemplateNotWhitelisted.selector, address(0x1234))
+        );
+        tokenizerModule.tokenize(
+            ipId,
+            address(0x1234),
+            abi.encode(IOwnableERC20.InitData({ cap: 1000, name: "Test1", symbol: "T1", initialOwner: u.alice }))
+        );
+    }
+
     function test_TokenizerModule_upgradeWhitelistedTokenTemplate() public {
         address newTokenTemplateImpl = address(new OwnableERC20(address(ownableERC20Beacon)));
 


### PR DESCRIPTION
## Description
This PR adds a new test function to improve test coverage for the tokenizer module, ensuring its correct behavior during tokenization.

## Test added
test_TokenizerModule_revert_tokenize_TokenTemplateNotWhitelisted()
Purpose: Validates that the tokenize() function reverts when given a license template that is not whitelisted.

## Coverage improvement

Before:

![image](https://github.com/user-attachments/assets/53a69e86-b76e-48f5-96fb-f8416cdbaaca)
After:

<img width="1059" alt="Screenshot 2025-06-24 at 1 13 05 PM" src="https://github.com/user-attachments/assets/86edd43c-7bb0-4db2-901a-475825ffdf04" />
