### PR TITLE
Fix: SPGNFT metadata hash setter

### DIFF
--- a/contracts/SPGNFT.sol
+++ b/contracts/SPGNFT.sol
@@ -241,8 +241,9 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
         // revert if caller is not the owner of the `tokenId` token
         address owner = ownerOf(tokenId);
         if (owner != msg.sender) revert Errors.SPGNFT__CallerNotOwner(tokenId, msg.sender, owner);
+        SPGNFTStorage storage $ = _getSPGNFTStorage();
+        if ($._nftMetadataHashToTokenId[nftMetadataHash] == 0) $._nftMetadataHashToTokenId[nftMetadataHash] = tokenId;
         _setTokenURI(tokenId, tokenUri);
-        _setNftMetadataHash(tokenId, nftMetadataHash);
     }
 
     /// @notice Sets the contract URI for the collection.
@@ -354,14 +355,6 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
         _safeMint(to, tokenId);
 
         if (bytes(nftMetadataURI).length > 0) _setTokenURI(tokenId, nftMetadataURI);
-    }
-
-    /// @dev Sets the metadata hash for a specific token.
-    /// @param tokenId The ID of the token to update.
-    /// @param nftMetadataHash The metadata hash of the token.
-    function _setNftMetadataHash(uint256 tokenId, bytes32 nftMetadataHash) internal {
-        SPGNFTStorage storage $ = _getSPGNFTStorage();
-        if ($._nftMetadataHashToTokenId[nftMetadataHash] == 0) $._nftMetadataHashToTokenId[nftMetadataHash] = tokenId;
     }
 
     /// @dev Sets the contract URI for the collection.

--- a/contracts/SPGNFT.sol
+++ b/contracts/SPGNFT.sol
@@ -219,25 +219,13 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
         _getSPGNFTStorage()._baseURI = baseURI;
     }
 
-    /// @notice Sets the token URI for a specific token. This function is deprecated, use {setTokenMetadata} instead.
-    /// @dev Only callable by the owner of the token. This updates the metadata URI
-    ///      for the specified token and emits a MetadataUpdate event.
-    /// @param tokenId The ID of the token to update.
-    /// @param tokenUri The new metadata URI to associate with the token.
-    function setTokenURI(uint256 tokenId, string memory tokenUri) external {
-        // revert if caller is not the owner of the `tokenId` token
-        address owner = ownerOf(tokenId);
-        if (owner != msg.sender) revert Errors.SPGNFT__CallerNotOwner(tokenId, msg.sender, owner);
-        _setTokenURI(tokenId, tokenUri);
-    }
-
     /// @notice Sets the token metadata for a specific token.
     /// @dev Only callable by the owner of the token. This updates the metadata URI and hash
     ///      for the specified token and emits a MetadataUpdate event.
     /// @param tokenId The ID of the token to update.
     /// @param tokenUri The new metadata URI to associate with the token.
     /// @param nftMetadataHash The new metadata hash to associate with the token.
-    function setTokenMetadata(uint256 tokenId, string memory tokenUri, bytes32 nftMetadataHash) external {
+    function setTokenURI(uint256 tokenId, string memory tokenUri, bytes32 nftMetadataHash) external {
         // revert if caller is not the owner of the `tokenId` token
         address owner = ownerOf(tokenId);
         if (owner != msg.sender) revert Errors.SPGNFT__CallerNotOwner(tokenId, msg.sender, owner);
@@ -402,5 +390,18 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
         assembly {
             $.slot := SPGNFTStorageLocation
         }
+    }
+
+    /// @notice Sets the token URI for a specific token.
+    /// @dev This function is deprecated, use setTokenURI(uint256 tokenId, string memory tokenUri, bytes32 nftMetadataHash) instead.
+    /// @dev Only callable by the owner of the token. This updates the metadata URI
+    ///      for the specified token and emits a MetadataUpdate event.
+    /// @param tokenId The ID of the token to update.
+    /// @param tokenUri The new metadata URI to associate with the token.
+    function setTokenURI(uint256 tokenId, string memory tokenUri) external {
+        // revert if caller is not the owner of the `tokenId` token
+        address owner = ownerOf(tokenId);
+        if (owner != msg.sender) revert Errors.SPGNFT__CallerNotOwner(tokenId, msg.sender, owner);
+        _setTokenURI(tokenId, tokenUri);
     }
 }

--- a/contracts/SPGNFT.sol
+++ b/contracts/SPGNFT.sol
@@ -219,7 +219,7 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
         _getSPGNFTStorage()._baseURI = baseURI;
     }
 
-    /// @notice Sets the token URI for a specific token.
+    /// @notice Sets the token URI for a specific token. This function is deprecated, use {setTokenMetadata} instead.
     /// @dev Only callable by the owner of the token. This updates the metadata URI
     ///      for the specified token and emits a MetadataUpdate event.
     /// @param tokenId The ID of the token to update.
@@ -231,17 +231,18 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
         _setTokenURI(tokenId, tokenUri);
     }
 
-    /// @notice Sets the metadata hash for a specific token.
-    /// @dev Only callable by the owner of the token. This updates the metadata hash in the nftMetadataHashToTokenId mapping
-    ///      for the specified token and emits a NFTMetadataHashUpdated event.
+    /// @notice Sets the token metadata for a specific token.
+    /// @dev Only callable by the owner of the token. This updates the metadata URI and hash
+    ///      for the specified token and emits a MetadataUpdate event.
     /// @param tokenId The ID of the token to update.
-    /// @param nftCurrentMetadataHash The current metadata hash of the token.
-    /// @param nftNewMetadataHash The new metadata hash of the token.
-    function setNftMetadataHash(uint256 tokenId, bytes32 nftCurrentMetadataHash, bytes32 nftNewMetadataHash) external {
+    /// @param tokenUri The new metadata URI to associate with the token.
+    /// @param nftMetadataHash The new metadata hash to associate with the token.
+    function setTokenMetadata(uint256 tokenId, string memory tokenUri, bytes32 nftMetadataHash) external {
         // revert if caller is not the owner of the `tokenId` token
         address owner = ownerOf(tokenId);
         if (owner != msg.sender) revert Errors.SPGNFT__CallerNotOwner(tokenId, msg.sender, owner);
-        _setNftMetadataHash(tokenId, nftCurrentMetadataHash, nftNewMetadataHash);
+        _setTokenURI(tokenId, tokenUri);
+        _setNftMetadataHash(tokenId, nftMetadataHash);
     }
 
     /// @notice Sets the contract URI for the collection.
@@ -357,17 +358,10 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
 
     /// @dev Sets the metadata hash for a specific token.
     /// @param tokenId The ID of the token to update.
-    /// @param nftCurrentMetadataHash The current metadata hash of the token.
-    /// @param nftNewMetadataHash The new metadata hash of the token.
-    function _setNftMetadataHash(uint256 tokenId, bytes32 nftCurrentMetadataHash, bytes32 nftNewMetadataHash) internal {
+    /// @param nftMetadataHash The metadata hash of the token.
+    function _setNftMetadataHash(uint256 tokenId, bytes32 nftMetadataHash) internal {
         SPGNFTStorage storage $ = _getSPGNFTStorage();
-        if ($._nftMetadataHashToTokenId[nftCurrentMetadataHash] != tokenId)
-            revert Errors.SPGNFT__InvalidNFTMetadataHash(address(this), tokenId, nftCurrentMetadataHash);
-        if ($._nftMetadataHashToTokenId[nftNewMetadataHash] != 0)
-            revert Errors.SPGNFT__DuplicatedNFTMetadataHash(address(this), tokenId, nftNewMetadataHash);
-        delete $._nftMetadataHashToTokenId[nftCurrentMetadataHash];
-        $._nftMetadataHashToTokenId[nftNewMetadataHash] = tokenId;
-        emit NFTMetadataHashUpdated(tokenId, nftCurrentMetadataHash, nftNewMetadataHash);
+        if ($._nftMetadataHashToTokenId[nftMetadataHash] == 0) $._nftMetadataHashToTokenId[nftMetadataHash] = tokenId;
     }
 
     /// @dev Sets the contract URI for the collection.

--- a/contracts/SPGNFT.sol
+++ b/contracts/SPGNFT.sol
@@ -219,7 +219,7 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
         _getSPGNFTStorage()._baseURI = baseURI;
     }
 
-    /// @notice Sets the token metadata for a specific token.
+    /// @notice Sets the token URI for a specific token.
     /// @dev Only callable by the owner of the token. This updates the metadata URI and hash
     ///      for the specified token and emits a MetadataUpdate event.
     /// @param tokenId The ID of the token to update.
@@ -391,6 +391,8 @@ contract SPGNFT is ISPGNFT, ERC721URIStorageUpgradeable, AccessControlUpgradeabl
             $.slot := SPGNFTStorageLocation
         }
     }
+
+    // >>>>>>>>>>>>>>>>>>>>>>>>>>> DEPRECATED FUNCTIONS >>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
     /// @notice Sets the token URI for a specific token.
     /// @dev This function is deprecated, use setTokenURI(uint256 tokenId, string memory tokenUri, bytes32 nftMetadataHash) instead.

--- a/contracts/interfaces/ISPGNFT.sol
+++ b/contracts/interfaces/ISPGNFT.sol
@@ -37,9 +37,6 @@ interface ISPGNFT is IAccessControl, IERC721Metadata, IERC7572 {
         bool isPublicMinting;
     }
 
-    /// @notice Emitted when the metadata hash for an NFT is updated.
-    event NFTMetadataHashUpdated(uint256 indexed tokenId, bytes32 currentMetadataHash, bytes32 newMetadataHash);
-
     /// @dev Initializes the NFT collection.
     /// @dev If mint fee is non-zero, mint token must be set.
     /// @param params The initialization parameters. See `InitParams`.
@@ -112,20 +109,20 @@ interface ISPGNFT is IAccessControl, IERC721Metadata, IERC7572 {
     ///        See https://eips.ethereum.org/EIPS/eip-7572
     function setContractURI(string memory contractURI) external;
 
-    /// @notice Sets the token URI for a specific token.
+    /// @notice Sets the token URI for a specific token. This function is deprecated, use {setTokenMetadata} instead.
     /// @dev Only callable by the owner of the token. This updates the metadata URI
     ///      for the specified token and emits a MetadataUpdate event.
     /// @param tokenId The ID of the token to update.
     /// @param tokenUri The new metadata URI to associate with the token.
     function setTokenURI(uint256 tokenId, string memory tokenUri) external;
 
-    /// @notice Sets the metadata hash for a specific token.
-    /// @dev Only callable by the owner of the token. This updates the metadata hash in the nftMetadataHashToTokenId mapping
-    ///      for the specified token and emits a NFTMetadataHashUpdated event.
+    /// @notice Sets the token metadata for a specific token.
+    /// @dev Only callable by the owner of the token. This updates the metadata URI and hash
+    ///      for the specified token and emits a MetadataUpdate event.
     /// @param tokenId The ID of the token to update.
-    /// @param nftCurrentMetadataHash The current metadata hash of the token.
-    /// @param nftNewMetadataHash The new metadata hash of the token.
-    function setNftMetadataHash(uint256 tokenId, bytes32 nftCurrentMetadataHash, bytes32 nftNewMetadataHash) external;
+    /// @param tokenUri The new metadata URI to associate with the token.
+    /// @param nftMetadataHash The new metadata hash to associate with the token.
+    function setTokenMetadata(uint256 tokenId, string memory tokenUri, bytes32 nftMetadataHash) external;
 
     /// @notice Mints an NFT from the collection. Only callable by the minter role.
     /// @param to The address of the recipient of the minted NFT.

--- a/contracts/interfaces/ISPGNFT.sol
+++ b/contracts/interfaces/ISPGNFT.sol
@@ -109,7 +109,7 @@ interface ISPGNFT is IAccessControl, IERC721Metadata, IERC7572 {
     ///        See https://eips.ethereum.org/EIPS/eip-7572
     function setContractURI(string memory contractURI) external;
 
-    /// @notice Sets the token metadata for a specific token.
+    /// @notice Sets the token URI for a specific token.
     /// @dev Only callable by the owner of the token. This updates the metadata URI and hash
     ///      for the specified token and emits a MetadataUpdate event.
     /// @param tokenId The ID of the token to update.
@@ -149,6 +149,8 @@ interface ISPGNFT is IAccessControl, IERC721Metadata, IERC7572 {
     /// @param token The token to withdraw.
     function withdrawToken(address token) external;
 
+    // >>>>>>>>>>>>>>>>>>>>>>>>>>> DEPRECATED FUNCTIONS >>>>>>>>>>>>>>>>>>>>>>>>>>>>>
+
     /// @notice Sets the token URI for a specific token.
     /// @dev This function is deprecated, use setTokenURI(uint256 tokenId, string memory tokenUri, bytes32 nftMetadataHash) instead.
     /// @dev Only callable by the owner of the token. This updates the metadata URI
@@ -157,5 +159,3 @@ interface ISPGNFT is IAccessControl, IERC721Metadata, IERC7572 {
     /// @param tokenUri The new metadata URI to associate with the token.
     function setTokenURI(uint256 tokenId, string memory tokenUri) external;
 }
-
-

--- a/contracts/interfaces/ISPGNFT.sol
+++ b/contracts/interfaces/ISPGNFT.sol
@@ -109,20 +109,13 @@ interface ISPGNFT is IAccessControl, IERC721Metadata, IERC7572 {
     ///        See https://eips.ethereum.org/EIPS/eip-7572
     function setContractURI(string memory contractURI) external;
 
-    /// @notice Sets the token URI for a specific token. This function is deprecated, use {setTokenMetadata} instead.
-    /// @dev Only callable by the owner of the token. This updates the metadata URI
-    ///      for the specified token and emits a MetadataUpdate event.
-    /// @param tokenId The ID of the token to update.
-    /// @param tokenUri The new metadata URI to associate with the token.
-    function setTokenURI(uint256 tokenId, string memory tokenUri) external;
-
     /// @notice Sets the token metadata for a specific token.
     /// @dev Only callable by the owner of the token. This updates the metadata URI and hash
     ///      for the specified token and emits a MetadataUpdate event.
     /// @param tokenId The ID of the token to update.
     /// @param tokenUri The new metadata URI to associate with the token.
     /// @param nftMetadataHash The new metadata hash to associate with the token.
-    function setTokenMetadata(uint256 tokenId, string memory tokenUri, bytes32 nftMetadataHash) external;
+    function setTokenURI(uint256 tokenId, string memory tokenUri, bytes32 nftMetadataHash) external;
 
     /// @notice Mints an NFT from the collection. Only callable by the minter role.
     /// @param to The address of the recipient of the minted NFT.
@@ -155,4 +148,14 @@ interface ISPGNFT is IAccessControl, IERC721Metadata, IERC7572 {
     /// @dev Withdraws the contract's token balance to the fee recipient.
     /// @param token The token to withdraw.
     function withdrawToken(address token) external;
+
+    /// @notice Sets the token URI for a specific token.
+    /// @dev This function is deprecated, use setTokenURI(uint256 tokenId, string memory tokenUri, bytes32 nftMetadataHash) instead.
+    /// @dev Only callable by the owner of the token. This updates the metadata URI
+    ///      for the specified token and emits a MetadataUpdate event.
+    /// @param tokenId The ID of the token to update.
+    /// @param tokenUri The new metadata URI to associate with the token.
+    function setTokenURI(uint256 tokenId, string memory tokenUri) external;
 }
+
+

--- a/contracts/interfaces/ISPGNFT.sol
+++ b/contracts/interfaces/ISPGNFT.sol
@@ -37,6 +37,9 @@ interface ISPGNFT is IAccessControl, IERC721Metadata, IERC7572 {
         bool isPublicMinting;
     }
 
+    /// @notice Emitted when the metadata hash for an NFT is updated.
+    event NFTMetadataHashUpdated(uint256 indexed tokenId, bytes32 currentMetadataHash, bytes32 newMetadataHash);
+
     /// @dev Initializes the NFT collection.
     /// @dev If mint fee is non-zero, mint token must be set.
     /// @param params The initialization parameters. See `InitParams`.
@@ -115,6 +118,14 @@ interface ISPGNFT is IAccessControl, IERC721Metadata, IERC7572 {
     /// @param tokenId The ID of the token to update.
     /// @param tokenUri The new metadata URI to associate with the token.
     function setTokenURI(uint256 tokenId, string memory tokenUri) external;
+
+    /// @notice Sets the metadata hash for a specific token.
+    /// @dev Only callable by the owner of the token. This updates the metadata hash in the nftMetadataHashToTokenId mapping
+    ///      for the specified token and emits a NFTMetadataHashUpdated event.
+    /// @param tokenId The ID of the token to update.
+    /// @param nftCurrentMetadataHash The current metadata hash of the token.
+    /// @param nftNewMetadataHash The new metadata hash of the token.
+    function setNftMetadataHash(uint256 tokenId, bytes32 nftCurrentMetadataHash, bytes32 nftNewMetadataHash) external;
 
     /// @notice Mints an NFT from the collection. Only callable by the minter role.
     /// @param to The address of the recipient of the minted NFT.

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -111,7 +111,7 @@ library Errors {
     /// @notice Caller is not one of the periphery contracts.
     error SPGNFT__CallerNotPeripheryContract();
 
-    /// @notice Error thrown when attempting to mint an NFT with a metadata hash that already exists.
+    /// @notice Error thrown when attempting to mint an NFT with a metadata hash that already exists or set a metadata hash that already exists.
     /// @param spgNftContract The address of the SPGNFT collection contract where the duplicate was detected.
     /// @param tokenId The ID of the original NFT that was first minted with this metadata hash.
     /// @param nftMetadataHash The hash of the NFT metadata that caused the duplication error.
@@ -122,6 +122,12 @@ library Errors {
     /// @param caller The address of the caller.
     /// @param owner The owner of the token.
     error SPGNFT__CallerNotOwner(uint256 tokenId, address caller, address owner);
+
+    /// @notice Error thrown when the passed metadata hash does not match the token's metadata hash.
+    /// @param spgNftContract The address of the SPGNFT collection contract where the duplicate was detected.
+    /// @param tokenId The ID of the token.
+    /// @param metadataHash The metadata hash that does not match the token's metadata hash.
+    error SPGNFT__InvalidNFTMetadataHash(address spgNftContract, uint256 tokenId, bytes32 metadataHash);
 
     ////////////////////////////////////////////////////////////////////////////
     //                               OwnableERC20                             //

--- a/contracts/lib/Errors.sol
+++ b/contracts/lib/Errors.sol
@@ -111,7 +111,7 @@ library Errors {
     /// @notice Caller is not one of the periphery contracts.
     error SPGNFT__CallerNotPeripheryContract();
 
-    /// @notice Error thrown when attempting to mint an NFT with a metadata hash that already exists or set a metadata hash that already exists.
+    /// @notice Error thrown when attempting to mint an NFT with a metadata hash that already exists.
     /// @param spgNftContract The address of the SPGNFT collection contract where the duplicate was detected.
     /// @param tokenId The ID of the original NFT that was first minted with this metadata hash.
     /// @param nftMetadataHash The hash of the NFT metadata that caused the duplication error.
@@ -122,12 +122,6 @@ library Errors {
     /// @param caller The address of the caller.
     /// @param owner The owner of the token.
     error SPGNFT__CallerNotOwner(uint256 tokenId, address caller, address owner);
-
-    /// @notice Error thrown when the passed metadata hash does not match the token's metadata hash.
-    /// @param spgNftContract The address of the SPGNFT collection contract where the duplicate was detected.
-    /// @param tokenId The ID of the token.
-    /// @param metadataHash The metadata hash that does not match the token's metadata hash.
-    error SPGNFT__InvalidNFTMetadataHash(address spgNftContract, uint256 tokenId, bytes32 metadataHash);
 
     ////////////////////////////////////////////////////////////////////////////
     //                               OwnableERC20                             //

--- a/test/SPGNFT.t.sol
+++ b/test/SPGNFT.t.sol
@@ -418,7 +418,7 @@ contract SPGNFTTest is BaseTest {
         vm.stopPrank();
     }
 
-    function test_SPGNFT_setTokenURI() public {
+    function test_SPGNFT_setTokenURI_deprecated() public {
         // mint a token to alice
         vm.startPrank(u.alice);
         mockToken.mint(address(u.alice), 1000 * 10 ** mockToken.decimals());
@@ -437,6 +437,53 @@ contract SPGNFTTest is BaseTest {
 
         // Verify the token URI was updated
         assertEq(nftContract.tokenURI(tokenId), newTokenURI);
+
+        vm.stopPrank();
+    }
+
+    function test_SPGNFT_setTokenURI_deprecated_revert_callerNotOwner() public {
+        // mint a token to alice
+        vm.startPrank(u.alice);
+        mockToken.mint(address(u.alice), 1000 * 10 ** mockToken.decimals());
+        mockToken.approve(address(nftContract), 1000 * 10 ** mockToken.decimals());
+
+        uint256 tokenId = nftContract.mint(
+            address(u.alice),
+            ipMetadataDefault.nftMetadataURI,
+            ipMetadataDefault.nftMetadataHash,
+            false
+        );
+        vm.stopPrank();
+
+        // bob cannot set the token URI as he's not the owner
+        vm.startPrank(u.bob);
+
+        vm.expectRevert(abi.encodeWithSelector(Errors.SPGNFT__CallerNotOwner.selector, tokenId, u.bob, u.alice));
+        nftContract.setTokenURI(tokenId, "newTokenURI");
+
+        vm.stopPrank();
+    }
+
+    function test_SPGNFT_setTokenURI() public {
+        // mint a token to alice
+        vm.startPrank(u.alice);
+        mockToken.mint(address(u.alice), 1000 * 10 ** mockToken.decimals());
+        mockToken.approve(address(nftContract), 1000 * 10 ** mockToken.decimals());
+
+        uint256 tokenId = nftContract.mint(
+            address(u.alice),
+            ipMetadataDefault.nftMetadataURI,
+            ipMetadataDefault.nftMetadataHash,
+            false
+        );
+
+        // alice can set the token URI as the owner
+        string memory newTokenURI = string.concat(testBaseURI, "newTokenURI");
+        nftContract.setTokenURI(tokenId, "newTokenURI", bytes32(keccak256(abi.encodePacked(newTokenURI))));
+
+        // Verify the token URI was updated
+        assertEq(nftContract.tokenURI(tokenId), newTokenURI);
+        assertEq(nftContract.getTokenIdByMetadataHash(bytes32(keccak256(abi.encodePacked(newTokenURI)))), tokenId);
 
         vm.stopPrank();
     }
@@ -459,54 +506,7 @@ contract SPGNFTTest is BaseTest {
         vm.startPrank(u.bob);
 
         vm.expectRevert(abi.encodeWithSelector(Errors.SPGNFT__CallerNotOwner.selector, tokenId, u.bob, u.alice));
-        nftContract.setTokenURI(tokenId, "newTokenURI");
-
-        vm.stopPrank();
-    }
-
-    function test_SPGNFT_setTokenMetadata() public {
-        // mint a token to alice
-        vm.startPrank(u.alice);
-        mockToken.mint(address(u.alice), 1000 * 10 ** mockToken.decimals());
-        mockToken.approve(address(nftContract), 1000 * 10 ** mockToken.decimals());
-
-        uint256 tokenId = nftContract.mint(
-            address(u.alice),
-            ipMetadataDefault.nftMetadataURI,
-            ipMetadataDefault.nftMetadataHash,
-            false
-        );
-
-        // alice can set the token URI as the owner
-        string memory newTokenURI = string.concat(testBaseURI, "newTokenURI");
-        nftContract.setTokenMetadata(tokenId, "newTokenURI", bytes32(keccak256(abi.encodePacked(newTokenURI))));
-
-        // Verify the token URI was updated
-        assertEq(nftContract.tokenURI(tokenId), newTokenURI);
-        assertEq(nftContract.getTokenIdByMetadataHash(bytes32(keccak256(abi.encodePacked(newTokenURI)))), tokenId);
-
-        vm.stopPrank();
-    }
-
-    function test_SPGNFT_setTokenMetadata_revert_callerNotOwner() public {
-        // mint a token to alice
-        vm.startPrank(u.alice);
-        mockToken.mint(address(u.alice), 1000 * 10 ** mockToken.decimals());
-        mockToken.approve(address(nftContract), 1000 * 10 ** mockToken.decimals());
-
-        uint256 tokenId = nftContract.mint(
-            address(u.alice),
-            ipMetadataDefault.nftMetadataURI,
-            ipMetadataDefault.nftMetadataHash,
-            false
-        );
-        vm.stopPrank();
-
-        // bob cannot set the token URI as he's not the owner
-        vm.startPrank(u.bob);
-
-        vm.expectRevert(abi.encodeWithSelector(Errors.SPGNFT__CallerNotOwner.selector, tokenId, u.bob, u.alice));
-        nftContract.setTokenMetadata(tokenId, "newTokenURI", bytes32(keccak256(abi.encodePacked("newTokenURI"))));
+        nftContract.setTokenURI(tokenId, "newTokenURI", bytes32(keccak256(abi.encodePacked("newTokenURI"))));
 
         vm.stopPrank();
     }

--- a/test/SPGNFT.t.sol
+++ b/test/SPGNFT.t.sol
@@ -464,6 +464,99 @@ contract SPGNFTTest is BaseTest {
         vm.stopPrank();
     }
 
+    function test_SPGNFT_setNftMetadataHash() public {
+        vm.startPrank(u.alice);
+        mockToken.mint(address(u.alice), 1000 * 10 ** mockToken.decimals());
+        mockToken.approve(address(nftContract), 1000 * 10 ** mockToken.decimals());
+
+        uint256 tokenId = nftContract.mint(
+            address(u.alice),
+            ipMetadataDefault.nftMetadataURI,
+            ipMetadataDefault.nftMetadataHash,
+            false
+        );
+
+        nftContract.setNftMetadataHash(tokenId, ipMetadataDefault.nftMetadataHash, bytes32(0));
+        assertEq(nftContract.getTokenIdByMetadataHash(ipMetadataDefault.nftMetadataHash), 0);
+        assertEq(nftContract.getTokenIdByMetadataHash(bytes32(0)), tokenId);
+
+        vm.stopPrank();
+    }
+
+    function test_SPGNFT_setNftMetadataHash_revert_callerNotOwner() public {
+        vm.startPrank(u.alice);
+        mockToken.mint(address(u.alice), 1000 * 10 ** mockToken.decimals());
+        mockToken.approve(address(nftContract), 1000 * 10 ** mockToken.decimals());
+
+        uint256 tokenId = nftContract.mint(
+            address(u.alice),
+            ipMetadataDefault.nftMetadataURI,
+            ipMetadataDefault.nftMetadataHash,
+            false
+        );
+        vm.stopPrank();
+
+        vm.startPrank(u.bob);
+        vm.expectRevert(abi.encodeWithSelector(Errors.SPGNFT__CallerNotOwner.selector, tokenId, u.bob, u.alice));
+        nftContract.setNftMetadataHash(tokenId, ipMetadataDefault.nftMetadataHash, bytes32(0));
+
+        vm.stopPrank();
+    }
+
+    function test_SPGNFT_setNftMetadataHash_revert_invalidMetadataHash() public {
+        vm.startPrank(u.alice);
+        mockToken.mint(address(u.alice), 1000 * 10 ** mockToken.decimals());
+        mockToken.approve(address(nftContract), 1000 * 10 ** mockToken.decimals());
+
+        uint256 tokenId = nftContract.mint(
+            address(u.alice),
+            ipMetadataDefault.nftMetadataURI,
+            ipMetadataDefault.nftMetadataHash,
+            false
+        );
+
+        // Expect revert since Alice token's current metadata hash is not 0
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.SPGNFT__InvalidNFTMetadataHash.selector,
+                address(nftContract),
+                tokenId,
+                bytes32(0)
+            )
+        );
+        nftContract.setNftMetadataHash(tokenId, 0, ipMetadataDefault.nftMetadataHash);
+
+        vm.stopPrank();
+    }
+
+    function test_SPGNFT_setNftMetadataHash_revert_duplicateMetadataHash() public {
+        vm.startPrank(u.alice);
+        mockToken.mint(address(u.alice), 1000 * 10 ** mockToken.decimals());
+        mockToken.approve(address(nftContract), 1000 * 10 ** mockToken.decimals());
+
+        uint256 aliceTokenId = nftContract.mint(
+            address(u.alice),
+            ipMetadataDefault.nftMetadataURI,
+            ipMetadataDefault.nftMetadataHash,
+            false
+        );
+
+        uint256 bobTokenId = nftContract.mint(address(u.bob), "", bytes32(0), false);
+
+        // Expect revert since the new metadata hash Alice tries to set is already used by Bob's token
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                Errors.SPGNFT__DuplicatedNFTMetadataHash.selector,
+                address(nftContract),
+                aliceTokenId,
+                bytes32(0)
+            )
+        );
+        nftContract.setNftMetadataHash(aliceTokenId, ipMetadataDefault.nftMetadataHash, bytes32(0));
+
+        vm.stopPrank();
+    }
+
     function test_SPGNFT_setMintOpen() public {
         vm.startPrank(u.alice);
         nftContract.setMintOpen(false);
@@ -476,7 +569,11 @@ contract SPGNFTTest is BaseTest {
 
         vm.startPrank(u.bob);
         vm.expectRevert(
-            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, u.bob, SPGNFTLib.ADMIN_ROLE)
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                u.bob,
+                SPGNFTLib.ADMIN_ROLE
+            )
         );
         nftContract.setMintOpen(false);
         vm.stopPrank();
@@ -494,7 +591,11 @@ contract SPGNFTTest is BaseTest {
 
         vm.startPrank(u.bob);
         vm.expectRevert(
-            abi.encodeWithSelector(IAccessControl.AccessControlUnauthorizedAccount.selector, u.bob, SPGNFTLib.ADMIN_ROLE)
+            abi.encodeWithSelector(
+                IAccessControl.AccessControlUnauthorizedAccount.selector,
+                u.bob,
+                SPGNFTLib.ADMIN_ROLE
+            )
         );
         nftContract.setPublicMinting(false);
         vm.stopPrank();

--- a/test/workflows/RoyaltyTokenDistributionWorkflows.t.sol
+++ b/test/workflows/RoyaltyTokenDistributionWorkflows.t.sol
@@ -272,7 +272,9 @@ contract RoyaltyTokenDistributionWorkflowsTest is BaseTest {
         vm.stopPrank();
     }
 
-    function  test_RoyaltyTokenDistributionWorkflows_revert_CallerNotSigner_registerIpAndAttachPILTermsAndDeployRoyaltyVault() public {
+    function test_RoyaltyTokenDistributionWorkflows_revert_CallerNotSigner_registerIpAndAttachPILTermsAndDeployRoyaltyVault()
+        public
+    {
         uint256 tokenId = mockNft.mint(u.alice);
         address expectedIpId = ipAssetRegistry.ipId(block.chainid, address(mockNft), tokenId);
 
@@ -291,11 +293,7 @@ contract RoyaltyTokenDistributionWorkflowsTest is BaseTest {
 
         vm.startPrank(u.bob);
         vm.expectRevert(
-            abi.encodeWithSelector(
-                Errors.RoyaltyTokenDistributionWorkflows__CallerNotSigner.selector,
-                u.bob,
-                u.alice
-            )
+            abi.encodeWithSelector(Errors.RoyaltyTokenDistributionWorkflows__CallerNotSigner.selector, u.bob, u.alice)
         );
         royaltyTokenDistributionWorkflows.registerIpAndAttachPILTermsAndDeployRoyaltyVault({
             nftContract: address(mockNft),
@@ -311,7 +309,9 @@ contract RoyaltyTokenDistributionWorkflowsTest is BaseTest {
         vm.stopPrank();
     }
 
-    function test_RoyaltyTokenDistributionWorkflows_revert_CallerNotSigner_registerIpAndMakeDerivativeAndDeployRoyaltyVault() public {
+    function test_RoyaltyTokenDistributionWorkflows_revert_CallerNotSigner_registerIpAndMakeDerivativeAndDeployRoyaltyVault()
+        public
+    {
         uint256 tokenId = mockNft.mint(u.alice);
         address expectedIpId = ipAssetRegistry.ipId(block.chainid, address(mockNft), tokenId);
 
@@ -331,11 +331,7 @@ contract RoyaltyTokenDistributionWorkflowsTest is BaseTest {
 
         vm.startPrank(u.bob);
         vm.expectRevert(
-            abi.encodeWithSelector(
-                Errors.RoyaltyTokenDistributionWorkflows__CallerNotSigner.selector,
-                u.bob,
-                u.alice
-            )
+            abi.encodeWithSelector(Errors.RoyaltyTokenDistributionWorkflows__CallerNotSigner.selector, u.bob, u.alice)
         );
         royaltyTokenDistributionWorkflows.registerIpAndMakeDerivativeAndDeployRoyaltyVault({
             nftContract: address(mockNft),
@@ -351,7 +347,7 @@ contract RoyaltyTokenDistributionWorkflowsTest is BaseTest {
         vm.stopPrank();
     }
 
-     function test_RoyaltyTokenDistributionWorkflows_revert_CallerNotSigner_distributeRoyaltyTokens() public {
+    function test_RoyaltyTokenDistributionWorkflows_revert_CallerNotSigner_distributeRoyaltyTokens() public {
         uint256 tokenId = mockNft.mint(u.alice);
         address expectedIpId = ipAssetRegistry.ipId(block.chainid, address(mockNft), tokenId);
 
@@ -402,11 +398,7 @@ contract RoyaltyTokenDistributionWorkflowsTest is BaseTest {
 
         vm.startPrank(u.bob);
         vm.expectRevert(
-            abi.encodeWithSelector(
-                Errors.RoyaltyTokenDistributionWorkflows__CallerNotSigner.selector,
-                u.bob,
-                u.alice
-            )
+            abi.encodeWithSelector(Errors.RoyaltyTokenDistributionWorkflows__CallerNotSigner.selector, u.bob, u.alice)
         );
         royaltyTokenDistributionWorkflows.distributeRoyaltyTokens({
             ipId: ipId,
@@ -418,7 +410,7 @@ contract RoyaltyTokenDistributionWorkflowsTest is BaseTest {
             })
         });
         vm.stopPrank();
-     }
+    }
 
     function test_RoyaltyTokenDistributionWorkflows_deployRoyaltyVault_LicenseShouldNotBeDisabled() public {
         uint256 tokenId = mockNft.mint(u.alice);


### PR DESCRIPTION
## Description
This PR adds functionality to allow NFT owners to update the metadata (both URI and hash) of their tokens in SPGNFT collections. It fixes this issue: https://github.com/storyprotocol/protocol-periphery-v1/issues/232
## Changes Made
### Core Functionality
- Added `setTokenURI(uint256 tokenId, string memory tokenUri, bytes32 nftMetadataHash) `external function in SPGNFT.sol -> allows token owners to update both metadata URI and metadata hash for their tokens
- Validates caller is the token owner using ownerOf() check
- Calls _setTokenURI() to update the token's URI
- Updates the nftMetadataHashToTokenId mapping
### Interface Updates
- Added `setTokenURI(uint256 tokenId, string memory tokenUri, bytes32 nftMetadataHash)` function declaration in ISPGNFT.sol
- Marked the existing `setTokenURI(uint256 tokenId, string memory tokenUri)` function as deprecated 
### Error Handling
- Reuses existing SPGNFT__CallerNotOwner error for access control validation
## Testing
- Added comprehensive test coverage in SPGNFT.t.sol:
- test_SPGNFT_setTokenURI() - successful metadata update (both URI and hash)
- test_SPGNFT_setTokenURI_revert_callerNotOwner() - access control validation
- Marked the tests of the old existing setTokenURI() function as deprecated, avoiding duplicated tests issues 
